### PR TITLE
Add support for puppetlabs-concat 2.x

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,6 +4,6 @@ fixtures:
       repo: 'git://github.com/puppetlabs/puppetlabs-stdlib'
     concat:
       repo: 'git://github.com/puppetlabs/puppetlabs-concat'
-      ref: '1.2.1'
+      ref: '2.1.0'
   symlinks:
     'collectd': "#{source_dir}"

--- a/manifests/plugin/dbi/database.pp
+++ b/manifests/plugin/dbi/database.pp
@@ -17,7 +17,6 @@ define collectd::plugin::dbi::database (
   validate_array($query)
 
   concat::fragment{"collectd_plugin_dbi_conf_db_${title}":
-    ensure  => $ensure,
     order   => '50',
     target  => "${collectd::params::plugin_conf_dir}/dbi-config.conf",
     content => template('collectd/plugin/dbi/database.conf.erb'),

--- a/manifests/plugin/dbi/query.pp
+++ b/manifests/plugin/dbi/query.pp
@@ -13,7 +13,6 @@ define collectd::plugin::dbi::query (
   validate_array($results)
 
   concat::fragment{"collectd_plugin_dbi_conf_query_${title}":
-    ensure  => $ensure,
     order   => '30',
     target  => "${collectd::params::plugin_conf_dir}/dbi-config.conf",
     content => template('collectd/plugin/dbi/query.conf.erb'),

--- a/manifests/plugin/exec/cmd.pp
+++ b/manifests/plugin/exec/cmd.pp
@@ -21,7 +21,6 @@ define collectd::plugin::exec::cmd (
   # End deprecation
 
   concat::fragment{"collectd_plugin_exec_conf_${title}":
-    ensure  => $ensure,
     order   => '50', # somewhere between header and footer
     target  => $collectd::plugin::exec::exec_conf,
     content => template('collectd/plugin/exec/cmd.conf.erb'),

--- a/manifests/plugin/postgresql/database.pp
+++ b/manifests/plugin/postgresql/database.pp
@@ -19,7 +19,6 @@ define collectd::plugin::postgresql::database (
   include ::collectd::plugin::postgresql
 
   concat::fragment{"collectd_plugin_postgresql_conf_db_${title}":
-    ensure  => $ensure,
     order   => '50',
     target  => "${collectd::params::plugin_conf_dir}/postgresql-config.conf",
     content => template('collectd/plugin/postgresql/database.conf.erb'),

--- a/manifests/plugin/postgresql/query.pp
+++ b/manifests/plugin/postgresql/query.pp
@@ -14,7 +14,6 @@ define collectd::plugin::postgresql::query (
   validate_array($params, $results)
 
   concat::fragment{"collectd_plugin_postgresql_conf_query_${title}":
-    ensure  => $ensure,
     order   => '30',
     target  => "${collectd::params::plugin_conf_dir}/postgresql-config.conf",
     content => template('collectd/plugin/postgresql/query.conf.erb'),

--- a/manifests/plugin/postgresql/writer.pp
+++ b/manifests/plugin/postgresql/writer.pp
@@ -10,7 +10,6 @@ define collectd::plugin::postgresql::writer (
   validate_string($statement)
 
   concat::fragment{"collectd_plugin_postgresql_conf_writer_${title}":
-    ensure  => $ensure,
     order   => '40',
     target  => "${collectd::params::plugin_conf_dir}/postgresql-config.conf",
     content => template('collectd/plugin/postgresql/writer.conf.erb'),

--- a/manifests/plugin/processes.pp
+++ b/manifests/plugin/processes.pp
@@ -32,13 +32,11 @@ class collectd::plugin::processes (
     ensure_newline => true,
   }
   concat::fragment{'collectd_plugin_processes_conf_header':
-    ensure  => $process_config_ensure,
     order   => '00',
     content => '<Plugin processes>',
     target  => "${collectd::params::plugin_conf_dir}/processes-config.conf",
   }
   concat::fragment{'collectd_plugin_processes_conf_footer':
-    ensure  => $process_config_ensure,
     order   => '99',
     content => '</Plugin>',
     target  => "${collectd::params::plugin_conf_dir}/processes-config.conf",

--- a/manifests/plugin/processes/process.pp
+++ b/manifests/plugin/processes/process.pp
@@ -7,7 +7,6 @@ define collectd::plugin::processes::process (
   include ::collectd::params
 
   concat::fragment{"collectd_plugin_processes_conf_process_${process}":
-    ensure  => $ensure,
     order   => '50',
     content => "Process \"${process}\"\n",
     target  => "${collectd::params::plugin_conf_dir}/processes-config.conf",

--- a/manifests/plugin/processes/processmatch.pp
+++ b/manifests/plugin/processes/processmatch.pp
@@ -8,7 +8,6 @@ define collectd::plugin::processes::processmatch (
   include ::collectd::params
 
   concat::fragment{"collectd_plugin_processes_conf_processmatch_${matchname}":
-    ensure  => $ensure,
     order   => '51',
     content => "ProcessMatch \"${matchname}\" \"${regex}\"\n",
     target  => "${collectd::params::plugin_conf_dir}/processes-config.conf",

--- a/manifests/plugin/python/module.pp
+++ b/manifests/plugin/python/module.pp
@@ -31,7 +31,6 @@ define collectd::plugin::python::module (
   }
 
   concat::fragment{"collectd_plugin_python_conf_${module}":
-    ensure  => $ensure,
     order   => '50', # somewhere between header and footer
     target  => $collectd::plugin::python::python_conf,
     content => template('collectd/plugin/python/module.conf.erb'),

--- a/manifests/plugin/write_graphite/carbon.pp
+++ b/manifests/plugin/write_graphite/carbon.pp
@@ -22,7 +22,6 @@ define collectd::plugin::write_graphite::carbon (
   validate_bool($logsenderrors)
 
   concat::fragment{"collectd_plugin_write_graphite_conf_${title}_${protocol}_${graphiteport}":
-    ensure  => $ensure,
     order   => '50', # somewhere between header and footer
     target  => $collectd::plugin::write_graphite::graphite_conf,
     content => template('collectd/plugin/write_graphite/carbon.conf.erb'),

--- a/spec/defines/collectd_typesdb_spec.rb
+++ b/spec/defines/collectd_typesdb_spec.rb
@@ -14,8 +14,10 @@ describe 'collectd::typesdb', :type => :define do
     let(:title) { '/etc/collectd/types.db' }
 
     it 'should contain empty types.db' do
-      should contain_concat('/etc/collectd/types.db')
-      should contain_file('/etc/collectd/types.db').with_mode('0640')
+      should contain_concat('/etc/collectd/types.db').with(
+        :ensure => 'present',
+        :path   => '/etc/collectd/types.db'
+      ).with_mode('0640')
     end
   end
 
@@ -24,7 +26,10 @@ describe 'collectd::typesdb', :type => :define do
     let(:params) { { 'mode' => '0644' } }
 
     it 'should contain file with different mode' do
-      should contain_file('/etc/collectd/types.db').with_mode('0644')
+      should contain_concat('/etc/collectd/types.db').with(
+        :ensure => 'present',
+        :path   => '/etc/collectd/types.db'
+      ).with_mode('0644')
     end
   end
 end


### PR DESCRIPTION
* Bumps fixture versions of concat to 2.1.0
* Fixes two tests
* Removes $ensure from concat::fragment as this is no longer support in concat 2.x