### PR TITLE
fix typo in write_sensu class example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1426,8 +1426,8 @@ class { 'collectd::plugin::write_riemann':
 
 ```puppet
 class { 'collectd::plugin::write_sensu':
-  riemann_host => 'sensu.example.org',
-  riemann_port => 3030,
+  sensu_host => 'sensu.example.org',
+  sensu_port => 3030,
 }
 ```
 


### PR DESCRIPTION
fix collectd::plugin::write_sensu parameter names to refer to sensu instead of riemann