### PR TITLE
Release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 2014-10-04 Release 3.0.1
+
+### Backwards-incompatible changes:
+
+none
+
+### Summary:
+
+Bug fix release
+
+### Features:
+
+* Add support for manually specifying the hostname
+
+### Bugs:
+
+* Add dependency for python plugins
+* Set default value of chains to be hash
+* Sort snmp data and hosts hash
+
 ## 2014-08-25 Release 3.0.0
 
 ### Backwards-incompatible changes:
@@ -7,6 +27,8 @@
 * Rewrite of postgresql module to allow invocation by defined types
 
 ### Summary:
+
+This release adds multiple new plugins and improvements
 
 ### Features:
 

--- a/metadata.json
+++ b/metadata.json
@@ -71,7 +71,7 @@
     }
   ],
   "name": "pdxcat-collectd",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "source": "https://github.com/pdxcat/puppet-module-collectd",
   "author": "Computer Action Team",
   "license": "Apache Version 2.0",


### PR DESCRIPTION
Backwards-incompatible changes:

  none

Summary:

  Bug fix release

Features:
- Add support for manually specifying the hostname

Bugs:
- Add dependency for python plugins
- Set default value of chains to be hash
- Sort snmp data and hosts hash
