### PR TITLE
(gh-85) Fix null versioncmp bug in plugin templates

### DIFF
--- a/templates/mysql-database.conf.erb
+++ b/templates/mysql-database.conf.erb
@@ -5,7 +5,7 @@
     Host "<%= @host %>"
     User "<%= @username %>"
     Password "<%= @password %>"
-<% if (scope.function_versioncmp([@collectd_version, '5.0']) >= 0) -%>
+<% if @collectd_version and (scope.function_versioncmp([@collectd_version, '5.0']) >= 0) -%>
     Port "<%= @port %>"
 <% else -%>
     Port <%= @port %>

--- a/templates/network.conf.erb
+++ b/templates/network.conf.erb
@@ -3,7 +3,7 @@ LoadPlugin network
 
 <Plugin network>
 <% if @server -%>
-<% if (scope.function_versioncmp([@collectd_version, '4.7']) >= 0) -%>
+<% if @collectd_version and (scope.function_versioncmp([@collectd_version, '4.7']) >= 0) -%>
   <Server "<%= @server %>" "<%= @serverport %>">
 <% if @server_securitylevel -%>
     SecurityLevel "<%= @server_securitylevel %>"
@@ -23,7 +23,7 @@ LoadPlugin network
 <% end -%>
 <% end -%>
 <% if @listen -%>
-<% if (scope.function_versioncmp([@collectd_version, '4.7']) >= 0) -%>
+<% if @collectd_version and (scope.function_versioncmp([@collectd_version, '4.7']) >= 0) -%>
   <Listen "<%= @listen %>" "<%= @listenport %>">
 <% if @listen_securitylevel -%>
     SecurityLevel "<%= @listen_securitylevel %>"

--- a/templates/write_graphite.conf.erb
+++ b/templates/write_graphite.conf.erb
@@ -12,7 +12,7 @@ LoadPlugin write_graphite
    EscapeCharacter "<%= @escapecharacter %>"
    StoreRates <%=  @storerates %>
    AlwaysAppendDS <%= @alwaysappendds %>
-<% if (scope.function_versioncmp([@collectd_version, '5.4']) >= 0) -%>
+<% if @collectd_version and (scope.function_versioncmp([@collectd_version, '5.4']) >= 0) -%>
    Protocol "<%= @protocol %>"
 <% end -%>
  </Carbon>


### PR DESCRIPTION
If the collectd_version fact returns null then
the versioncmp function throws a ruby error. This
commit add checks to see if it is null before calling
versioncmp.

Fixes #85
