### PR TITLE
scrap package provider

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,6 @@ class collectd(
   package { 'collectd':
     ensure   => $version,
     name     => $collectd::params::package,
-    provider => $collectd::params::provider,
     before   => File['collectd.conf', 'collectd.d'],
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,6 @@ class collectd::params {
   case $::osfamily {
     'Debian': {
       $package           = 'collectd'
-      $provider          = 'apt'
       $collectd_dir      = '/etc/collectd'
       $plugin_conf_dir   = "${collectd_dir}/conf.d"
       $service_name      = 'collectd'
@@ -12,7 +11,6 @@ class collectd::params {
     }
     'Solaris': {
       $package           = 'CSWcollectd'
-      $provider          = 'pkgutil'
       $collectd_dir      = '/etc/opt/csw'
       $plugin_conf_dir   = "${collectd_dir}/conf.d"
       $service_name      = 'collectd'
@@ -20,7 +18,6 @@ class collectd::params {
     }
     'Redhat': {
       $package           = "collectd.${::architecture}"
-      $provider          = 'yum'
       $collectd_dir      = '/etc/collectd.d'
       $plugin_conf_dir   = $collectd_dir
       $service_name      = 'collectd'
@@ -28,7 +25,6 @@ class collectd::params {
     }
     'Suse': {
       $package           = 'collectd'
-      $provider          = 'zypper'
       $collectd_dir      = '/etc/collectd'
       $plugin_conf_dir   = $collectd_dir
       $service_name      = 'collectd'


### PR DESCRIPTION
Normally this shouldn't be needed anyway. It's giving me some headache because I'm thinking of adding FreeBSD support. There's an ongoing transition from the old pkg to the new pkgng system in the FreeBSD world and so it's normal to set the provider property globally to pkgng if a system is using the new way to manage packages and this would clash if it gets set here for the one package.
