### PR TITLE
Check $manage_package if not undef

### DIFF
--- a/manifests/plugin/disk.pp
+++ b/manifests/plugin/disk.pp
@@ -15,7 +15,7 @@ class collectd::plugin::disk (
   validate_bool($ignoreselected)
 
   if $::osfamily == 'RedHat' {
-    if $manage_package {
+    if $manage_package != undef {
       $_manage_package = $manage_package
     } else {
       if versioncmp($::collectd::collectd_version_real, '5.5') >= 0 {

--- a/spec/classes/collectd_plugin_disk_spec.rb
+++ b/spec/classes/collectd_plugin_disk_spec.rb
@@ -48,6 +48,25 @@ describe 'collectd::plugin::disk', type: :class do
     end
   end
 
+  context ':manage_package => false on osfamily => RedHat' do
+    let :facts do
+      {
+        osfamily: 'RedHat',
+        collectd_version: '5.5',
+      }
+    end
+
+    let :params do
+      {
+        manage_package: false,
+      }
+    end
+    it 'Will not manage collectd-disk' do
+      should_not contain_package('collectd-disk').with(ensure: 'present',
+                                                       name: 'collectd-disk',)
+    end
+  end
+
   context ':manage_package => undef on osfamily => RedHat with collectd 5.5 and up' do
     let :facts do
       {


### PR DESCRIPTION
If $manage_package is false, the else block will be used instead disable managing the package.