### PR TITLE
Fix Puppet deprecation warning

### DIFF
--- a/templates/plugin/statsd.conf.erb
+++ b/templates/plugin/statsd.conf.erb
@@ -3,21 +3,21 @@
   Host "<%= @host %>"
 <% end -%>
 <% if @port -%>
-  Port <%= port %>
+  Port <%= @port %>
 <% end -%>
 <% if @deletecounters -%>
-  DeleteCounters <%= deletecounters %>
+  DeleteCounters <%= @deletecounters %>
 <% end -%>
 <% if @deletetimers -%>
-  DeleteTimers <%= deletetimers %>
+  DeleteTimers <%= @deletetimers %>
 <% end -%>
 <% if @deletegauges -%>
-  DeleteGauges <%= deletegauges %>
+  DeleteGauges <%= @deletegauges %>
 <% end -%>
 <% if @deletesets -%>
-  Deletesets <%= deletesets %>
+  Deletesets <%= @deletesets %>
 <% end -%>
 <% if @timerpercentile -%>
-  TimerPercentile <%= timerpercentile %>
+  TimerPercentile <%= @timerpercentile %>
 <% end -%>
 </Plugin>


### PR DESCRIPTION
Example:

```
Warning: Variable access via 'port' is deprecated. Use '@port' instead. template[/etc/puppet/modules/collectd/templates/plugin/statsd.conf.erb]:6
   (at /etc/puppet/modules/collectd/templates/plugin/statsd.conf.erb:6:in `result')
Warning: Variable access via 'timerpercentile' is deprecated. Use '@timerpercentile' instead. template[/etc/puppet/modules/collectd/templates/plugin/statsd.conf.erb]:21
   (at /etc/puppet/modules/collectd/templates/plugin/statsd.conf.erb:21:in `result')
```
