### PR TITLE
Allow easier creation of mysql monitoring through hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,6 +787,17 @@ collectd::plugin::mysql::database { 'betadase':
 }
 ```
 
+Hiera example in YAML:
+
+```
+collectd::plugin::mysql::databases:
+  'localhost':
+    'host': 'localhost'
+    'username': 'collectd'
+    'password': 'somePassword'
+    'masterstats': true
+```
+
 ####Class: `collectd::plugin::mongodb`
 
 ```puppet

--- a/manifests/plugin/mysql.pp
+++ b/manifests/plugin/mysql.pp
@@ -4,6 +4,7 @@ class collectd::plugin::mysql (
   $ensure           = present,
   $manage_package   = $collectd::manage_package,
   $interval         = undef,
+  $databases        = { },
 ){
 
   if $::osfamily == 'Redhat' {
@@ -17,4 +18,6 @@ class collectd::plugin::mysql (
   collectd::plugin { 'mysql':
     interval => $interval,
   }
+
+  create_resources(collectd::plugin::mysql::database, $databases)
 }


### PR DESCRIPTION
Would something like this be possible for the mysql plugin ?
I've tested it locally w. my own manifests, but I don't know if it could cause problems elsewhere.