### PR TITLE
Set default value of chains to be hash

### DIFF
--- a/manifests/plugin/iptables.pp
+++ b/manifests/plugin/iptables.pp
@@ -1,7 +1,7 @@
 # https://collectd.org/wiki/index.php/Plugin:IPTables
 class collectd::plugin::iptables (
   $ensure = present,
-  $chains = [],
+  $chains = {},
 ) {
   validate_hash($chains)
 


### PR DESCRIPTION
Seeing errors like this when value isn't set:

```
Error: [] is not a Hash.  It looks to be a Array at /vagrant/dist/modules/collectd/manifests/plugin/iptables.pp:6
```
