### PR TITLE
notify the collectd service when purging plugins

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,7 @@ class collectd(
     group   => $collectd::params::root_group,
     purge   => $purge,
     recurse => $recurse,
+    notify  => Service['collectd'],
   }
 
   $conf_content = $purge_config ? {


### PR DESCRIPTION
currently, if you have purge enabled and remove a plugin, the collectd service isn't notified. this should make it do that.
