### PR TITLE
Varnish fixup

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,6 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = "${collectd_dir}/collectd.conf"
       $root_group        = 'root'
-      $varnish_package    = 'core'
     }
     'Solaris': {
       $package           = 'CSWcollectd'
@@ -20,7 +19,6 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = "${collectd_dir}/collectd.conf"
       $root_group        = 'root'
-      $varnish_package    = undef
     }
     'Redhat': {
       $package           = 'collectd'
@@ -30,7 +28,6 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = '/etc/collectd.conf'
       $root_group        = 'root'
-      $varnish_package    = 'varnish'
     }
     'Suse': {
       $package           = 'collectd'
@@ -40,7 +37,6 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = '/etc/collectd.conf'
       $root_group        = 'root'
-      $varnish_package    = undef
     }
     'FreeBSD': {
       $package           = 'collectd5'
@@ -50,7 +46,6 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = '/usr/local/etc/collectd.conf'
       $root_group        = 'wheel'
-      $varnish_package    = undef
     }
     'Archlinux': {
       $package           = 'collectd'
@@ -60,11 +55,9 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = '/etc/collectd.conf'
       $root_group        = 'wheel'
-      $varnish_package    = undef
     }
     default: {
       fail("${::osfamily} is not supported.")
     }
   }
-
 }

--- a/manifests/plugin/varnish.pp
+++ b/manifests/plugin/varnish.pp
@@ -1,19 +1,19 @@
 # https://collectd.org/wiki/index.php/Plugin:Varnish
 class collectd::plugin::varnish (
-  $ensure           = present,
-  $instances        = {
+  $ensure    = present,
+  $instances = {
       'localhost' => {
-        'CollectCache' => 'true',
-        'CollectBackend' => 'true',
+        'CollectCache'       => 'true',
+        'CollectBackend'     => 'true',
         'CollectConnections' => 'true',
-        'CollectSHM' => 'true',
-        'CollectESI' => 'false',
-        'CollectFetch' => 'true',
-        'CollectHCB' => 'false',
-        'CollectTotals' => 'true',
-        'CollectWorkers' => 'true',
+        'CollectSHM'         => 'true',
+        'CollectESI'         => 'false',
+        'CollectFetch'       => 'true',
+        'CollectHCB'         => 'false',
+        'CollectTotals'      => 'true',
+        'CollectWorkers'     => 'true',
+      }
     }
-  }
 ) {
   include collectd::params
 
@@ -26,12 +26,10 @@ class collectd::plugin::varnish (
     $instances
   )
 
-  if $collectd::params::varnish_pacakge {
-
-    package { "${collectd::params::package}-${collectd::params::varnish_package}":
+  if $::osfamily == 'Redhat' {
+    package { 'collectd-varnish':
       ensure => installed
     }
-
   }
 
   file { 'varnish.conf':


### PR DESCRIPTION
I don't see the point of the special parameter for the varnish collectd plugin only for the case of RedHat osfamily and only for varnish. It seems that several plugins are packaged in their own package on RedHat and I don't think it's a good idea to add a parameter for each package, given that it only concerns one osfamily...
The collectd-core package is a dependency of the collectd package under debian so I don't think there's a need to install it via puppet, and even less for the varnish plugin.
Moreover there was a typo in the variable name.
