### PR TITLE
Release 0.1.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,19 @@
+2013-09-27 Release 0.1.0
+
+Summary:
+
+Add curl_json and apache plugin
+
+Backwards-incompatible changes:
+
+ - The write_network plugin now accepts a hash of servers
+
+Features:
+
+ - Add curl_json plugin
+ - Added collectd package version parameter
+ - Add apache plugin
+
 0.0.5 - pdxcat/collectd - 2013/09/24
 
   6adca9a add ntpd plugin

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'pdxcat-collectd'
-version '0.0.5'
+version '0.1.0'
 author 'Computer Action Team'
 license 'Apache License 2.0'
 project_page 'https://github.com/pdxcat/puppet-module-collectd'


### PR DESCRIPTION
Summary:

Add curl_json and apache plugin

Backward-incompatible changes:
- The write_network plugin now accepts a hash of servers

Features:
- Add curl_json plugin
- Added collectd package version parameter
- Add apache plugin
