### PR TITLE
Require 'shellwords' in the template. Fixes #456

### DIFF
--- a/templates/plugin/python/module.conf.erb
+++ b/templates/plugin/python/module.conf.erb
@@ -1,3 +1,4 @@
+  <%- require 'shellwords' -%>
   Import "<%= @module %>"
 
   <Module "<%= @module %>">


### PR DESCRIPTION
Supercedes #478 