### PR TITLE
Add class parameter typesdb

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,12 +7,14 @@ class collectd(
   $recurse      = undef,
   $threads      = 5,
   $timeout      = 2,
+  $typesdb      = [],
   $version      = installed,
 ) {
   include collectd::params
 
   $plugin_conf_dir = $collectd::params::plugin_conf_dir
   validate_bool($purge_config, $fqdnlookup)
+  validate_array($typesdb)
 
   package { 'collectd':
     ensure   => $version,

--- a/templates/collectd.conf.erb
+++ b/templates/collectd.conf.erb
@@ -8,7 +8,11 @@ FQDNLookup true
 <% end %>
 #BaseDir "/var/lib/collectd"
 #PluginDir "/usr/lib/collectd"
+<% if @typesdb and not @typesdb.empty? -%>
+TypesDB<% @typesdb.each do |path| -%> "<%= path %>"<% end %>
+<% else -%>
 #TypesDB "/usr/share/collectd/types.db" "/etc/collectd/my_types.db"
+<% end -%>
 Interval <%= @interval %>
 Timeout <%= @timeout %>
 ReadThreads <%= @threads %>


### PR DESCRIPTION
Some collectd modules (e.g. dbi or postgresql) can use user defined types to collect database results. In order to define such a type one either has to modify the supplied `types.db` file or add a local `types.db` file to the configuration. The new class parameter `typesdb` takes an array of file names to allow multiple `types.db` files in addition to the one supplied by collectd.
