### PR TITLE
Use collectd::params::root_group instead of fixed group name

### DIFF
--- a/manifests/plugin/apache.pp
+++ b/manifests/plugin/apache.pp
@@ -13,7 +13,7 @@ class collectd::plugin::apache (
     path      => "${conf_dir}/apache.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/apache.conf.erb'),
     notify    => Service['collectd']
   }

--- a/manifests/plugin/bind.pp
+++ b/manifests/plugin/bind.pp
@@ -30,7 +30,7 @@ class collectd::plugin::bind (
     path    => "${conf_dir}/bind.conf",
     mode    => '0644',
     owner   => 'root',
-    group   => 'root',
+    group   => $collectd::params::root_group,
     content => template('collectd/bind.conf.erb'),
     notify  => Service['collectd']
   }

--- a/manifests/plugin/curl_json.pp
+++ b/manifests/plugin/curl_json.pp
@@ -15,8 +15,8 @@ define collectd::plugin::curl_json (
   file {
     "${name}.load":
       path    => "${conf_dir}/${name}.conf",
-      owner   => root,
-      group   => root,
+      owner   => 'root',
+      group   => $collectd::params::root_group,
       mode    => '0644',
       content => template('collectd/curl_json.conf.erb'),
       notify  => Service['collectd'],

--- a/manifests/plugin/df.pp
+++ b/manifests/plugin/df.pp
@@ -25,7 +25,7 @@ class collectd::plugin::df (
     path      => "${conf_dir}/df.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/df.conf.erb'),
     notify    => Service['collectd'],
   }

--- a/manifests/plugin/disk.pp
+++ b/manifests/plugin/disk.pp
@@ -15,7 +15,7 @@ class collectd::plugin::disk (
     path      => "${conf_dir}/disk.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/disk.conf.erb'),
     notify    => Service['collectd']
   }

--- a/manifests/plugin/exec.pp
+++ b/manifests/plugin/exec.pp
@@ -15,8 +15,8 @@ define collectd::plugin::exec (
   file {
     "${name}.load":
       path    => "${conf_dir}/${name}.conf",
-      owner   => root,
-      group   => root,
+      owner   => 'root',
+      group   => $collectd::params::root_group,
       mode    => '0644',
       content => template('collectd/exec.conf.erb'),
       notify  => Service['collectd'],

--- a/manifests/plugin/filecount.pp
+++ b/manifests/plugin/filecount.pp
@@ -13,9 +13,8 @@ class collectd::plugin::filecount (
     path      => "${conf_dir}/filecount.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/filecount.conf.erb'),
     notify    => Service['collectd']
   }
 }
-

--- a/manifests/plugin/interface.pp
+++ b/manifests/plugin/interface.pp
@@ -15,7 +15,7 @@ class collectd::plugin::interface (
     path      => "${conf_dir}/interface.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/interface.conf.erb'),
     notify    => Service['collectd']
   }

--- a/manifests/plugin/iptables.pp
+++ b/manifests/plugin/iptables.pp
@@ -13,7 +13,7 @@ class collectd::plugin::iptables (
     path      => "${conf_dir}/iptables.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/iptables.conf.erb'),
     notify    => Service['collectd']
   }

--- a/manifests/plugin/irq.pp
+++ b/manifests/plugin/irq.pp
@@ -15,7 +15,7 @@ class collectd::plugin::irq (
     path      => "${conf_dir}/irq.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/irq.conf.erb'),
     notify    => Service['collectd']
   }

--- a/manifests/plugin/memcached.pp
+++ b/manifests/plugin/memcached.pp
@@ -13,9 +13,8 @@ class collectd::plugin::memcached (
     path      => "${conf_dir}/memcached.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/memcached.conf.erb'),
     notify    => Service['collectd']
   }
 }
-

--- a/manifests/plugin/mysql/database.pp
+++ b/manifests/plugin/mysql/database.pp
@@ -26,7 +26,7 @@ define collectd::plugin::mysql::database (
     path      => "${conf_dir}/mysql-${name}.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/mysql-database.conf.erb'),
     notify    => Service['collectd'],
   }

--- a/manifests/plugin/network.pp
+++ b/manifests/plugin/network.pp
@@ -30,7 +30,7 @@ class collectd::plugin::network (
     path    => "${conf_dir}/network.conf",
     mode    => '0644',
     owner   => 'root',
-    group   => 'root',
+    group   => $collectd::params::root_group,
     content => template('collectd/network.conf.erb'),
     notify  => Service['collectd']
   }

--- a/manifests/plugin/nginx.pp
+++ b/manifests/plugin/nginx.pp
@@ -17,7 +17,7 @@ class collectd::plugin::nginx (
     path    => "${conf_dir}/nginx.conf",
     mode    => '0644',
     owner   => 'root',
-    group   => 'root',
+    group   => $collectd::params::root_group,
     content => template('collectd/nginx.conf.erb'),
     notify  => Service['collectd']
   }

--- a/manifests/plugin/ntpd.pp
+++ b/manifests/plugin/ntpd.pp
@@ -15,7 +15,7 @@ class collectd::plugin::ntpd (
     path      => "${conf_dir}/ntpd.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/ntpd.conf.erb'),
     notify    => Service['collectd'],
   }

--- a/manifests/plugin/openvpn.pp
+++ b/manifests/plugin/openvpn.pp
@@ -23,7 +23,7 @@ class collectd::plugin::openvpn (
     path      => "${conf_dir}/openvpn.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/openvpn.conf.erb'),
     notify    => Service['collectd'],
   }

--- a/manifests/plugin/ping.pp
+++ b/manifests/plugin/ping.pp
@@ -17,8 +17,8 @@ define collectd::plugin::ping (
   file {
     "${name}.load":
       path    => "${conf_dir}/ping-${name}.conf",
-      owner   => root,
-      group   => root,
+      owner   => 'root',
+      group   => $collectd::params::root_group,
       mode    => '0644',
       content => template('collectd/ping.conf.erb'),
       notify  => Service['collectd'],

--- a/manifests/plugin/python.pp
+++ b/manifests/plugin/python.pp
@@ -14,8 +14,8 @@ define collectd::plugin::python (
   file {
     "${name}.load":
       path    => "${conf_dir}/${name}.conf",
-      owner   => root,
-      group   => root,
+      owner   => 'root',
+      group   => $collectd::params::root_group,
       mode    => '0644',
       content => template('collectd/python.conf.erb'),
       notify  => Service['collectd'],
@@ -24,8 +24,8 @@ define collectd::plugin::python (
   file {
     "${name}.script":
       path    => "${modulepath}/${module}.py",
-      owner   => root,
-      group   => root,
+      owner   => 'root',
+      group   => $collectd::params::root_group,
       mode    => '0644',
       source  => $script_source,
       require => File["${name}.load"],

--- a/manifests/plugin/snmp.pp
+++ b/manifests/plugin/snmp.pp
@@ -15,7 +15,7 @@ class collectd::plugin::snmp (
     path      => "${conf_dir}/snmp.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/snmp.conf.erb'),
     notify    => Service['collectd']
   }

--- a/manifests/plugin/syslog.pp
+++ b/manifests/plugin/syslog.pp
@@ -12,7 +12,7 @@ class collectd::plugin::syslog (
     path      => "${conf_dir}/syslog.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/syslog.conf.erb'),
     notify    => Service['collectd'],
   }

--- a/manifests/plugin/tail/file.pp
+++ b/manifests/plugin/tail/file.pp
@@ -20,7 +20,7 @@ define collectd::plugin::tail::file (
     path      => "${conf_dir}/tail-${name}.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/tail-file.conf.erb'),
     notify    => Service['collectd'],
   }

--- a/manifests/plugin/tcpconns.pp
+++ b/manifests/plugin/tcpconns.pp
@@ -28,9 +28,8 @@ class collectd::plugin::tcpconns (
     path      => "${conf_dir}/tcpconns.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/tcpconns.conf.erb'),
     notify    => Service['collectd']
   }
 }
-

--- a/manifests/plugin/unixsock.pp
+++ b/manifests/plugin/unixsock.pp
@@ -15,7 +15,7 @@ class collectd::plugin::unixsock (
     path      => "${conf_dir}/unixsock.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/unixsock.conf.erb'),
     notify    => Service['collectd']
   }

--- a/manifests/plugin/write_graphite.pp
+++ b/manifests/plugin/write_graphite.pp
@@ -19,7 +19,7 @@ class collectd::plugin::write_graphite (
     path      => "${conf_dir}/write_graphite.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/write_graphite.conf.erb'),
     notify    => Service['collectd'],
   }

--- a/manifests/plugin/write_network.pp
+++ b/manifests/plugin/write_network.pp
@@ -13,7 +13,7 @@ class collectd::plugin::write_network (
     path      => "${conf_dir}/write_network.conf",
     mode      => '0644',
     owner     => 'root',
-    group     => 'root',
+    group     => $collectd::params::root_group,
     content   => template('collectd/write_network.conf.erb'),
     notify    => Service['collectd'],
   }

--- a/manifests/plugin/write_riemann.pp
+++ b/manifests/plugin/write_riemann.pp
@@ -19,9 +19,8 @@ class collectd::plugin::write_riemann (
     path    => "${conf_dif}/write_riemann.conf",
     mode    => '0644',
     owner   => 'root',
-    group   => 'root',
+    group   => $collectd::params::root_group,
     content => template('collectd/write_riemann.conf.erb'),
     notify  => Service['collectd'],
   }
 }
-


### PR DESCRIPTION
Most of the plugins currentyl use a fixed value `root` to set the group of managed files. This makes it difficult to use the module on systems which do not use the `root` group. The `collectd::params` class already has the code to provide an operating system specific value. This patch modifies the plugins to refer to the corresponding variable.
