### PR TITLE
change Include to only use *.conf files

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,9 +41,17 @@ class collectd(
   }
 
   if $purge_config != true {
-    # Include conf_d directory
+    # former include of conf_d directory
     file_line { 'include_conf_d':
+      ensure  => absent,
       line    => "Include \"${collectd::params::plugin_conf_dir}/\"",
+      path    => $collectd::params::config_file,
+      notify  => Service['collectd'],
+    }
+    # include (conf_d directory)/*.conf
+    file_line { 'include_conf_d_dot_conf':
+      ensure  => present,
+      line    => "Include \"${collectd::params::plugin_conf_dir}/*.conf\"",
       path    => $collectd::params::config_file,
       notify  => Service['collectd'],
     }

--- a/templates/collectd.conf.erb
+++ b/templates/collectd.conf.erb
@@ -12,4 +12,4 @@ FQDNLookup true
 Interval <%= @interval %>
 Timeout <%= @timeout %>
 ReadThreads <%= @threads %>
-Include "<%= @plugin_conf_dir %>"
+Include "<%= @plugin_conf_dir %>/*.conf"


### PR DESCRIPTION
A little background on this:

Currently I use an homegrown collectd module which is OK, but I want to replace it with the pdxcat one for various reasons. I need to distribute a custom types DB file with additional types, which is placed as custom.types.db in the conf.d directory and a custom.types.conf file with

```
TypesDB "/etc/collectd/conf.d/custom.types.db"
```

in it. If all files in conf.d are included, this doesn't work, so I included only *.conf files.
