### PR TITLE
Fix rabbitmq module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1243,16 +1243,24 @@ class { 'collectd::plugin::redis':
 
 ####Class: `collectd::plugin::rabbitmq`
 
-Please note the rabbitmq plugin provides a [types.db.custom](https://github.com/NYTimes/collectd-rabbitmq/blob/master/config/types.db.custom). You will need to add this to [collectd::typesdb](https://github.com/voxpupuli/puppet-collectd/blob/master/manifests/init.pp#L28) via hiera or in a manifest. Failure to set the types.db.custom content will result in *no* metrics from the rabbitmq plugin.
+Please note the rabbitmq plugin provides a [types.db.custom](https://github.com/NYTimes/collectd-rabbitmq/blob/master/config/types.db.custom). You will need to add this to [collectd::config::typesdb](https://github.com/voxpupuli/puppet-collectd/blob/master/manifests/config.pp#L18) via hiera or in a manifest. Failure to set the types.db.custom content will result in *no* metrics from the rabbitmq plugin.
+
+set typesdb to include the collectd-rabbitmq types.db.custom
+
+```yaml
+collectd::config::typesdb:
+  - /usr/share/collectd/types.db
+  - /usr/share/collect-rabbitmq/types.db.custom
+```
 
 ```puppet
 class { '::collectd::plugin::rabbitmq':
   config           => {
-    'Username' => '"admin"',
-    'Password' => "${admin_pass}",
-    'Scheme'   => '"https"',
-    'Port'     => '"15671"',
-    'Host'     => "${::fqdn}",
+    'Username' => 'admin',
+    'Password' => $admin_pass,
+    'Scheme'   => 'https',
+    'Port'     => '15671',
+    'Host'     => $::fqdn,
     'Realm'    => '"RabbitMQ Management"',
   },
 }

--- a/manifests/plugin/rabbitmq.pp
+++ b/manifests/plugin/rabbitmq.pp
@@ -30,22 +30,23 @@
 # [*config*]
 #   Hash
 #   Contains key/value passed to the python module to configure the plugin
+#   Note we have had issues with the Realm value and quoting, seems to be an issue with quoting. Multi-word values need to be wrapped in '"xxxx"'
 #   Default: {
-#    'Username' => '"guest"',
-#    'Password' => '"guest_pass"',
-#    'Scheme'   => '"http"',
-#    'Port'     => '"15672"',
-#    'Host'     => "\"${::fqdn}\"",
+#    'Username' => 'guest',
+#    'Password' => 'guest_pass',
+#    'Scheme'   => 'http',
+#    'Port'     => '15672',
+#    'Host'     => $::fqdn,
 #    'Realm'    => '"RabbitMQ Management"',
 #   }
 #
 class collectd::plugin::rabbitmq (
   $config           = {
-    'Username' => '"guest"',
-    'Password' => '"guest"',
-    'Scheme'   => '"http"',
-    'Port'     => '"15672"',
-    'Host'     => "\"${::fqdn}\"",
+    'Username' => 'guest',
+    'Password' => 'guest',
+    'Scheme'   => 'http',
+    'Port'     => '15672',
+    'Host'     => $::fqdn,
     'Realm'    => '"RabbitMQ Management"',
   },
   $ensure           = 'present',
@@ -67,7 +68,6 @@ class collectd::plugin::rabbitmq (
       provider => $package_provider,
     }
   }
-  collectd::typesdb { '/usr/share/collect-rabbitmq/types.db.custom': }
   collectd::plugin::python::module { 'collectd_rabbitmq.collectd_plugin':
     ensure => $ensure,
     config => $config,

--- a/spec/classes/collectd_plugin_rabbitmq_spec.rb
+++ b/spec/classes/collectd_plugin_rabbitmq_spec.rb
@@ -11,6 +11,18 @@ describe 'collectd::plugin::rabbitmq', type: :class do
   context 'package ensure' do
     context ':ensure => present' do
       let(:node) { 'testhost.example.com' }
+      let :params do
+        {
+          config: {
+            'Username' => 'guest',
+            'Password' => 'guest',
+            'Port'     => '15672',
+            'Scheme'   => 'http',
+            'Host'     => 'testhost.example.com',
+            'Realm'    => '"RabbitMQ Management"'
+          }
+        }
+      end
 
       it 'Load collectd_rabbitmq in python-config' do
         should contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(/Module "collectd_rabbitmq.collectd_plugin"/)
@@ -38,6 +50,10 @@ describe 'collectd::plugin::rabbitmq', type: :class do
 
       it 'Host should be set to $::fqdn python-config' do
         should contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(/Host "testhost.example.com"/)
+      end
+
+      it 'Realm set to "RabbitMQ Management"' do
+        should contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(/Realm "RabbitMQ Management"/)
       end
     end
 


### PR DESCRIPTION
This is picking up where https://github.com/voxpupuli/puppet-collectd/pull/478 left off. I have reduced the changes in this to just what is needed to fix my busted stuff for the rabbitmq python module check.

I'm having problems getting the rake tasks to run due to a gem issue. Curious if this is occurring upstream as well.

```
An error occurred while installing listen (3.1.3), and Bundler cannot continue.
Make sure that `gem install listen -v '3.1.3'` succeeds before bundling.
```

The tests were passing previously in #478 so I believe this will pass