### PR TITLE
collectd < 5.5 doesn't come with mysql InnodbStats.

### DIFF
--- a/templates/mysql-database.conf.erb
+++ b/templates/mysql-database.conf.erb
@@ -15,8 +15,10 @@
 <%- if @socket -%>
     Socket "<%= @socket %>"
 <%- end -%>
+<% if @collectd_version and (scope.function_versioncmp([@collectd_version, '5.5']) >= 0) -%>
 <%- if not @innodbstats.nil? -%>
     InnodbStats <%= @innodbstats %>
+<%- end -%>
 <%- end -%>
 <%- if not @slavenotifications.nil? -%>
     SlaveNotifications <%= @slavenotifications %>


### PR DESCRIPTION
The InnodbStats option of the mysql plugin was introduced in collectd 5.5.