### PR TITLE
target replace filter fix to allow identical keys with different values

### DIFF
--- a/templates/plugin/filter/target.erb
+++ b/templates/plugin/filter/target.erb
@@ -8,7 +8,9 @@
 <%    elsif value.kind_of?(Integer) or value.kind_of?(TrueClass) or value.kind_of?(FalseClass) -%>
       <%= key %> <%= value %>
 <%    elsif value.kind_of?(Array) -%>
-      <%= key %> <%= value.flatten.map {|entry| "\"#{entry}\""}.join(' ') %>
+			<% value.each do |array_val| -%>
+						<%= key %> <%= array_val %>
+			<%    end -%>
 <%    end -%>
 <%  end -%>
     </Target>


### PR DESCRIPTION
This change allows having several occurrences of PluginInstance within the same target filter definition block.

```
collectd::plugin::filter::target{ "overwrite OIDs":
      chain   => $chainname,
      rule    => $rulename,
      plugin  => 'replace',
      options => {
          'PluginInstance' => ['"string1." "replace_string_1_"','"string2-" "replace_string_2"','"\"" "."']
      }
```

Resulting in this output in config file
```
<Target "replace">
   PluginInstance "string1." "replace_string_1_"
   PluginInstance "string2-" "replace_string_2_"
   PluginInstance "\"" "."
</Target>
```
