### PR TITLE
Adding has_wordexp variable for template

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,7 @@ class collectd::config (
   $config_file            = $collectd::config_file,
   $conf_content           = $collectd::conf_content,
   $fqdnlookup             = $collectd::fqdnlookup,
+  $has_wordexp            = $collectd::has_wordexp,
   $include                = $collectd::include,
   $internal_stats         = $collectd::internal_stats,
   $interval               = $collectd::interval,


### PR DESCRIPTION
$has_wordexp was always being considered to be false as it is not being called from the collectd main class (which in turns calls it from the params class). This bug should now be fixed.