### PR TITLE
SNMP Plugin - Instance should be optional

### DIFF
--- a/manifests/plugin/curl_json.pp
+++ b/manifests/plugin/curl_json.pp
@@ -27,9 +27,7 @@ define collectd::plugin::curl_json (
     }
 
     if $::osfamily == 'Redhat' {
-      package { 'collectd-curl_json':
-        ensure => $ensure,
-      }
+      ensure_packages('collectd-curl_json')
     }
   }
 

--- a/templates/plugin/snmp.conf.erb
+++ b/templates/plugin/snmp.conf.erb
@@ -6,7 +6,9 @@
 <% if val['Table'] -%>
     Table <%= val['Table'] %>
 <% end -%>
+<% if val['Instance'] -%>
     Instance "<%= val['Instance'] %>"
+<% end -%>
 <% if val['InstancePrefix'] -%>
     InstancePrefix "<%= val['InstancePrefix'] %>"
 <% end -%>


### PR DESCRIPTION
The SNMP plugin allows Instance to be undefined if Table is set to true.

This is documented on https://collectd.org/documentation/manpages/collectd-snmp.5.shtml
"If Table is set to true and Instance is omitted, then "SUBID" will be used as the instance."