### PR TITLE
Only set ExcludeRegex in config file if variable is defined

### DIFF
--- a/templates/tail-file.conf.erb
+++ b/templates/tail-file.conf.erb
@@ -6,7 +6,9 @@
 <% @matches.each do |match| -%>
   <Match>
    Regex "<%= match['regex'] %>"
+<% unless @excluderegex.nil? -%>
    ExcludeRegex "<%= match['excluderegex'] %>"
+<% end -%>
    DSType "<%= match['dstype'] %>"
    Type "<%= match['type'] %>"
    Instance "<%= match['instance'] %>"


### PR DESCRIPTION
ExcludeRegex was set in config file even if it wasn't defined. This fix only sets ExcludeRegex when you define it in manifest.