### PR TITLE
Add quotes for string values in network plugin

### DIFF
--- a/templates/network.conf.erb
+++ b/templates/network.conf.erb
@@ -5,29 +5,29 @@ LoadPlugin network
 <% if @server -%>
   <Server "<%= @server %>" "<%= @serverport %>">
 <% if @server_securitylevel -%>
-    SecurityLevel <%= @server_securitylevel %>
+    SecurityLevel "<%= @server_securitylevel %>"
 <% end -%>
 <% if @server_username -%>
-    Username <%= @server_username %>
+    Username "<%= @server_username %>"
 <% end -%>
 <% if @server_password -%>
-    Password <%= @server_password %>
+    Password "<%= @server_password %>"
 <% end -%>
 <% if @server_interface -%>
-    Interface <%= @server_interface %>
+    Interface "<%= @server_interface %>"
 <% end -%>
   </Server>
 <% end -%>
 <% if @listen -%>
   <Listen "<%= @listen %>" "<%= @listenport %>">
 <% if @listen_securitylevel -%>
-    SecurityLevel <%= @listen_securitylevel %>
+    SecurityLevel "<%= @listen_securitylevel %>"
 <% end -%>
 <% if @listen_authfile -%>
-    AuthFile <%= @listen_authfile %>
+    AuthFile "<%= @listen_authfile %>"
 <% end -%>
 <% if @listen_interface -%>
-    Interface <%= @listen_interface %>
+    Interface "<%= @listen_interface %>"
 <% end -%>
   </Listen>
 <% end -%>
@@ -38,9 +38,9 @@ LoadPlugin network
   MaxPacketSize <%= @maxpacketsize %>
 <% end -%>
 <% if @forward -%>
-  Forward <%= @forward %>
+  Forward "<%= @forward %>"
 <% end -%>
 <% if @reportstats -%>
-  ReportStats <%= @reportstats %>
+  ReportStats "<%= @reportstats %>"
 <% end -%>
 </Plugin>


### PR DESCRIPTION
String values in the configuration file can be quoted or unquoted strings and unquoted strings can only contain alphanumeric characters or underscores. This patch adds quotes to the strings parameters in order to allow additional characters. In case of the network plugin at least the "Username" and  "Password" parameters may include additional characters that require a quoted string.
