### PR TITLE
Add protocol paramter to write_graphite plugin

### DIFF
--- a/manifests/plugin/write_graphite.pp
+++ b/manifests/plugin/write_graphite.pp
@@ -8,6 +8,7 @@ class collectd::plugin::write_graphite (
   $graphitepostfix = undef,
   $escapecharacter = '_',
   $alwaysappendds  = false,
+  $protocol        = 'tcp',
 ) {
   include collectd::params
 

--- a/templates/write_graphite.conf.erb
+++ b/templates/write_graphite.conf.erb
@@ -12,5 +12,6 @@ LoadPlugin write_graphite
    EscapeCharacter "<%= @escapecharacter %>"
    StoreRates <%=  @storerates %>
    AlwaysAppendDS <%= @alwaysappendds %>
+   Protocol "<%= @protocol %>"
  </Carbon>
 </Plugin>


### PR DESCRIPTION
Collectd will let you write to graphite over UDP, but at the moment the
plugin doesn't let you choose your protocol. I have defaulted it to TCP
which is the Collectd default.
