### PR TITLE
Allow for alphanumeric collectd version numbers

### DIFF
--- a/lib/facter/collectd_version.rb
+++ b/lib/facter/collectd_version.rb
@@ -9,7 +9,7 @@
 Facter.add(:collectd_version) do
   setcode do
     if Facter::Util::Resolution.which('collectd')
-      collectd_help = Facter::Util::Resolution.exec('collectd -h') and collectd_help =~ /^collectd ([0-9.]+), http:\/\/collectd.org\//
+      collectd_help = Facter::Util::Resolution.exec('collectd -h') and collectd_help =~ /^collectd ([\w.]+), http:\/\/collectd.org\//
       $1
     else
       nil


### PR DESCRIPTION
Some PPA packages currently report their version as
5.x.x.git. Open up the regex to allow for this.
