### PR TITLE
Added scale plugin

### DIFF
--- a/manifests/plugin/filter.pp
+++ b/manifests/plugin/filter.pp
@@ -10,7 +10,7 @@ class collectd::plugin::filter (
   include ::collectd
 
   $plugin_matches = ['regex','timediff','value','empty_counter','hashed']
-  $plugin_targets = ['notification','replace','set']
+  $plugin_targets = ['notification','replace','set','scale']
   $conf_file = "${collectd::plugin_conf_dir}/01-filter.conf"
 
   file { $conf_file:

--- a/templates/plugin/filter/target.erb
+++ b/templates/plugin/filter/target.erb
@@ -5,7 +5,7 @@
 <%  @options.each do |key, value| -%>
 <%    if value.kind_of?(String) -%>
       <%= key %> "<%= value %>"
-<%    elsif value.kind_of?(Integer) or value.kind_of?(TrueClass) or value.kind_of?(FalseClass) -%>
+<%    elsif value.kind_of?(Integer) or value.kind_of?(Float) or value.kind_of?(TrueClass) or value.kind_of?(FalseClass) -%>
       <%= key %> <%= value %>
 <%    elsif value.kind_of?(Array) -%>
       <%= key %> <%= value.flatten.map {|entry| "\"#{entry}\""}.join(' ') %>


### PR DESCRIPTION
Also needed to add Float as supported value in plugin/filter/target.erb template.
Scale is usefull for scaling memory size from bytes to GB.
This now works (tested on our environment):
  $chain2name = 'PreCache'
  collectd::plugin::filter::chain { $chain2name:
  }
  $rule2name = 'scale_to_gb'
  collectd::plugin::filter::rule { $rule2name:
    chain => $chain2name,
  }
  collectd::plugin::filter::match { "regex_mem":
    chain   => $chain2name,
    rule    => $rule2name,
    plugin  => 'regex',
    options => {
      'Type' => '^(memory|swap)$'
    }
  }
  collectd::plugin::filter::target{ "scale_mem":
    chain   => $chain2name,
    rule    => $rule2name,
    plugin  => 'scale',
    options => {
      'Factor' => 0.000000000931322574615478515625,
    }
  }