### PR TITLE
Double quote the csv plugin DataDir.

### DIFF
--- a/templates/plugin/csv.conf.erb
+++ b/templates/plugin/csv.conf.erb
@@ -1,4 +1,4 @@
 <Plugin csv>
-  DataDir <%= @datadir %>
+  DataDir "<%= @datadir %>"
   StoreRates <%= @storerates %>
 </Plugin>


### PR DESCRIPTION
I tried using the csv plugin _without_ this on CentOS6 with collectd-5.4.1, but got:

```
$ sudo service collectd restart
Parse error in file `/etc/collectd.d/10-csv.conf', line 27 near `/': syntax error, unexpected SLASH
yyparse returned error #1
configfile: Cannot read file `/etc/collectd.d/10-csv.conf'.
Unable to read config file /etc/collectd.conf.
Error: Reading the config file failed!
Read the syslog for details.
not restarting due to configuration error
                                       [FAILED]
```
