### PR TITLE
Support LogSendErrors on the write_graphite plugin

### DIFF
--- a/manifests/plugin/write_graphite.pp
+++ b/manifests/plugin/write_graphite.pp
@@ -10,9 +10,11 @@ class collectd::plugin::write_graphite (
   $alwaysappendds    = false,
   $protocol          = 'tcp',
   $separateinstances = false,
+  $logsenderrors     = true,
 ) {
   validate_bool($storerates)
   validate_bool($separateinstances)
+  validate_bool($logsenderrors)
 
   collectd::plugin {'write_graphite':
     ensure  => $ensure,

--- a/templates/plugin/write_graphite.conf.erb
+++ b/templates/plugin/write_graphite.conf.erb
@@ -10,6 +10,7 @@
     StoreRates <%=  @storerates %>
     AlwaysAppendDS <%= @alwaysappendds %>
     SeparateInstances <%= @separateinstances %>
+    LogSendErrors <%= @logsenderrors %>
 <% if @collectd_version and (scope.function_versioncmp([@collectd_version, '5.4']) >= 0) -%>
     Protocol "<%= @protocol %>"
 <% end -%>


### PR DESCRIPTION
From [collectd.conf(5)](http://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_write_graphite):

```
LogSendErrors false|true

    If set to true (the default), logs errors when sending data to
    Graphite. If set to false, it will not log the errors. This is
    especially useful when using Protocol UDP since many times we want
    to use the "fire-and-forget" approach and logging errors fills
    syslog with unneeded messages.
```
