### PR TITLE
Documentation fix and removed blank lines from curl_json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1332,7 +1332,7 @@ class { 'collectd::plugin::statsd':
   deletetimers    => false,
   deletegauges    => false,
   deletesets      => false,
-  timerpercentile => 50,
+  timerpercentile => ['50','90'],
 }
 ```
 

--- a/templates/curl_json.conf.erb
+++ b/templates/curl_json.conf.erb
@@ -11,12 +11,10 @@ LoadPlugin "curl_json"
 <% if @interval -%>
     Interval <%= @interval %>
 <% end -%>
-
-<% if @user %>
+<% if @user -%>
     User "<%= @user %>"
     Password "<%= @password %>"
-<% end %>
-
+<% end -%>
 <% unless @verifypeer.nil? -%>
     VerifyPeer <%= @verifypeer %>
 <% end -%>
@@ -26,12 +24,10 @@ LoadPlugin "curl_json"
 <% if @cacert -%>
     CACert "<%= @cacert %>"
 <% end -%>
-
-<% if @header %>
+<% if @header -%>
     Header "<%= @header %>"
-<% end %>
-
-<% @keys.sort.each do |key,keydata| %>
+<% end -%>
+<% @keys.sort.each do |key,keydata| -%>
     <Key "<%= key %>">
       Type "<%= keydata['type'] %>"
 <% if keydata['instance'] -%>
@@ -39,10 +35,10 @@ LoadPlugin "curl_json"
 <% end -%>
     </Key>
 <% end -%>
-
 <%- if @url.start_with? '/' -%>
   </Sock>
 <%- else -%>
   </URL>
 <%- end -%>
 </Plugin>
+


### PR DESCRIPTION
When declaring statsd plugin, timerpercentile must be an array.

There is also a cosmetic fix in curl_json template which removes a bunch of blank lines.