### PR TITLE
curl : 'MeasureResponseTime' needs exactly one boolean argument

### DIFF
--- a/templates/plugin/curl-page.conf.erb
+++ b/templates/plugin/curl-page.conf.erb
@@ -1,5 +1,5 @@
 <Plugin curl>
-  <Page "<%= plugininstance %>">
+  <Page "<%= @plugininstance %>">
     URL "<%= @url %>"
 <% if @user -%>
     User "<%= @user %>"


### PR DESCRIPTION
Collectd log an error when 'MeasureResponseTime' boolean argument is wrapped by double quotes.
