### PR TITLE
Adds report_relative parameter

### DIFF
--- a/manifests/plugin/load.pp
+++ b/manifests/plugin/load.pp
@@ -2,6 +2,7 @@
 class collectd::plugin::load (
   $ensure   = present,
   $interval = undef,
+  $report_relative = undef,
 ) {
   collectd::plugin {'load':
     ensure   => $ensure,

--- a/spec/classes/collectd_plugin_load_spec.rb
+++ b/spec/classes/collectd_plugin_load_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::load', type: :class do
+  let :pre_condition do
+    'include ::collectd'
+  end
+
+  let :facts do
+    { osfamily: 'Debian',
+      collectd_version: '4.10.1'
+    }
+  end
+
+  context 'report_relative in load.conf' do
+    let :params do
+      {
+        report_relative: true
+      }
+    end
+
+    it 'should be present' do
+      should contain_file('load.load')
+        .without_content(/\s{2}ReportRelative true\s{2}/)
+    end
+  end
+end

--- a/templates/loadplugin.conf.erb
+++ b/templates/loadplugin.conf.erb
@@ -5,6 +5,9 @@
 <% if @interval and @collectd_version and (scope.function_versioncmp([@collectd_version, '5.2']) >= 0) -%>
   Interval <%= @interval %>
 <% end -%>
+<% if @report_relative -%>
+  ReportRelative <%= @report_relative %>
+<% end -%>
 </LoadPlugin>
 <% else -%>
 LoadPlugin <%= @plugin %>


### PR DESCRIPTION
From CollectD docs:

```
ReportRelative false|true
When enabled, system load divided by number of available CPU cores is reported for intervals 1 min, 5 min and 15 min. Defaults to false.
```
- https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_load