### PR TITLE
Make module.conf.erb support complex config

### DIFF
--- a/spec/defines/collectd_plugin_python_module_spec.rb
+++ b/spec/defines/collectd_plugin_python_module_spec.rb
@@ -81,4 +81,21 @@ describe 'collectd::plugin::python::module', :type => :define do
                                              :path    => '/usr/share/collectd/python/foo.py',)
     end
   end
+
+  context 'complex config' do
+    let(:title) { 'foo' }
+    let :params do
+      {
+        :config => {'k1' => 'v1', 'k2' => ['v21', 'v22'], 'k3' => {'k31' => 'v31', 'k32' => 'v32'}},
+      }
+    end
+
+    it 'includes foo module configuration' do
+      should contain_concat__fragment('collectd_plugin_python_conf_foo').with(:content => /k1 v1/,)
+      should contain_concat__fragment('collectd_plugin_python_conf_foo').with(:content => /k2 v21/,)
+      should contain_concat__fragment('collectd_plugin_python_conf_foo').with(:content => /k2 v22/,)
+      should contain_concat__fragment('collectd_plugin_python_conf_foo').with(:content => /k3 k31 v31/,)
+      should contain_concat__fragment('collectd_plugin_python_conf_foo').with(:content => /k3 k32 v32/,)
+    end
+  end
 end

--- a/templates/plugin/python/module.conf.erb
+++ b/templates/plugin/python/module.conf.erb
@@ -2,6 +2,16 @@
 
   <Module "<%= @module %>">
   <%- @config.sort.each do |key,value| -%>
+  <%- if value.is_a?(Array) -%>
+  <%- value.sort.each do |v| -%>
+    <%= key %> <%= v %>
+  <%- end -%>
+  <%- elsif value.is_a?(Hash) -%>
+  <%- value.sort.each do |k,v| -%>
+    <%= key %> <%= k %> <%= v %>
+  <%- end -%>
+  <%- else -%>
     <%= key %> <%= value %>
+  <%- end -%>
   <%- end -%>
   </Module>


### PR DESCRIPTION
This makes the module.conf.erb template support complex config, i.e. config
with values that are arrays or hashes.

Closes #390