### PR TITLE
Style fixes

### DIFF
--- a/manifests/plugin/varnish.pp
+++ b/manifests/plugin/varnish.pp
@@ -3,15 +3,15 @@ class collectd::plugin::varnish (
   $ensure    = present,
   $instances = {
       'localhost' => {
-        'CollectCache'       => 'true',
-        'CollectBackend'     => 'true',
-        'CollectConnections' => 'true',
-        'CollectSHM'         => 'true',
-        'CollectESI'         => 'false',
-        'CollectFetch'       => 'true',
-        'CollectHCB'         => 'false',
-        'CollectTotals'      => 'true',
-        'CollectWorkers'     => 'true',
+        'CollectCache'       => true,
+        'CollectBackend'     => true,
+        'CollectConnections' => true,
+        'CollectSHM'         => true,
+        'CollectESI'         => false,
+        'CollectFetch'       => true,
+        'CollectHCB'         => false,
+        'CollectTotals'      => true,
+        'CollectWorkers'     => true,
       }
     }
 ) {
@@ -30,7 +30,7 @@ class collectd::plugin::varnish (
   }
 
   collectd::plugin {'varnish':
-    ensure => $ensure,
-    content   => template('collectd/plugin/varnish.conf.erb'),
+    ensure  => $ensure,
+    content => template('collectd/plugin/varnish.conf.erb'),
   }
 }

--- a/manifests/plugin/write_network.pp
+++ b/manifests/plugin/write_network.pp
@@ -10,7 +10,7 @@ class collectd::plugin::write_network (
 
   $servernames = keys($servers)
   if empty($servernames) {
-    fail("servers cannot be empty")
+    fail('servers cannot be empty')
   }
   $servername = $servernames[0]
   $serverport = $servers[$servername]['serverport']


### PR DESCRIPTION
Runs puppet-lint with the following options: --no-80chars-check --no-class_parameter_defaults-check

(to be discussed :) )
