### PR TITLE
Fixing bug with rename collectd::params::package variable

### DIFF
--- a/manifests/plugin/python.pp
+++ b/manifests/plugin/python.pp
@@ -45,7 +45,7 @@ class collectd::plugin::python (
       'mode'    => '0750',
       'owner'   => 'root',
       'group'   => $collectd::params::root_group,
-      'require' => Package[$collectd::params::package]
+      'require' => Package[$collectd::params::package_name]
     }
   )
 


### PR DESCRIPTION
Change-Id: I2dc6239228fc19da1bcfa426f75388529b9b3eae

In addition to https://github.com/voxpupuli/puppet-collectd/pull/393, last parameter that should be renamed in python plugin.