### PR TITLE
Fix bug that always creates notification in exec on empty params

### DIFF
--- a/templates/exec.conf.erb
+++ b/templates/exec.conf.erb
@@ -5,7 +5,7 @@ LoadPlugin "exec"
 <% if @exec %>
     Exec "<%= @user %>:<%= @group %>" <% @exec.each do |exec| -%>"<%= exec %>"<% end -%>
 <% end %>
-<% if @notification_exec %>
+<% if !@notification_exec.empty? %>
     NotificationExec "<%= @user %>:<%= @group %>" <% @notification_exec.each do |exec| -%>"<%= exec %>"<% end -%>
 <% end %>
 </Plugin>


### PR DESCRIPTION
if <emptyarray> returns true, needs if !<emptyarray>.empty?
