### PR TITLE
Add the possibility to customize package name.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,17 +9,17 @@ class collectd(
   $threads      = 5,
   $timeout      = 2,
   $typesdb      = [],
+  $package_name = $collectd::params::package,
   $version      = installed,
-) {
-  include collectd::params
+) inherits collectd::params {
 
   $plugin_conf_dir = $collectd::params::plugin_conf_dir
   validate_bool($purge_config, $fqdnlookup)
   validate_array($include, $typesdb)
 
-  package { 'collectd':
+  package { $package_name:
     ensure   => $version,
-    name     => $collectd::params::package,
+    name     => $package_name,
     provider => $collectd::params::provider,
     before   => File['collectd.conf', 'collectd.d'],
   }
@@ -67,6 +67,6 @@ class collectd(
     ensure    => running,
     name      => $collectd::params::service_name,
     enable    => true,
-    require   => Package['collectd'],
+    require   => Package[$package_name],
   }
 }

--- a/spec/classes/collectd_init_spec.rb
+++ b/spec/classes/collectd_init_spec.rb
@@ -44,4 +44,14 @@ describe 'collectd' do
    it { should_not contain_file_line('include_conf_d') }
  end
 
+ context 'when custom package_name is set' do
+   let :params do
+     { :package_name => 'collectd-core' }
+   end
+
+   it { should contain_package('collectd-core').with(
+     :ensure => 'installed'
+   )}
+ end
+
 end


### PR DESCRIPTION
For example, this add the possibility to install 'collectd-core' instead 'collectd'. Less dependencies (no consolekit etc ...) and enough to make the collector work on clients. Tested on Debian.

Thank you in advance.
