### PR TITLE
Allow to set all write_graphite options

### DIFF
--- a/manifests/plugin/write_graphite.pp
+++ b/manifests/plugin/write_graphite.pp
@@ -1,9 +1,13 @@
 # https://collectd.org/wiki/index.php/Graphite
 class collectd::plugin::write_graphite (
-  $ensure       = present,
-  $graphitehost = 'localhost',
-  $graphiteport = 2003,
-  $storerates   = false,
+  $ensure          = present,
+  $graphitehost    = 'localhost',
+  $graphiteport    = 2003,
+  $storerates      = false,
+  $graphiteprefix  = 'collectd.',
+  $graphitepostfix = undef,
+  $escapecharacter = '_',
+  $alwaysappendds  = false,
 ) {
   include collectd::params
 

--- a/templates/write_graphite.conf.erb
+++ b/templates/write_graphite.conf.erb
@@ -5,10 +5,12 @@ LoadPlugin write_graphite
  <Carbon>
    Host "<%= @graphitehost %>"
    Port "<%= @graphiteport %>"
-   Prefix "collectd."
-   #Postfix ""
-   EscapeCharacter "_"
+   Prefix "<%= @graphiteprefix %>"
+   <% if @graphitepostfix -%>
+   Postfix "<%= @graphitepostfix %>"
+   <% end -%>
+   EscapeCharacter "<%= @escapecharacter %>"
    StoreRates <%=  @storerates %>
-   AlwaysAppendDS false
+   AlwaysAppendDS <%= @alwaysappendds %>
  </Carbon>
 </Plugin>


### PR DESCRIPTION
From the original commit, with permission of the author:

Also keep the defaults from the current implementation,
allowing to override them.
