### PR TITLE
add collectd-rrdtool package needed for RedHat

### DIFF
--- a/manifests/plugin/rrdtool.pp
+++ b/manifests/plugin/rrdtool.pp
@@ -42,6 +42,12 @@ class collectd::plugin::rrdtool (
     fail('writespersecond must be an integer!')
   }
 
+  if $::osfamily == 'RedHat' {
+    package { 'collectd-rrdtool':
+      ensure => $ensure,
+    }
+  }
+
   collectd::plugin {'rrdtool':
     ensure  => $ensure,
     content => template('collectd/plugin/rrdtool.conf.erb'),

--- a/spec/classes/collectd_plugin_rrdtool_spec.rb
+++ b/spec/classes/collectd_plugin_rrdtool_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::rrdtool', :type => :class do
+  let :facts do
+    {:osfamily => 'RedHat'}
+  end
+
+  context ':ensure => present, default args' do
+    it 'Will create /etc/collectd.d/10-rrdtool.conf' do
+      should contain_file('rrdtool.load').with({
+        :ensure  => 'present',
+        :path    => '/etc/collectd.d/10-rrdtool.conf',
+        :content => /DataDir "\/var\/lib\/collectd\/rrd/,
+      })
+    end
+
+   it { should contain_package('collectd-rrdtool').with(
+     :ensure => 'present'
+   )}
+
+  end
+
+  context ':ensure => absent' do
+    let :params do
+      {:ensure => 'absent'}
+    end
+    it 'Will not create /etc/collectd.d/10-rrdtool.conf' do
+      should contain_file('rrdtool.load').with({
+        :ensure => 'absent',
+        :path   => '/etc/collectd.d/10-rrdtool.conf',
+      })
+    end
+  end
+end
+


### PR DESCRIPTION
RedHat distros bundle collectd's rrdtool libraries in a separate package (collectd-rrdtool).  Without this package installed, collectd generates errors when using collectd::plugin::rrdtool, because the module doesn't exist.
