### PR TITLE
[WIP] fixes for python module shellwords issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1241,17 +1241,25 @@ class { 'collectd::plugin::redis':
 
 ####Class: `collectd::plugin::rabbitmq`
 
-Please note the rabbitmq plugin provides a [types.db.custom](https://github.com/NYTimes/collectd-rabbitmq/blob/master/config/types.db.custom). You will need to add this to [collectd::typesdb](https://github.com/voxpupuli/puppet-collectd/blob/master/manifests/init.pp#L28) via hiera or in a manifest. Failure to set the types.db.custom content will result in *no* metrics from the rabbitmq plugin.
+Please note the rabbitmq plugin provides a [types.db.custom](https://github.com/NYTimes/collectd-rabbitmq/blob/master/config/types.db.custom). You will need to add this to [collectd::config::typesdb](https://github.com/voxpupuli/puppet-collectd/blob/master/manifests/config.pp#L18) via hiera or in a manifest. Failure to set the types.db.custom content will result in *no* metrics from the rabbitmq plugin.
+
+set typesdb to include the collectd-rabbitmq types.db.custom
+
+```yaml
+collectd::config::typesdb:
+  - /usr/share/collectd/types.db
+  - /usr/share/collect-rabbitmq/types.db.custom
+```
 
 ```puppet
 class { '::collectd::plugin::rabbitmq':
   config           => {
-    'Username' => '"admin"',
-    'Password' => "${admin_pass}",
-    'Scheme'   => '"https"',
-    'Port'     => '"15671"',
-    'Host'     => "${::fqdn}",
-    'Realm'    => '"RabbitMQ Management"',
+    'Username' => 'admin',
+    'Password' => $admin_pass,
+    'Scheme'   => 'https',
+    'Port'     => '15671',
+    'Host'     => $::fqdn,
+    'Realm'    => 'RabbitMQ Management',
   },
 }
 ```

--- a/manifests/plugin/rabbitmq.pp
+++ b/manifests/plugin/rabbitmq.pp
@@ -31,22 +31,22 @@
 #   Hash
 #   Contains key/value passed to the python module to configure the plugin
 #   Default: {
-#    'Username' => '"guest"',
-#    'Password' => '"guest_pass"',
-#    'Scheme'   => '"http"',
-#    'Port'     => '"15672"',
-#    'Host'     => "\"${::fqdn}\"",
-#    'Realm'    => '"RabbitMQ Management"',
+#    'Username' => 'guest',
+#    'Password' => 'guest_pass',
+#    'Scheme'   => 'http',
+#    'Port'     => '15672',
+#    'Host'     => $::fqdn,
+#    'Realm'    => 'RabbitMQ Management',
 #   }
 #
 class collectd::plugin::rabbitmq (
   $config           = {
-    'Username' => '"guest"',
-    'Password' => '"guest"',
-    'Scheme'   => '"http"',
-    'Port'     => '"15672"',
-    'Host'     => "\"${::fqdn}\"",
-    'Realm'    => '"RabbitMQ Management"',
+    'Username' => 'guest',
+    'Password' => 'guest',
+    'Scheme'   => 'http',
+    'Port'     => '15672',
+    'Host'     => $::fqdn,
+    'Realm'    => 'RabbitMQ Management',
   },
   $ensure           = 'present',
   $interval         = undef,
@@ -67,7 +67,6 @@ class collectd::plugin::rabbitmq (
       provider => $package_provider,
     }
   }
-  collectd::typesdb { '/usr/share/collect-rabbitmq/types.db.custom': }
   collectd::plugin::python::module { 'collectd_rabbitmq.collectd_plugin':
     ensure => $ensure,
     config => $config,

--- a/spec/classes/collectd_plugin_rabbitmq_spec.rb
+++ b/spec/classes/collectd_plugin_rabbitmq_spec.rb
@@ -11,6 +11,18 @@ describe 'collectd::plugin::rabbitmq', type: :class do
   context 'package ensure' do
     context ':ensure => present' do
       let(:node) { 'testhost.example.com' }
+      let :params do
+        {
+          config: {
+            'Username' => 'guest',
+            'Password' => 'guest',
+            'Port' => '15672',
+            'Scheme' => 'http',
+            'Host' => 'testhost.example.com',
+            'Realm' => 'RabbitMQ Management'
+          }
+        }
+      end
 
       it 'Load collectd_rabbitmq in python-config' do
         should contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(/Module "collectd_rabbitmq.collectd_plugin"/)
@@ -38,6 +50,10 @@ describe 'collectd::plugin::rabbitmq', type: :class do
 
       it 'Host should be set to $::fqdn python-config' do
         should contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(/Host "testhost.example.com"/)
+      end
+
+      it 'Realm set to "RabbitMQ Management"' do
+        should contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(/Realm "RabbitMQ Management"/)
       end
     end
 

--- a/spec/defines/collectd_plugin_python_module_spec.rb
+++ b/spec/defines/collectd_plugin_python_module_spec.rb
@@ -11,6 +11,49 @@ describe 'collectd::plugin::python::module', type: :define do
     }
   end
 
+  context 'true|false to boolean' do
+    context 'true to boolean' do
+      let(:title) { 'dummy' }
+      let :params do
+        {
+          config: { 'someFunkyBoolean' => true },
+          modulepath: '/var/lib/collectd/python',
+        }
+      end
+      it 'ensure someFunkyBoolean is boolean true' do
+        should contain_concat__fragment('collectd_plugin_python_conf_dummy')
+          .with(content: /someFunkyBoolean true/,
+                target: '/etc/collectd/conf.d/python-config.conf',)
+      end
+
+      it 'ensure someFunkyBoolean is not string "true"' do
+        should_not contain_concat__fragment('collectd_plugin_python_conf_dummy')
+          .with(content: /someFunkyBoolean "true"/,
+                target: '/etc/collectd/conf.d/python-config.conf',)
+      end
+    end
+    context 'false to boolean' do
+      let(:title) { 'dummy' }
+      let :params do
+        {
+          config: { 'someFunkyBoolean' => false },
+          modulepath: '/var/lib/collectd/python',
+        }
+      end
+      it 'ensure someFunkyBoolean is boolean true' do
+        should contain_concat__fragment('collectd_plugin_python_conf_dummy')
+          .with(content: /someFunkyBoolean false/,
+                target: '/etc/collectd/conf.d/python-config.conf',)
+      end
+
+      it 'ensure someFunkyBoolean is not string "false"' do
+        should_not contain_concat__fragment('collectd_plugin_python_conf_dummy')
+          .with(content: /someFunkyBoolean "false"/,
+                target: '/etc/collectd/conf.d/python-config.conf',)
+      end
+    end
+  end
+
   context 'spam module' do
     let(:title) { 'spam' }
     let :params do

--- a/templates/plugin/python/module.conf.erb
+++ b/templates/plugin/python/module.conf.erb
@@ -11,7 +11,11 @@
     <%= key %> <%= k %> <% if !!v == v %><%= v %><% else %>"<%= Shellwords.split(v).join('" "') %>"<% end %>
   <%- end -%>
   <%- else -%>
-    <%= key %> <% if !!value == value %><%= value %><% else %>"<%= Shellwords.split(value).join('" "') %>"<% end %>
+  <%- if not !!value == value and value.include?('"') -%>
+    <%= key %> "<%= Shellwords.split(value).join('" "') %>"
+  <%- else -%>
+    <%= key %> <% if !!value == value %><%= value %><% else %>"<%= value %>"<% end %>
+  <%- end -%>
   <%- end -%>
   <%- end -%>
   </Module>


### PR DESCRIPTION
I would like to know if this patch set addresses #418 @aequitas would you mind trying my fork of the module?

This patch set fixes a few things. The rabbitmq change ( #468 ) was mostly there but I did not notice an issue with the typesdb change. This should now be fixed.

This should address #456 but would like some additional validation.

This patch is addressing a few things - should I break it up or no?