### PR TITLE
have configurable load plugin use template standard

### DIFF
--- a/manifests/plugin/load.pp
+++ b/manifests/plugin/load.pp
@@ -2,13 +2,14 @@
 class collectd::plugin::load (
   $ensure   = 'present',
   $interval = undef,
-  $report_relative = undef,
+  $report_relative = false,
 ) {
 
   include ::collectd
 
   collectd::plugin { 'load':
     ensure   => $ensure,
+    content  => template('collectd/plugin/load.conf.erb'),
     interval => $interval,
   }
 }

--- a/templates/loadplugin.conf.erb
+++ b/templates/loadplugin.conf.erb
@@ -5,9 +5,6 @@
 <% if @interval and scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.2']) >= 0) -%>
   Interval <%= @interval %>
 <% end -%>
-<% if @report_relative -%>
-  ReportRelative <%= @report_relative %>
-<% end -%>
 </LoadPlugin>
 <% else -%>
 LoadPlugin <%= @plugin %>

--- a/templates/plugin/load.conf.erb
+++ b/templates/plugin/load.conf.erb
@@ -1,0 +1,5 @@
+<% if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.5']) >= 0) -%>
+<Plugin load>
+  ReportRelative <%= @report_relative %>
+</Plugin>
+<% end -%>


### PR DESCRIPTION
In reference to: https://github.com/voxpupuli/puppet-collectd/commit/783c128fc2ff614e2b298c94d7c4c7702f3206ce#diff-71752fe3834a3d780fea4260c2cc003e

it looks like templates/loadplugin.conf.erb was confused for templates/plugin/load.conf.erb -- the former being used to build parameterized conf files from manifests/plugin/* , and the latter where .load files for specific manifests are built to include in the conf file.

The outcome was that ReportRelative was being dropped in the declaration of the plugin, rather than in the plugin's configuration.

the change in the manifest from undef to false supports default behavior.
--- 

Remove Load-Plugin specific lookup from loadplugin.conf.erb now that Load-Plugin's manifest uses template/plugin/load.conf.erb correctly

equals signs not standard