### PR TITLE
add manage_service param

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@ class collectd (
   $interval                = $collectd::params::interval,
   $internal_stats          = $collectd::params::internal_stats,
   $manage_package          = $collectd::params::manage_package,
+  $manage_service          = $collectd::params::manage_service,
   $minimum_version         = $collectd::params::minimum_version,
   $package_ensure          = $collectd::params::package_ensure,
   $package_install_options = $collectd::params::package_install_options,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,7 @@ class collectd::params {
   $service_enable          = true
   $minimum_version         = '4.8'
   $manage_package          = true
+  $manage_service          = true
   $package_install_options = undef
   $plugin_conf_dir_mode    = '0750'
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,12 +2,15 @@ class collectd::service (
   $service_name   = $collectd::service_name,
   $service_ensure = $collectd::service_ensure,
   $service_enable = $collectd::service_enable,
+  $manage_service = $collectd::manage_service,
 ) {
 
-  service { 'collectd':
-    ensure => $service_ensure,
-    name   => $service_name,
-    enable => $service_enable,
+  if $manage_service {
+    service { 'collectd':
+      ensure => $service_ensure,
+      name   => $service_name,
+      enable => $service_enable,
+    }
   }
 
 }

--- a/spec/classes/collectd_init_spec.rb
+++ b/spec/classes/collectd_init_spec.rb
@@ -131,6 +131,21 @@ describe 'collectd' do
     it { should contain_package('collectd').with_ensure('installed') }
   end
 
+  context 'when manage_service is true' do
+    let(:params) { { manage_service: true } }
+    it { should contain_service('collectd').with_ensure('running') }
+  end
+
+  context 'when manage_service is false' do
+    let(:params) { { manage_service: false } }
+    it { should_not contain_service('collectd') }
+  end
+
+  context 'when manage_service is undefined' do
+    let(:params) { { manage_service: nil } }
+    it { should contain_service('collectd').with_ensure('running') }
+  end
+
   context 'when plugin_conf_dir_mode is set' do
     let(:params) { { plugin_conf_dir_mode: '0755' } }
     it { should contain_file('collectd.d').with_mode('0755') }


### PR DESCRIPTION
Added a parameter to toggle automatic starting of the collectd service.  
The default behavior is the same as before, which is to automatically start the service.