### PR TITLE
Apache plugin - Remove quotes from VerifyPeer and VerifyHost

### DIFF
--- a/spec/defines/collectd_plugin_apache_instance_spec.rb
+++ b/spec/defines/collectd_plugin_apache_instance_spec.rb
@@ -43,15 +43,15 @@ describe 'collectd::plugin::apache::instance', type: :define do
       required_params.merge(url: 'http://bar.example.com/server-status?auto',
                             user: 'admin',
                             password: 'admin123',
-                            verifypeer: 'false',
-                            verifyhost: 'false',
+                            verifypeer: false,
+                            verifyhost: false,
                             cacert: '/etc/ssl/certs/ssl-cert-snakeoil.pem',)
     end
     it { should contain_file(filename).with_content(%r{URL "http://bar\.example\.com/server-status\?auto"}) }
     it { should contain_file(filename).with_content(/User "admin"/) }
     it { should contain_file(filename).with_content(/Password "admin123"/) }
-    it { should contain_file(filename).with_content(/VerifyPeer "false"/) }
-    it { should contain_file(filename).with_content(/VerifyHost "false"/) }
+    it { should contain_file(filename).with_content(/VerifyPeer false/) }
+    it { should contain_file(filename).with_content(/VerifyHost false/) }
     it { should contain_file(filename).with_content(%r{CACert "/etc/ssl/certs/ssl-cert-snakeoil\.pem"}) }
   end
 end

--- a/templates/plugin/apache.conf.erb
+++ b/templates/plugin/apache.conf.erb
@@ -9,10 +9,10 @@
     Password "<%= values['password'] %>"
 <% end -%>
 <% unless values['verifypeer'].nil? -%>
-    VerifyPeer "<%= values['verifypeer'] %>"
+    VerifyPeer <%= values['verifypeer'] %>
 <% end -%>
 <% unless values['verifyhost'].nil? -%>
-    VerifyHost "<%= values['verifyhost'] %>"
+    VerifyHost <%= values['verifyhost'] %>
 <% end -%>
 <% if values['cacert'] -%>
     CACert "<%= values['cacert'] %>"

--- a/templates/plugin/apache/instance.conf.erb
+++ b/templates/plugin/apache/instance.conf.erb
@@ -7,11 +7,11 @@
 <% if @password -%>
     Password "<%= @password %>"
 <% end -%>
-<% if @verifypeer -%>
-    VerifyPeer "<%= @verifypeer %>"
+<% if defined? @verifypeer -%>
+    VerifyPeer <%= @verifypeer %>
 <% end -%>
-<% if @verifyhost -%>
-    VerifyHost "<%= @verifyhost %>"
+<% if defined? @verifyhost -%>
+    VerifyHost <%= @verifyhost %>
 <% end -%>
 <% if @cacert -%>
     CACert "<%= @cacert %>"


### PR DESCRIPTION
Currently the plugin fails to load when passing `verifypeer` and `verifyhost` args to an instance definition:
`cf_util_get_boolean: The VerifyPeer option requires exactly one boolean argument.`

