### PR TITLE
Fixes issue with strict variables

### DIFF
--- a/spec/classes/collectd_plugin_curl_spec.rb
+++ b/spec/classes/collectd_plugin_curl_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::curl', :type => :class do
+  let :pre_condition do
+    'include ::collectd'
+  end
+
   context ':ensure => present, default params' do
     let :facts do
       { :osfamily => 'RedHat' }

--- a/spec/classes/collectd_plugin_iptables_spec.rb
+++ b/spec/classes/collectd_plugin_iptables_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::iptables', :type => :class do
+  let :pre_condition do
+    'include ::collectd'
+  end
+
   let :facts do
     { :osfamily => 'RedHat' }
   end

--- a/spec/classes/collectd_plugin_libvirt_spec.rb
+++ b/spec/classes/collectd_plugin_libvirt_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::libvirt', :type => :class do
+  let :pre_condition do
+    'include ::collectd'
+  end
+
   context 'interface_format in libvirt.conf' do
     let :params do
       { :connection       => 'qemu:///system',

--- a/spec/classes/collectd_plugin_ping_spec.rb
+++ b/spec/classes/collectd_plugin_ping_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::ping' do
+  let :pre_condition do
+    'include ::collectd'
+  end
+
   let :facts do
     { :osfamily => 'RedHat' }
   end

--- a/spec/classes/collectd_plugin_postgresql_spec.rb
+++ b/spec/classes/collectd_plugin_postgresql_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::postgresql', :type => :class do
+  let :pre_condition do
+    'include ::collectd'
+  end
+
   let :facts do
     {
       :osfamily => 'RedHat',

--- a/spec/classes/collectd_plugin_snmp_spec.rb
+++ b/spec/classes/collectd_plugin_snmp_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::snmp', :type => :class do
+  let :pre_condition do
+    'include ::collectd'
+  end
+
   let :facts do
     { :osfamily => 'RedHat' }
   end

--- a/spec/classes/collectd_plugin_varnish_spec.rb
+++ b/spec/classes/collectd_plugin_varnish_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::varnish', :type => :class do
+  let :pre_condition do
+    'include ::collectd'
+  end
+
   context 'When the version is not 5.4' do
     let :facts do
       { :osfamily => 'RedHat',

--- a/spec/defines/collectd_plugin_curl_page_spec.rb
+++ b/spec/defines/collectd_plugin_curl_page_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::curl::page', :type => :define do
+  let :pre_condition do
+    'include ::collectd'
+  end
+
   let :facts do
     { :osfamily => 'Debian' }
   end

--- a/spec/defines/collectd_plugin_mysql_database_spec.rb
+++ b/spec/defines/collectd_plugin_mysql_database_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::mysql::database', :type => :define do
+  let :pre_condition do
+    'include ::collectd'
+  end
+
   let :facts do
     { :osfamily => 'Debian' }
   end


### PR DESCRIPTION
`Undefined variable "collectd::manage_package"; class collectd has not been evaluated at /home/travis/build/voxpupuli/puppet-collectd/spec/fixtures/modules/collectd/manifests/plugin/mysql.pp:5 on node testing-worker-linux-docker-d88cd221-3376-linux-15.prod.travis-ci.org`