### PR TITLE
Rabbitmq

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ documentation for each plugin for configurable attributes.
 * `protocols` (see [collectd::plugin:protocols](#class-collectdpluginprotocols) below)
 * `python` (see [collectd::plugin::python](#class-collectdpluginpython) below)
 * `redis` (see [collectd::plugin::redis](#class-collectdpluginredis) below)
+* `rabbitmq` (see [collectd-rabbitmq](https://pypi.python.org/pypi/collectd-rabbitmq) and [below](#class-collectdpluginrabbitmq) for implementation notes
 * `rrdcached` (see [collectd::plugin::rrdcached](#class-collectdpluginrrdcached) below)
 * `rrdtool` (see [collectd::plugin::rrdtool](#class-collectdpluginrrdtool) below)
 * `sensors` (see [collectd::plugin::sensors](#class-collectdpluginsensors) below)
@@ -1226,6 +1227,23 @@ class { 'collectd::plugin::redis':
       'timeout'  => 3000,
     }
   }
+}
+```
+
+####Class: `collectd::plugin::rabbitmq`
+
+Please note the rabbitmq plugin provides a [types.db.custom](https://github.com/NYTimes/collectd-rabbitmq/blob/master/config/types.db.custom). You will need to add this to [collectd::typesdb](https://github.com/voxpupuli/puppet-collectd/blob/master/manifests/init.pp#L28) via hiera or in a manifest. Failure to set the types.db.custom content will result in *no* metrics from the rabbitmq plugin.
+
+```puppet
+class { '::collectd::plugin::rabbitmq':
+  config           => {
+    'Username' => '"admin"',
+    'Password' => "${admin_pass}",
+    'Scheme'   => '"https"',
+    'Port'     => '"15671"',
+    'Host'     => "${::fqdn}",
+    'Realm'    => '"RabbitMQ Management"',
+  },
 }
 ```
 

--- a/manifests/plugin/rabbitmq.pp
+++ b/manifests/plugin/rabbitmq.pp
@@ -1,0 +1,75 @@
+# rabbitmq plugin
+# https://pypi.python.org/pypi/collectd-rabbitmq
+#
+# == Class collectd::plugin::rabbitmq
+#
+#  Configures rabbitmq metrics collection. Optionally installs the plugin
+#  Note, it is up to you to support package installation and sources
+#
+# === Parameters:
+# [*ensure*]
+#   String
+#   Passed to package and collectd::plugin resources ( both )
+#   Default: present
+#
+# [*interval*]
+#   Integer
+#   Interval setting for the plugin
+#   Default: undef
+#
+# [*manage_package*]
+#   Boolean
+#   Toggles installation of plugin. Please reference https://collectd-rabbitmq.readthedocs.org/en/latest/installation.html
+#   Default: undef
+#
+# [*package_provider*]
+#   String
+#   Passed to package resource
+#   Default: pip
+#
+# [*config*]
+#   Hash
+#   Contains key/value passed to the python module to configure the plugin
+#   Default: {
+#    'Username' => '"guest"',
+#    'Password' => '"guest_pass"',
+#    'Scheme'   => '"http"',
+#    'Port'     => '"15672"',
+#    'Host'     => "\"${::fqdn}\"",
+#    'Realm'    => '"RabbitMQ Management"',
+#   }
+#
+class collectd::plugin::rabbitmq (
+  $config           = {
+    'Username' => '"guest"',
+    'Password' => '"guest"',
+    'Scheme'   => '"http"',
+    'Port'     => '"15672"',
+    'Host'     => "\"${::fqdn}\"",
+    'Realm'    => '"RabbitMQ Management"',
+  },
+  $ensure           = 'present',
+  $interval         = undef,
+  $manage_package   = undef,
+  $package_name     = 'collectd-rabbitmq',
+  $package_provider = 'pip',
+) {
+  include ::collectd
+
+  validate_string($ensure)
+  validate_hash($config)
+
+  $_manage_package = pick($manage_package, $::collectd::manage_package)
+
+  if $_manage_package {
+    package { $package_name:
+      ensure   => $ensure,
+      provider => $package_provider,
+    }
+  }
+  collectd::typesdb { '/usr/share/collect-rabbitmq/types.db.custom': }
+  collectd::plugin::python::module { 'collectd_rabbitmq.collectd_plugin':
+    ensure => $ensure,
+    config => $config,
+  }
+}

--- a/spec/classes/collectd_plugin_rabbitmq_spec.rb
+++ b/spec/classes/collectd_plugin_rabbitmq_spec.rb
@@ -1,0 +1,129 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::rabbitmq', type: :class do
+  let :facts do
+    {
+      osfamily: 'RedHat',
+      collectd_version: '5.5.1'
+    }
+  end
+
+  context 'package ensure' do
+    context ':ensure => present' do
+      let(:node) { 'testhost.example.com' }
+
+      it 'Load collectd_rabbitmq in python-config' do
+        should contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(/Module "collectd_rabbitmq.collectd_plugin"/)
+      end
+
+      it 'import collectd_rabbitmq.collectd_plugin in python-config' do
+        should contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(/Import "collectd_rabbitmq.collectd_plugin"/)
+      end
+
+      it 'default to Username guest in python-config' do
+        should contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(/Username "guest"/)
+      end
+
+      it 'default to Password guest in python-config' do
+        should contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(/Password "guest"/)
+      end
+
+      it 'default to Port 15672 in python-config' do
+        should contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(/Port "15672"/)
+      end
+
+      it 'default to Scheme http in python-config' do
+        should contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(/Scheme "http"/)
+      end
+
+      it 'Host should be set to $::fqdn python-config' do
+        should contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(/Host "testhost.example.com"/)
+      end
+    end
+
+    context 'override Username to foo' do
+      let :facts do
+        { osfamily: 'RedHat',
+          collectd_version: '5.5'
+        }
+      end
+      let :params do
+        { config: { 'Username' => 'foo' } }
+      end
+
+      it 'override Username to foo in python-config' do
+        should contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(/Username "foo"/)
+      end
+    end
+
+    context 'override Password to foo' do
+      let :facts do
+        { osfamily: 'RedHat',
+          collectd_version: '5.5'
+        }
+      end
+      let :params do
+        { config: { 'Password' => 'foo' } }
+      end
+
+      it 'override Username to foo in python-config' do
+        should contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(/Password "foo"/)
+      end
+    end
+
+    context 'override Scheme to https' do
+      let :facts do
+        { osfamily: 'RedHat',
+          collectd_version: '5.5'
+        }
+      end
+      let :params do
+        { config: { 'Scheme' => 'https' } }
+      end
+
+      it 'override Username to foo in python-config' do
+        should contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(/Scheme "https"/)
+      end
+    end
+  end
+
+  context ':ensure => absent' do
+    let :params do
+      { ensure: 'absent' }
+    end
+
+    it 'Will remove python-config' do
+      should_not contain_concat__fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with(ensure: 'present')
+    end
+  end
+
+  # based on manage_package from dns spec but I added support for multiple providers
+  describe 'with manage_package parameter' do
+    ['true', true].each do |value|
+      context "set to #{value}" do
+        %w(present absent).each do |ensure_value|
+          %w(pip yum).each do |provider|
+            %w(collectd-rabbitmq collectd_rabbitmq).each do |packagename|
+              context "and ensure set to #{ensure_value} for package #{packagename} with package_provider #{provider}" do
+                let :params do
+                  { ensure: ensure_value,
+                    manage_package: value,
+                    package_name: packagename,
+                    package_provider: provider
+                  }
+                end
+
+                it do
+                  should contain_package(packagename).with(
+                    'ensure' => ensure_value,
+                    'provider' => provider
+                  )
+                end
+              end # packagename
+            end # ensure set
+          end # provider
+        end # present absent
+      end # context set
+    end # 'true', true
+  end # describe with manage_package
+end


### PR DESCRIPTION
Adding support for rabbitmq monitoring.

This is mostly complete / ready. I still need to look at the TypesDB line - I think that is just a config thing on my part.

The spec is mostly complete though at present it does not check a provider other than pip. I don't have other providers ( eg, rpm deb / apt etc ) available for testing. Can be added to the spec if desired.