### PR TITLE
Make sure that plugins are loaded before their configuration

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -18,4 +18,11 @@ define collectd::plugin (
     notify  => Service['collectd'],
   }
 
+  # Older versions of this module didn't use the "00-" prefix.
+  # Delete those potentially left over files just to be sure.
+  file { "old_${plugin}.load":
+    ensure  => absent,
+    path    => "${conf_dir}/${plugin}.conf",
+    notify  => Service['collectd'],
+  }
 }


### PR DESCRIPTION
supersedes #66
if you don't want the second commit to get in, just cherry-pick smokey42's. I can work around this in my environment like in the second commit, if needed.
