### PR TITLE
tcpconn plugin: $localports and $remoteports can me left undef

### DIFF
--- a/manifests/plugin/tcpconns.pp
+++ b/manifests/plugin/tcpconns.pp
@@ -2,13 +2,9 @@
 class collectd::plugin::tcpconns (
   $localports  = undef,
   $remoteports = undef,
-  $listening   = false,
+  $listening   = undef,
   $ensure      = present
 ) {
-
-  if ! $localports and ! $remoteports {
-    fail('Either local or remote ports need to be specified')
-  }
 
   if $localports {
     validate_array($localports)
@@ -17,8 +13,6 @@ class collectd::plugin::tcpconns (
   if $remoteports {
     validate_array($remoteports)
   }
-
-  validate_bool($listening)
 
   collectd::plugin {'tcpconns':
     ensure  => $ensure,

--- a/spec/classes/collectd_plugin_tcpconns_spec.rb
+++ b/spec/classes/collectd_plugin_tcpconns_spec.rb
@@ -60,11 +60,5 @@ describe 'collectd::plugin::tcpconns', :type => :class do
       expect {should}.to raise_error(Puppet::Error,/String/)
     end
   end
-
-  context 'neither :remoteports nor :localports defined' do
-    it 'Will raise an error about :remoteports or :localports not defined' do
-      expect {should}.to raise_error(Puppet::Error,/need to be specified/)
-    end
-  end
 end
 

--- a/templates/plugin/tcpconns.conf.erb
+++ b/templates/plugin/tcpconns.conf.erb
@@ -1,5 +1,8 @@
 <Plugin tcpconns>
+
+<% if @listening -%>
   ListeningPorts <%= @listening %>
+<% end -%>
 <% if @localports -%>
 <%   @localports.each do |localport| -%>
   LocalPort "<%= localport %>"


### PR DESCRIPTION
This fixes #142. 

Release note : Anybody relying on the default set by the plugin (that was not consistent with collectd's) might want to set listening to false manually to avoid surprises 
