### PR TITLE
Add ability to upload scripts used with exec plugin

### DIFF
--- a/manifests/plugin/exec/cmd.pp
+++ b/manifests/plugin/exec/cmd.pp
@@ -3,7 +3,10 @@ define collectd::plugin::exec::cmd (
   $group,
   $exec              = [],
   $notification_exec = [],
-  $ensure = present,
+  $script_source     = undef,
+  $extra_param       = undef,
+  $module            = $title,
+  $ensure            = present,
 ) {
   include collectd::params
   include collectd::plugin::exec
@@ -19,6 +22,19 @@ define collectd::plugin::exec::cmd (
     path   => "${conf_dir}/${name}.conf",
   }
   # End deprecation
+
+  if $script_source {
+    file { "${module}.script":
+      ensure  => $ensure,
+      path    => "${conf_dir}/${module}.sh",
+      owner   => 'root',
+      group   => $collectd::params::root_group,
+      mode    => '0755',
+      source  => $script_source,
+      require => File[$conf_dir],
+      notify  => Service['collectd'],
+    }
+  }
 
   concat::fragment{"collectd_plugin_exec_conf_${title}":
     ensure  => $ensure,

--- a/templates/plugin/exec/cmd.conf.erb
+++ b/templates/plugin/exec/cmd.conf.erb
@@ -1,5 +1,5 @@
 <%- unless @exec.empty? -%>
-  Exec "<%= @user %>:<%= @group %>" "<%= @exec.join('" "') %>"
+  Exec "<%= @user %>:<%= @group %>" "<%= @exec.join('" "') %>" <% if @extra_param %><% @extra_param.each do |extra| -%>"<%= extra %>" <% end -%><% end -%>
 <%- end -%>
 <%- unless @notification_exec.empty? -%>
   NotificationExec "<%= @user %>:<%= @group %>" "<%= @notification_exec.join('" "') %>"


### PR DESCRIPTION
I'm no expert in puppet and I don't know enough to write tests, but I'm using this hack to be able to upload shell scripts together with exec plugin. It's based on python plugin.

Example:
```puppet
  class { 'collectd::plugin::exec':
    commands => {
      'sockstat'            => {
        user          => 'collector',
        group         => 'collector',
        script_source => 'puppet:///modules/collectd/sockstat.sh',
        exec          => ['/etc/collectd.d/sockstat.sh'],
      },
      'network_connections' => {
        user          => 'collector',
        group         => 'collector',
        script_source => 'puppet:///modules/collectd/network_connections.sh',
        exec          => ['/etc/collectd.d/network_connections.sh'],
      },
      'smartmon'            => {
        user          => 'collector',
        group         => 'collector',
        script_source => 'puppet:///modules/collectd/smartmon.sh',
        exec          => ['/etc/collectd.d/smartmon.sh'],
        extra_param   => ['sda','sda'],
      },
    }
  }
```