### PR TITLE
Fixed missing double quotes in unixsock plugin template

### DIFF
--- a/templates/unixsock.conf.erb
+++ b/templates/unixsock.conf.erb
@@ -4,5 +4,5 @@ LoadPlugin unixsock
 <Plugin unixsock>
     SocketFile  "<%= @socketfile %>"
     SocketGroup "<%= @socketgroup %>"
-    SocketPerms "<%= @socketperms %>
+    SocketPerms "<%= @socketperms %>"
 </Plugin>


### PR DESCRIPTION
While writing rspec tests noticed this missing double quotes in the template.
