### PR TITLE
Replace collectd with collectd-core package

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@ class collectd::params {
 
   case $::osfamily {
     'Debian': {
-      $package           = 'collectd'
+      $package           = 'collectd-core'
       $provider          = 'apt'
       $collectd_dir      = '/etc/collectd'
       $plugin_conf_dir   = "${collectd_dir}/conf.d"


### PR DESCRIPTION
Switching from using the package collectd to collectd-core for Debian.

This avoids the following packages being installed on all servers collectd is applied to:

```
acl colord consolekit dbus-x11 dconf-gsettings-backend dconf-service gconf-service gconf2 gconf2-common libasound2 libcairo-gobject2 libcanberra-gtk3-0 libcanberra-gtk3-module libcanberra0 libcap-ng0 libck-connector0 libcolord1  libdbus-glib-1-2 libdconf0 libesmtp6 libexif12 libgconf-2-4 libgd2-xpm libgphoto2-2 libgphoto2-l10n libgphoto2-port0 libgtk-3-0 libgtk-3-bin libgtk-3-common libgudev-1.0-0 libgusb2 libhal1 libieee1284-3 libmemcached10 libmodbus5 libnetcf1 libnl1 libnotify4 libnuma1 libogg0 libopenipmi0 liboping0 libpam-ck-connector libpolkit-agent-1-0 libpolkit-backend-1-0 libpolkit-gobject-1-0 libprotobuf-c0 librabbitmq0 libsane libsane-common libsane-extras libsane-extras-common libtokyotyrant3 libupsclient1 libusb-1.0-0 libv4l-0 libv4lconvert0 libvarnishapi1 libvirt0 libvorbis0a libvorbisfile3 libxenstore3.0 libyajl2 notification-daemon policykit-1 sane-utils
```

This is unacceptable in a production environment as the dependancy tree is
HUGE, see: http://people.debian.org/~mika/collectd.svg

The list of plugins and their dependancies are available here:
https://collectd.org/wiki/index.php/Table_of_Plugins
