### PR TITLE
Issue 164: syslog plugin needs to be loaded as first plugin

### DIFF
--- a/manifests/plugin/logfile.pp
+++ b/manifests/plugin/logfile.pp
@@ -8,5 +8,8 @@ class collectd::plugin::logfile (
   collectd::plugin { 'logfile':
     ensure  => $ensure,
     content => template('collectd/plugin/logfile.conf.erb'),
+    # Load logging plugin first
+    # https://github.com/pdxcat/puppet-module-collectd/pull/166#issuecomment-50591413
+    order   => '05',
   }
 }

--- a/manifests/plugin/syslog.pp
+++ b/manifests/plugin/syslog.pp
@@ -7,5 +7,8 @@ class collectd::plugin::syslog (
   collectd::plugin {'syslog':
     ensure  => $ensure,
     content => template('collectd/plugin/syslog.conf.erb'),
+    # Load logging plugin first
+    # https://github.com/pdxcat/puppet-module-collectd/pull/166#issuecomment-50591413
+    order   => '05',
   }
 }


### PR DESCRIPTION
If the syslog plugin is not initialized as first plugin, other plugins
won't be able to log their startup/fail output at load time.

reported by bzed
