### PR TITLE
curl: fix handling of some parameters

### DIFF
--- a/manifests/plugin/curl/page.pp
+++ b/manifests/plugin/curl/page.pp
@@ -10,7 +10,7 @@ define collectd::plugin::curl::page (
   $header              = undef,
   $post                = undef,
   $measureresponsetime = undef,
-  $matches             = [{ }],
+  $matches             = undef,
   $plugininstance      = $name, # You can have multiple <Page> with the same name.
 ) {
   include collectd::params
@@ -19,6 +19,10 @@ define collectd::plugin::curl::page (
   $conf_dir = $collectd::params::plugin_conf_dir
 
   validate_string($url)
+
+  if $matches != undef {
+    validate_array($matches)
+  }
 
   file { "${conf_dir}/curl-${name}.conf":
     ensure  => $ensure,

--- a/spec/classes/collectd_plugin_curl_spec.rb
+++ b/spec/classes/collectd_plugin_curl_spec.rb
@@ -49,6 +49,33 @@ describe 'collectd::plugin::curl', :type => :class do
     end
   end
 
+  context ':ensure => present, verifypeer => false, verifyhost => \'false\', measureresponsetime => true, matches empty' do
+    let :facts do
+      {:osfamily => 'Debian'}
+    end
+    let :params do
+      {
+        :ensure => 'present',
+        :pages => {
+          'selfsigned_ssl' => {
+            'url'                 => 'https://some.selfsigned.ssl.site/',
+            'verifypeer'          => false,
+            'verifyhost'          => 'false',
+            'measureresponsetime' => true,
+          },
+        }
+      }
+    end
+
+    it 'Will create /etc/collectd.d/conf.d/curl-selfsigned_ssl.conf' do
+      should contain_file('/etc/collectd/conf.d/curl-selfsigned_ssl.conf').with({
+        :ensure  => 'present',
+        :path    => '/etc/collectd/conf.d/curl-selfsigned_ssl.conf',
+        :content => "<Plugin curl>\n  <Page \"selfsigned_ssl\">\n    URL \"https://some.selfsigned.ssl.site/\"\n    VerifyPeer false\n    VerifyHost false\n    MeasureResponseTime true\n  </Page>\n</Plugin>\n",
+      })
+    end
+  end
+
   context ':ensure => absent' do
     let :facts do
       {:osfamily => 'RedHat'}

--- a/templates/plugin/curl-page.conf.erb
+++ b/templates/plugin/curl-page.conf.erb
@@ -7,11 +7,11 @@
 <% if @password -%>
     Password "<%= @password %>"
 <% end -%>
-<% if @verifypeer -%>
-    VerifyPeer "<%= @verifypeer %>"
+<% unless @verifypeer.nil? -%>
+    VerifyPeer <%= @verifypeer %>
 <% end -%>
-<% if @verifyhost %>
-    VerifyHost "<%= @verifyhost %>"
+<% unless @verifyhost.nil? -%>
+    VerifyHost <%= @verifyhost %>
 <% end -%>
 <% if @cacert -%>
     CACert "<%= @cacert %>"
@@ -22,9 +22,11 @@
 <% if @post and @collectd_version and (scope.function_versioncmp([@collectd_version, '5.3']) >= 0) -%>
     Post "<%= @post %>"
 <% end -%>
-<% if @measureresponsetime -%>
+<% unless @measureresponsetime.nil? -%>
     MeasureResponseTime <%= @measureresponsetime %>
 <% end -%>
+<% if @matches -%>
 <%= scope.function_template(["collectd/plugin/match.tpl.erb"]) %>
+<% end -%>
   </Page>
 </Plugin>


### PR DESCRIPTION
- $verifypeer/$verifyhost/$measureresponsetime: properly handle undef vs. false
- $matches: default value (array with empty hash) creates bad config (match
  block with missing values)
- $matches: match blocks are optional if measureresponsetime is enabled
