### PR TITLE
Improve collectd varnish

### DIFF
--- a/manifests/plugin/varnish.pp
+++ b/manifests/plugin/varnish.pp
@@ -3,23 +3,10 @@ class collectd::plugin::varnish (
   $ensure    = present,
   $instances = {
       'localhost' => {
-        'CollectCache'       => true,
-        'CollectBackend'     => true,
-        'CollectConnections' => true,
-        'CollectSHM'         => true,
-        'CollectESI'         => false,
-        'CollectFetch'       => true,
-        'CollectHCB'         => false,
-        'CollectTotals'      => true,
-        'CollectWorkers'     => true,
       }
     }
 ) {
   include collectd::params
-
-  if versioncmp($::collectd_version, 5.4) == -1 {
-    fail('Only collectd v5.4 and varnish v3 are supported!')
-  }
 
   validate_hash($instances)
 

--- a/spec/classes/collectd_plugin_varnish_spec.rb
+++ b/spec/classes/collectd_plugin_varnish_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::varnish', :type => :class do
+  context 'When the version is not 5.4' do
+    let :facts do
+      { :osfamily => 'RedHat',
+        :collectd_version => '5.3',
+      }
+    end
+    let :params do
+      {}
+    end
+    it 'should render the template with the default values' do
+content = <<EOS
+<Plugin varnish>
+  <Instance "localhost">
+  </Instance>
+</Plugin>
+EOS
+      should contain_collectd__plugin('varnish').with_content(content)
+    end
+  end
+  context 'When the version is nil' do
+    let :facts do
+      { :osfamily => 'RedHat',
+        :collectd_version => nil,
+      }
+    end
+    let :params do
+      {}
+    end
+    it 'should render the template with the default values' do
+content = <<EOS
+<Plugin varnish>
+  <Instance "localhost">
+  </Instance>
+</Plugin>
+EOS
+      should contain_collectd__plugin('varnish').with_content(content)
+    end
+  end
+
+  context 'When the version is 5.4' do
+    let :facts do
+      { :osfamily => 'RedHat',
+        :collectd_version => '5.4',
+      }
+    end
+    context 'when there are no params given' do
+      let :params do
+        {}
+      end
+      it 'should render the template with the default values' do
+content = <<EOS
+<Plugin varnish>
+  <Instance "localhost">
+  </Instance>
+</Plugin>
+EOS
+        should contain_collectd__plugin('varnish').with_content(content)
+      end
+    end
+    context 'when there are params given' do
+      let :params do
+        {
+          'instances' => {
+            'warble' => {
+              'BATMAN' => true,
+              'Robin' => false
+            }
+          }
+        }
+      end
+      it 'should render the template with the values passed in the params' do
+content = <<EOS
+<Plugin varnish>
+  <Instance "warble">
+    BATMAN true
+    Robin false
+  </Instance>
+</Plugin>
+EOS
+        should contain_collectd__plugin('varnish').with_content(content)
+      end
+    end
+  end
+
+
+end

--- a/templates/plugin/varnish.conf.erb
+++ b/templates/plugin/varnish.conf.erb
@@ -1,33 +1,9 @@
 <Plugin varnish>
 <% @instances.each do |instance,params| -%>
   <Instance "<%= instance %>">
-<%   if params['CollectCache'] -%>
-    CollectCache <%= params['CollectCache'] %>
-<%   end -%>
-<%   if params['CollectBackend'] -%>
-    CollectBackend <%= params['CollectBackend'] %>
-<%   end -%>
-<%   if params['CollectConnections'] -%>
-    CollectConnections <%= params['CollectConnections'] %>
-<%   end -%>
-<%   if params['CollectSHM'] -%>
-    CollectSHM <%= params['CollectSHM'] %>
-<%   end -%>
-<%   if params['CollectESI'] -%>
-    CollectESI <%= params['CollectESI'] %>
-<%   end -%>
-<%   if params['CollectFetch'] -%>
-    CollectFetch <%= params['CollectFetch'] %>
-<%   end -%>
-<%   if params['CollectHCB'] -%>
-    CollectHCB <%= params['CollectHCB'] %>
-<%   end -%>
-<%   if params['CollectTotals'] -%>
-    CollectTotals <%= params['CollectTotals'] %>
-<%   end -%>
-<%   if params['CollectWorkers'] -%>
-    CollectWorkers <%= params['CollectWorkers'] %>
-<%   end -%>
+<% params.sort.each do |k,v| -%>
+    <%= k %> <%= v %>
+<% end -%>
   </Instance>
 <% end -%>
 </Plugin>


### PR DESCRIPTION
- Fixes bug of being unable to use module if you have no current version of collectd - restriction to version 5.4 would block installation when version is nil
- Fixes bug of ignoring configs set to false - some of these will default to true if they are not explicitly set to false.
- More permissive about collectd version number - the user is expected to know what config options are allowed in their version.

Previously: https://github.com/pdxcat/puppet-module-collectd/pull/136
