### PR TITLE
Add dependency for python plugins

### DIFF
--- a/manifests/plugin/python.pp
+++ b/manifests/plugin/python.pp
@@ -29,5 +29,6 @@ define collectd::plugin::python (
       mode    => '0644',
       source  => $script_source,
       require => File["${name}.load"],
+      notify  => Service['collectd'],
   }
 }


### PR DESCRIPTION
As there's no dependency between the .py file and the collectd service, there's no
guarantee they're installed and present before collectd is (re)started.
