### PR TITLE
Ensure plugin_conf_dir to be present

### DIFF
--- a/manifests/plugin/python.pp
+++ b/manifests/plugin/python.pp
@@ -59,6 +59,7 @@ class collectd::plugin::python (
     group          => $collectd::params::root_group,
     notify         => Service['collectd'],
     ensure_newline => true,
+    require        => File['collectd.d'],
   }
 
   concat::fragment{'collectd_plugin_python_conf_header':


### PR DESCRIPTION
plugin_conf_dir has to be present prior to creation of python_conf.

Fixes #416 