### PR TITLE
Fix collectd conf dir path parameter assignment

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@ class collectd(
 
   file { 'collectd.d':
     ensure  => directory,
-    name    => $collectd::params::plugin_conf_dir,
+    path    => $collectd::params::plugin_conf_dir,
     mode    => '0644',
     owner   => 'root',
     group   => $collectd::params::root_group,


### PR DESCRIPTION
I supposed a typo.
It's highlighted as deprecated by Geppetto in any case.
