### PR TITLE
Add version check around emitting Protocol config

### DIFF
--- a/spec/classes/collectd_plugin_write_graphite_spec.rb
+++ b/spec/classes/collectd_plugin_write_graphite_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::write_graphite', :type => :class do
+
+  context 'protocol should not be include with version < 5.4' do
+    let :facts do
+      { :osfamily => 'RedHat',
+        :collectd_version => '5.3',
+      }
+    end
+    let :params do
+      { :protocol => 'udp',
+      }
+    end
+
+    it 'Should not include protocol in /etc/collectd.d/write_graphite.conf for collectd < 5.4' do
+      should_not contain_file('write_graphite.conf').with_content(/.*Protocol \"udp\".*/)
+    end
+  end
+
+  context 'protocol should be include with version >= 5.4' do
+    let :facts do
+      { :osfamily => 'RedHat',
+        :collectd_version => '5.4',
+      }
+    end
+    let :params do
+      { :protocol => 'udp',
+      }
+    end
+
+    it 'Should include protocol in /etc/collectd.d/write_graphite.conf for collectd >= 5.4' do
+      should contain_file('write_graphite.conf') \
+        .with_content(/.*Protocol \"udp\".*/)
+    end
+  end
+
+end

--- a/templates/write_graphite.conf.erb
+++ b/templates/write_graphite.conf.erb
@@ -6,12 +6,14 @@ LoadPlugin write_graphite
    Host "<%= @graphitehost %>"
    Port "<%= @graphiteport %>"
    Prefix "<%= @graphiteprefix %>"
-   <% if @graphitepostfix -%>
+<% if @graphitepostfix -%>
    Postfix "<%= @graphitepostfix %>"
-   <% end -%>
+<% end -%>
    EscapeCharacter "<%= @escapecharacter %>"
    StoreRates <%=  @storerates %>
    AlwaysAppendDS <%= @alwaysappendds %>
+<% if (scope.function_versioncmp([@collectd_version, '5.4']) >= 0) -%>
    Protocol "<%= @protocol %>"
+<% end -%>
  </Carbon>
 </Plugin>


### PR DESCRIPTION
The Protocol config directive only got added in version 5.4. We need to
check whether the current collectd installed meets or exceeds this
version before we output the config.

I have added two tests to check the version before and after 5.4
