### PR TITLE
Added comma to syntax error in bind.pp

### DIFF
--- a/manifests/plugin/bind.pp
+++ b/manifests/plugin/bind.pp
@@ -1,7 +1,7 @@
 # https://collectd.org/wiki/index.php/Plugin:BIND
 class collectd::plugin::bind (
   $url,
-  $ensure         = present
+  $ensure         = present,
   $memorystats    = true,
   $opcodes        = true,
   $parsetime      = false,


### PR DESCRIPTION
Ran into a minor problem while trying to use the bind plugin.

Error: Could not parse for environment production: Syntax error at 'memorystats'; expected ')' at /home/dlawrence/code/puppet/modules/collectd/manifests/plugin/bind.pp:5
Error: Try 'puppet help parser validate' for usage

This patch fixes the issue by adding a comma to the ensure line.
