### PR TITLE
Adds the ability to set tags and attributes for the `write_riemann` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1517,6 +1517,8 @@ class { 'collectd::plugin::write_network':
 class { 'collectd::plugin::write_riemann':
   riemann_host => 'riemann.example.org',
   riemann_port => 5555,
+  tags         => ['foo'],
+  attributes   => {'bar' => 'baz'},
 }
 ```
 

--- a/manifests/plugin/write_riemann.pp
+++ b/manifests/plugin/write_riemann.pp
@@ -10,6 +10,8 @@ class collectd::plugin::write_riemann (
   $always_append_ds = false,
   $interval         = undef,
   $ttl_factor       = '2.0',
+  $tags             = [],
+  $attributes       = {},
 ) {
 
   include ::collectd
@@ -20,6 +22,8 @@ class collectd::plugin::write_riemann (
   validate_bool($always_append_ds)
   validate_bool($batch)
   validate_numeric($ttl_factor)
+  validate_array($tags)
+  validate_hash($attributes)
 
   if $::osfamily == 'Redhat' {
     if $_manage_package {

--- a/spec/classes/collectd_plugin_write_riemann_spec.rb
+++ b/spec/classes/collectd_plugin_write_riemann_spec.rb
@@ -10,7 +10,9 @@ describe 'collectd::plugin::write_riemann', type: :class do
 
   context ':ensure => present and :riemann_host => \'myhost\'' do
     let :params do
-      { riemann_host: 'myhost', riemann_port: '5555', protocol: 'TCP', batch: false, ttl_factor: '3' }
+      { riemann_host: 'myhost', riemann_port: '5555',
+        protocol: 'TCP', batch: false, ttl_factor: '3',
+        tags: ['foo'], attributes: { 'bar' => 'baz' } }
     end
     it 'Will create /etc/collectd.d/10-write_riemann.conf' do
       should contain_file('write_riemann.load').with(ensure: 'present',)
@@ -20,6 +22,8 @@ describe 'collectd::plugin::write_riemann', type: :class do
       should contain_file('write_riemann.load').with(content: /Protocol TCP/,)
       should contain_file('write_riemann.load').with(content: /Batch false/,)
       should contain_file('write_riemann.load').with(content: /TTLFactor 3/,)
+      should contain_file('write_riemann.load').with(content: /Tag "foo"/,)
+      should contain_file('write_riemann.load').with(content: /Attribute "bar" "baz"/,)
     end
   end
 
@@ -48,6 +52,24 @@ describe 'collectd::plugin::write_riemann', type: :class do
     end
     it 'Will raise an error about :ttl_factor not being a Boolean' do
       should compile.and_raise_error(/"false" is not a boolean/)
+    end
+  end
+
+  context ':tags is an array' do
+    let :params do
+      { tags: 'test' }
+    end
+    it 'Will raise an error about :tags not being an array' do
+      should compile.and_raise_error(/"test" is not an Array/)
+    end
+  end
+
+  context ':attributes is a hash' do
+    let :params do
+      { attributes: 'test' }
+    end
+    it 'Will raise an error about :attributes not being a hash' do
+      should compile.and_raise_error(/"test" is not a Hash/)
     end
   end
 end

--- a/templates/plugin/write_riemann.conf.erb
+++ b/templates/plugin/write_riemann.conf.erb
@@ -8,4 +8,10 @@
     AlwaysAppendDS <%= @always_append_ds %>
     TTLFactor <%= @ttl_factor %>
   </Node>
+<% @tags.each do |t| -%>
+  Tag "<%= t %>"
+<% end -%>
+<% @attributes.each do |k, v| -%>
+  Attribute "<%= k %>" "<%= v %>"
+<% end -%>
 </Plugin>


### PR DESCRIPTION
This has been tested in a real environment. Unit tests are also provided.

I'm a bit on the fence about calling the parameter `tags`, due to possible confusion with the Puppet metaparameter `tag`, but tried to follow existing conventions from this and other plugin manifests.