### PR TITLE
split out apache instance into define

### DIFF
--- a/manifests/plugin/apache/instance.pp
+++ b/manifests/plugin/apache/instance.pp
@@ -1,0 +1,26 @@
+# https://collectd.org/wiki/index.php/Plugin:Apache
+define collectd::plugin::apache::instance (
+  $url,
+  $ensure = present,
+  $user = undef,
+  $password = undef,
+  $verifypeer = undef,
+  $verifyhost = undef,
+  $cacert = undef,
+) {
+  include ::collectd
+  include ::collectd::plugin::apache
+
+  $conf_dir = $collectd::params::plugin_conf_dir
+  $root_group = $collectd::params::root_group
+
+  file { "apache-instance-${name}.conf":
+    ensure  => $ensure,
+    path    => "${conf_dir}/25-apache-instance-${name}.conf",
+    owner   => root,
+    group   => $root_group,
+    mode    => '0640',
+    content => template('collectd/plugin/apache/instance.conf.erb'),
+    notify  => Service['collectd'],
+  }
+}

--- a/spec/defines/collectd_plugin_apache_instance_spec.rb
+++ b/spec/defines/collectd_plugin_apache_instance_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::apache::instance', :type => :define do
+  let :facts do
+    { :osfamily => 'Debian' }
+  end
+
+  let(:title) { 'foo.example.com' }
+  let(:required_params) do
+    {
+      :url => 'http://localhost/mod_status?auto'
+    }
+  end
+
+  let(:filename) { 'apache-instance-foo.example.com.conf' }
+
+  context 'default params' do
+    let(:params) { required_params }
+
+    it do
+      should contain_file(filename).with(
+        :ensure => 'present',
+        :path   => '/etc/collectd/conf.d/25-apache-instance-foo.example.com.conf'
+      )
+    end
+
+    it { should contain_file(filename).that_notifies('Service[collectd]') }
+    it { should contain_file(filename).with_content(/<Plugin "apache">/) }
+    it { should contain_file(filename).with_content(/<Instance "foo\.example\.com">/) }
+    it { should contain_file(filename).with_content(%r{URL "http://localhost/mod_status\?auto"}) }
+    it { should contain_file(filename).without_content(/User "/) }
+    it { should contain_file(filename).without_content(/Password "/) }
+    it { should contain_file(filename).without_content(/VerifyHost "/) }
+    it { should contain_file(filename).without_content(/VerifyHost "/) }
+    it { should contain_file(filename).without_content(/CACert "/) }
+  end
+
+  context 'all params set' do
+    let(:params) do
+      required_params.merge(:url        => 'http://bar.example.com/server-status?auto',
+                            :user       => 'admin',
+                            :password   => 'admin123',
+                            :verifypeer => 'false',
+                            :verifyhost => 'false',
+                            :cacert     => '/etc/ssl/certs/ssl-cert-snakeoil.pem',)
+    end
+    it { should contain_file(filename).with_content(%r{URL "http://bar\.example\.com/server-status\?auto"}) }
+    it { should contain_file(filename).with_content(/User "admin"/) }
+    it { should contain_file(filename).with_content(/Password "admin123"/) }
+    it { should contain_file(filename).with_content(/VerifyPeer "false"/) }
+    it { should contain_file(filename).with_content(/VerifyHost "false"/) }
+    it { should contain_file(filename).with_content(%r{CACert "/etc/ssl/certs/ssl-cert-snakeoil\.pem"}) }
+  end
+end

--- a/templates/plugin/apache/instance.conf.erb
+++ b/templates/plugin/apache/instance.conf.erb
@@ -1,0 +1,20 @@
+<Plugin "apache">
+  <Instance "<%= @name %>">
+    URL "<%= @url %>"
+<% if @user -%>
+    User "<%= @user %>"
+<% end -%>
+<% if @password -%>
+    Password "<%= @password %>"
+<% end -%>
+<% if @verifypeer -%>
+    VerifyPeer "<%= @verifypeer %>"
+<% end -%>
+<% if @verifyhost -%>
+    VerifyHost "<%= @verifyhost %>"
+<% end -%>
+<% if @cacert -%>
+    CACert "<%= @cacert %>"
+<% end -%>
+  </Instance>
+</Plugin>


### PR DESCRIPTION
This PR adds a new defined type `collectd::plugin::apache::instance` that allows to automatize the configuration of apache monitoring in a central collectd server:

Consider the following use case:
Let's define the `profile::apache` class as: 
```
class profile::apache {
  # hiera stuff
  ...
  class { '::apache' :
    ...
  }

  @@collectd::plugin::apache::instance { $hostname :
    ...
  }
}
```
and the `profile::collectd::server` class as:
```
class profile::collectd::server {
  # hiera stuff
  ...
  Collectd::Plugin::Apache::Instance <<||>>
}
```
Whenever you apply the `profile::apache` class to a node, all the monitoring configuration of the apache instance will be 'automagically' generated on the central collectd server.