### PR TITLE
Add collectd-apache package needed on RedHat

### DIFF
--- a/manifests/plugin/apache.pp
+++ b/manifests/plugin/apache.pp
@@ -6,6 +6,12 @@ class collectd::plugin::apache (
 
   validate_hash($instances)
 
+  if $::osfamily == 'RedHat' {
+    package { 'collectd-apache':
+      ensure => $ensure,
+    }
+  }
+
   collectd::plugin {'apache':
     ensure  => $ensure,
     content => template('collectd/plugin/apache.conf.erb'),


### PR DESCRIPTION
RedHat distros bundle apache plugin in a separate package
(collectd-apache).
