### PR TITLE
Ensure variable using 'false' will be interpreted.

### DIFF
--- a/templates/plugin/apache.conf.erb
+++ b/templates/plugin/apache.conf.erb
@@ -8,10 +8,10 @@
 <% if values['password'] -%>
     Password "<%= values['password'] %>"
 <% end -%>
-<% if values['verifypeer'] -%>
+<% unless values['verifypeer'].nil? -%>
     VerifyPeer "<%= values['verifypeer'] %>"
 <% end -%>
-<% if values['verifyhost'] -%>
+<% unless values['verifyhost'].nil? -%>
     VerifyHost "<%= values['verifyhost'] %>"
 <% end -%>
 <% if values['cacert'] -%>

--- a/templates/plugin/bind.conf.erb
+++ b/templates/plugin/bind.conf.erb
@@ -9,13 +9,13 @@
   MemoryStats <%= @memorystats %>
 <% @views.each do |view| -%>
   <View "<%= view['name'] %>">
-<% if view['qtypes'] -%>
+<% unless view['qtypes'].nil? -%>
     QTypes <%= view['qtypes'] %>
 <% end -%>
-<% if view['resolverstats'] -%>
+<% unless view['resolverstats'].nil? -%>
     ResolverStats <%= view['resolverstats'] %>
 <% end -%>
-<% if view['cacherrsets'] -%>
+<% unless view['cacherrsets'].nil? -%>
     CacheRRSets <%= view['cacherrsets'] %>
 <% end -%>
 <% if view['zones'] -%>

--- a/templates/plugin/match.tpl.erb
+++ b/templates/plugin/match.tpl.erb
@@ -1,7 +1,7 @@
 <% @matches.each do |match| -%>
   <Match>
     Regex "<%= match['regex'] %>"
-<% if match['excluderegex'] -%>
+<% unless match['excluderegex'].nil? -%>
     ExcludeRegex "<%= match['excluderegex'] %>"
 <% end -%>
     DSType "<%= match['dstype'] %>"

--- a/templates/plugin/network.conf.erb
+++ b/templates/plugin/network.conf.erb
@@ -5,10 +5,10 @@
 <% if @maxpacketsize -%>
     MaxPacketSize <%= @maxpacketsize %>
 <% end -%>
-<% if @forward -%>
+<% unless @forward.nil? -%>
     Forward "<%= @forward %>"
 <% end -%>
-<% if @reportstats -%>
+<% unless @reportstats.nil? -%>
     ReportStats "<%= @reportstats %>"
 <% end -%>
   

--- a/templates/plugin/nginx.conf.erb
+++ b/templates/plugin/nginx.conf.erb
@@ -6,10 +6,10 @@
 <% if @password -%>
   Password "<%= @password %>"
 <% end -%>
-<% if @verifypeer -%>
+<% unless @verifypeer.nil? -%>
   VerifyPeer <%= @verifypeer %>
 <% end -%>
-<% if @verifyhost -%>
+<% unless @verifyhost.nil? -%>
   VerifyHost <%= @verifyhost %>
 <% end -%>
 <% if @cacert -%>

--- a/templates/plugin/postgresql/writer.conf.erb
+++ b/templates/plugin/postgresql/writer.conf.erb
@@ -1,6 +1,6 @@
   <Writer <%= @name %>>
     Statement "<%= @statement %>"
-<% if @storerates -%>
+<% unless @storerates.nil? -%>
     StoreRates <%= @storerates %>
 <% end -%>
   </Writer>

--- a/templates/plugin/rrdcached.conf.erb
+++ b/templates/plugin/rrdcached.conf.erb
@@ -1,10 +1,10 @@
 <Plugin rrdcached>
   DaemonAddress "<%= @daemonaddress %>"
   DataDir "<%= @datadir %>"
-<% unless @createfiles -%>
+<% unless @createfiles.nil? -%>
   CreateFiles "<%= @createfiles %>"
 <% end -%>
-<% if @createfilesasync -%>
+<% unless @createfilesasync.nil? -%>
   CreateFilesAsync "<%= @createfilesasync %>"
 <% end -%>
 <% if @stepsize -%>

--- a/templates/plugin/sensors.conf.erb
+++ b/templates/plugin/sensors.conf.erb
@@ -7,7 +7,7 @@
   Sensor "<%= @sensor %>"
 <% end -%>
 <% end -%>
-<% if @ignoreselected -%>
+<% unless @ignoreselected.nil? -%>
   IgnoreSelected "<%= @ignoreselected %>"
 <% end -%>
 </Plugin>

--- a/templates/plugin/statsd.conf.erb
+++ b/templates/plugin/statsd.conf.erb
@@ -5,16 +5,16 @@
 <% if @port -%>
   Port <%= @port %>
 <% end -%>
-<% if @deletecounters -%>
+<% unless @deletecounters.nil? -%>
   DeleteCounters <%= @deletecounters %>
 <% end -%>
-<% if @deletetimers -%>
+<% unless @deletetimers.nil? -%>
   DeleteTimers <%= @deletetimers %>
 <% end -%>
-<% if @deletegauges -%>
+<% unless @deletegauges.nil? -%>
   DeleteGauges <%= @deletegauges %>
 <% end -%>
-<% if @deletesets -%>
+<% unless @deletesets.nil? -%>
   Deletesets <%= @deletesets %>
 <% end -%>
 <% if @timerpercentile -%>

--- a/templates/plugin/write_http.conf.erb
+++ b/templates/plugin/write_http.conf.erb
@@ -7,10 +7,10 @@
 <% if values['password'] -%>
     Password "<%= values['password'] %>"
 <% end -%>
-<% if values['verifypeer'] -%>
+<% unless values['verifypeer'].nil? -%>
     VerifyPeer "<%= values['verifypeer'] %>"
 <% end -%>
-<% if values['verifyhost'] -%>
+<% unless values['verifyhost'].nil? -%>
     VerifyHost "<%= values['verifyhost'] %>"
 <% end -%>
 <% if values['cacert'] -%>


### PR DESCRIPTION
I read all templates in the module to ensure that issues like #182 and #201 (number one) doesn't happen again. 

Basically we confused how the string 'false' and the boolean false are handled. As implemented by #201, we check if the variable is null instead

Fixes #182. 
