### PR TITLE
Update ceph.conf.erb to support boolean data type

### DIFF
--- a/templates/plugin/ceph.conf.erb
+++ b/templates/plugin/ceph.conf.erb
@@ -1,6 +1,14 @@
 <Plugin ceph>
-  LongRunAvgLatency <%= @longrunavglatency %>
-  ConvertSpecialMetricTypes <%= @convertspecialmetrictypes %>
+  <%- if @longrunavglatency -%>
+  LongRunAvgLatency true
+  <%- else -%>
+  LongRunAvgLatency false
+  <%- end -%>
+  <%- if @convertspecialmetrictypes -%>
+  ConvertSpecialMetricTypes true
+  <%- else -%>
+  ConvertSpecialMetricTypes false
+  <%- end -%>
 
 <% @osds.each do |osd| -%>
   <Daemon "<%= osd %>">


### PR DESCRIPTION
Currently ```<%= @longrunavglatency %>``` and ```<%= @convertspecialmetrictypes %>``` doesn't output anything, as they are boolean and not strings.
Monkey patch to fix that behavior.
Prettier version apprieciated.