### PR TITLE
Adding support for WriteQueueLimitLow & WriteQueueLimitHigh

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,17 +1,19 @@
 #
 class collectd(
-  $fqdnlookup         = true,
-  $collectd_hostname  = $::hostname,
-  $interval           = 10,
-  $include            = [],
-  $purge              = undef,
-  $purge_config       = false,
-  $recurse            = undef,
-  $threads            = 5,
-  $timeout            = 2,
-  $typesdb            = [],
-  $package_name       = $collectd::params::package,
-  $version            = installed,
+  $fqdnlookup             = true,
+  $collectd_hostname      = $::hostname,
+  $interval               = 10,
+  $include                = [],
+  $purge                  = undef,
+  $purge_config           = false,
+  $recurse                = undef,
+  $threads                = 5,
+  $timeout                = 2,
+  $typesdb                = [],
+  $write_queue_limit_high = undef,
+  $write_queue_limit_low  = undef,
+  $package_name           = $collectd::params::package,
+  $version                = installed,
 ) inherits collectd::params {
 
   $plugin_conf_dir = $collectd::params::plugin_conf_dir

--- a/templates/collectd.conf.erb
+++ b/templates/collectd.conf.erb
@@ -13,6 +13,12 @@ TypesDB<% @typesdb.each do |path| -%> "<%= path %>"<% end %>
 <% else -%>
 #TypesDB "/usr/share/collectd/types.db" "/etc/collectd/my_types.db"
 <% end -%>
+<% if @write_queue_limit_high -%>
+WriteQueueLimitHigh <%= @write_queue_limit_high %>
+<% end -%>
+<% if @write_queue_limit_low -%>
+WriteQueueLimitLow <%= @write_queue_limit_low %>
+<% end -%>
 Interval <%= @interval %>
 Timeout <%= @timeout %>
 ReadThreads <%= @threads %>


### PR DESCRIPTION
WriteQueueLimitLow & WriteQueueLimitHigh are very useful config options that were added in collectd 5.4.  If for any reason the output plugin can't send events it'll prevent the collectd processes from slowly consuming all of the memory on the server.
