### PR TITLE
Set collectd_version fact to empty string if collectd not installed

### DIFF
--- a/lib/facter/collectd_version.rb
+++ b/lib/facter/collectd_version.rb
@@ -11,6 +11,8 @@ Facter.add(:collectd_version) do
     if Facter::Util::Resolution.which('collectd')
       collectd_help = Facter::Util::Resolution.exec('collectd -h')
       %r{^collectd ([\w\.]+), http://collectd\.org/}.match(collectd_help)[1]
+    else
+      ''
     end
   end
 end

--- a/spec/unit/collectd_real_version_spec.rb
+++ b/spec/unit/collectd_real_version_spec.rb
@@ -17,4 +17,9 @@ describe 'collectd_version', :type => :fact do
     Facter::Util::Resolution.stubs(:exec).with('collectd -h').returns(sample_collectd_help_git)
     expect(Facter.fact(:collectd_version).value).to eq('5.1.0.git')
   end
+
+  it 'should be empty string if collectd not installed' do
+    Facter::Util::Resolution.stubs(:which).with('collectd').returns(nil)
+    expect(Facter.fact(:collectd_version).value).to eq('')
+  end
 end


### PR DESCRIPTION
Fixes #421 - ```collectd_real_version``` in ```init.pp``` not set correctly as the fact returns ```nil```, and ```pick``` will accept that as a value.