### PR TITLE
Fix template variable to use @-notation

### DIFF
--- a/templates/plugin/network/listener.conf.erb
+++ b/templates/plugin/network/listener.conf.erb
@@ -1,5 +1,5 @@
 <Plugin network>
-<% if @collectd_version and (scope.function_versioncmp([collectd_version, '4.7']) >= 0) -%>
+<% if @collectd_version and (scope.function_versioncmp([@collectd_version, '4.7']) >= 0) -%>
   <Listen "<%= @name %>" "<%= @port %>">
 <% if @securitylevel -%>
     SecurityLevel "<%= @securitylevel %>"

--- a/templates/plugin/network/server.conf.erb
+++ b/templates/plugin/network/server.conf.erb
@@ -1,5 +1,5 @@
 <Plugin network>
-<% if @collectd_version and (scope.function_versioncmp([collectd_version, '4.7']) >= 0) -%>
+<% if @collectd_version and (scope.function_versioncmp([@collectd_version, '4.7']) >= 0) -%>
   <Server "<%= @name %>" "<%= @port %>">
 <% if @securitylevel -%>
     SecurityLevel "<%= @securitylevel %>"


### PR DESCRIPTION
This fix prevents the following messages:

```
Variable access via 'collectd_version' is deprecated. Use '@collectd_version' instead. template[/etc/puppet/modules/collectd/templates/plugin/network/listener.conf.erb]:2
   (at /usr/lib/ruby/vendor_ruby/puppet/parser/templatewrapper.rb:76:in `method_missing')
```
