### PR TITLE
Fixes mongodb plugin params docs to be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,40 +798,13 @@ class { 'collectd::plugin::mongodb':
 
 ##### Parameters:
 
-ensure
-------
-Optional. String that must be 'present' or 'absent'.
-
-- *Default*: 'present'
-
-interval
---------
-Optional. Number of seconds that collectd pauses between data collection.
-
-- *Default*: undef
-
-db_host
--------
-Optional. String that holds the IP of the MongoDB server.
-
-- *Default*: '127.0.0.1'
-
-db_user
--------
-Required. String that specifies the user name of an account that can log into MongoDB
-
-
-db_pass
--------
-Required. String that specifies the password of an account that can log into MongoDB
-
-configured_dbs
---------------
-Optional. Array of Strings that lists the databases that should be monitored in addition to the "admin" database.
-
-db_port
--------
-Required if the configured_dbs parameter is set. Unused otherwise.  Integer that specifies with port MongoDB listens on.
+* `ensure` (String): String that must be 'present' or 'absent'. *Default*: 'present' 
+* `interval` (String): Number of seconds that collectd pauses between data collection. *Default*: undef
+* `db_host` (String): String that holds the IP of the MongoDB server. *Default*: '127.0.0.1'
+* `db_user` (String): Required. String that specifies the user name of an account that can log into MongoDB
+* `db_user` (String): Required. String that specifies the password of an account that can log into MongoDB
+* `configured_dbs` (String): Optional. Array of Strings that lists the databases that should be monitored in addition to the "admin"
+* `db_port` (String): Required if the configured_dbs parameter is set. Unused otherwise.  Integer that specifies with port MongoDB listens on.
 
 ```puppet
 class { 'collectd::plugin::mongodb':


### PR DESCRIPTION
Rest of the document uses bullets rather than headings