### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2014-04-14 Release 2.1.0
+
+### Summary:
+
+This release adds Gentoo osfamily support and minor plugin changes
+
+### Features:
+
+- adding Gentoo support
+- tcpconn plugin: $localports and $remoteports can me left undef if $listening is not set
+- unixsock plugin: Implement the "DeleteSocket" option.
+- add reportreserved parameter for df plugin
+
+
 ## 2014-04-14 Release 2.0.1
 
 ### Summary:

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'pdxcat-collectd'
-version '2.0.1'
+version '2.1.0'
 author 'Computer Action Team'
 license 'Apache License 2.0'
 project_page 'https://github.com/pdxcat/puppet-module-collectd'

--- a/metadata.json
+++ b/metadata.json
@@ -41,6 +41,9 @@
         "10.04",
         "12.04"
       ]
+    },
+    {
+      "operatingsystem": "Gentoo"
     }
   ],
   "requirements": [
@@ -54,7 +57,7 @@
     }
   ],
   "name": "pdxcat-collectd",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "source": "https://github.com/pdxcat/puppet-module-collectd",
   "author": "Computer Action Team",
   "license": "Apache Version 2.0",


### PR DESCRIPTION
Summary:

This release adds Gentoo osfamily support and minor plugin changes

Features:
- adding Gentoo support
- tcpconn plugin: $localports and $remoteports can me left undef if $listening is not set
- unixsock plugin: Implement the "DeleteSocket" option.
- add reportreserved parameter for df plugin
