### PR TITLE
TimerPercentile can be specified multiple times

### DIFF
--- a/manifests/plugin/statsd.pp
+++ b/manifests/plugin/statsd.pp
@@ -8,7 +8,7 @@ class collectd::plugin::statsd (
   $deletegauges    = undef,
   $deletesets      = undef,
   $interval        = undef,
-  $timerpercentile = undef,
+  $timerpercentile = [],
   $timerlower      = undef,
   $timerupper      = undef,
   $timersum        = undef,

--- a/manifests/plugin/statsd.pp
+++ b/manifests/plugin/statsd.pp
@@ -8,7 +8,7 @@ class collectd::plugin::statsd (
   $deletegauges    = undef,
   $deletesets      = undef,
   $interval        = undef,
-  $timerpercentile = [],
+  $timerpercentile = undef,
   $timerlower      = undef,
   $timerupper      = undef,
   $timersum        = undef,
@@ -16,6 +16,10 @@ class collectd::plugin::statsd (
 ) {
 
   include ::collectd
+
+  $timerpercentile_real = pick($timerpercentile, [])
+
+  validate_array($timerpercentile_real)
 
   collectd::plugin { 'statsd':
     ensure   => $ensure,

--- a/templates/plugin/statsd.conf.erb
+++ b/templates/plugin/statsd.conf.erb
@@ -17,8 +17,10 @@
 <% unless @deletesets.nil? -%>
   Deletesets <%= @deletesets %>
 <% end -%>
-<% if @timerpercentile -%>
-  TimerPercentile <%= @timerpercentile %>
+<% if @timerpercentile != [] -%>
+<% @timerpercentile.flatten.each do |percentile| -%>
+  TimerPercentile <%= percentile %>
+<% end -%>
 <% end -%>
 <% if @timerupper -%>
   TimerUpper <%= @timerupper %>

--- a/templates/plugin/statsd.conf.erb
+++ b/templates/plugin/statsd.conf.erb
@@ -17,10 +17,8 @@
 <% unless @deletesets.nil? -%>
   Deletesets <%= @deletesets %>
 <% end -%>
-<% if @timerpercentile != [] -%>
-<% @timerpercentile.flatten.each do |percentile| -%>
+<% @timerpercentile_real.each do |percentile| -%>
   TimerPercentile <%= percentile %>
-<% end -%>
 <% end -%>
 <% if @timerupper -%>
   TimerUpper <%= @timerupper %>


### PR DESCRIPTION
As is, this is a backwards incompatible change. Is there a way either in the manifest or the template to check if the value is an array or scalar first?