### PR TITLE
Fix for Concat lockfile issue

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -69,4 +69,7 @@ class collectd::config (
     purge   => $purge,
     recurse => $recurse,
   }
+
+  File['collectd.d'] -> Concat <| |>
+
 }

--- a/spec/classes/collectd_plugin_dbi_spec.rb
+++ b/spec/classes/collectd_plugin_dbi_spec.rb
@@ -19,6 +19,8 @@ describe 'collectd::plugin::dbi', type: :class do
                                            content: %r{LoadPlugin dbi})
     end
     it 'Will create /etc/collectd.d/dbi-config.conf' do
+      should contain_concat('/etc/collectd/conf.d/dbi-config.conf').
+        that_requires('File[collectd.d]')
       should contain_concat__fragment('collectd_plugin_dbi_conf_header').with(content: %r{<Plugin dbi>})
     end
   end

--- a/spec/classes/collectd_plugin_disk_spec.rb
+++ b/spec/classes/collectd_plugin_disk_spec.rb
@@ -52,18 +52,18 @@ describe 'collectd::plugin::disk', type: :class do
     let :facts do
       {
         osfamily: 'RedHat',
-        collectd_version: '5.5',
+        collectd_version: '5.5'
       }
     end
 
     let :params do
       {
-        manage_package: false,
+        manage_package: false
       }
     end
     it 'Will not manage collectd-disk' do
       should_not contain_package('collectd-disk').with(ensure: 'present',
-                                                       name: 'collectd-disk',)
+                                                       name: 'collectd-disk')
     end
   end
 

--- a/spec/classes/collectd_plugin_exec_spec.rb
+++ b/spec/classes/collectd_plugin_exec_spec.rb
@@ -28,6 +28,8 @@ describe 'collectd::plugin::exec', type: :class do
     end
 
     it 'Will create /etc/collectd.d/conf.d/exec-config' do
+      should contain_concat('/etc/collectd/conf.d/exec-config.conf').
+        that_requires('File[collectd.d]')
       should contain_concat__fragment('collectd_plugin_exec_conf_footer').
         with(content: %r{</Plugin>},
              target: '/etc/collectd/conf.d/exec-config.conf',

--- a/spec/classes/collectd_plugin_genericjmx_spec.rb
+++ b/spec/classes/collectd_plugin_genericjmx_spec.rb
@@ -28,6 +28,7 @@ describe 'collectd::plugin::genericjmx', type: :class do
     end
 
     it { should contain_concat(config_filename).that_notifies('Service[collectd]') }
+    it { should contain_concat(config_filename).that_requires('File[collectd.d]') }
 
     it do
       should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').

--- a/spec/classes/collectd_plugin_postgresql_spec.rb
+++ b/spec/classes/collectd_plugin_postgresql_spec.rb
@@ -22,6 +22,7 @@ describe 'collectd::plugin::postgresql', type: :class do
                                                   content: %r{LoadPlugin postgresql})
     end
     it 'Will create /etc/collectd.d/postgresql-config.conf' do
+      should contain_concat('/etc/collectd.d/postgresql-config.conf').that_requires('File[collectd.d]')
       should contain_concat__fragment('collectd_plugin_postgresql_conf_header').with(content: %r{<Plugin postgresql>})
     end
   end

--- a/spec/classes/collectd_plugin_processes_spec.rb
+++ b/spec/classes/collectd_plugin_processes_spec.rb
@@ -22,6 +22,7 @@ describe 'collectd::plugin::processes', type: :class do
       end
 
       it 'Will create /etc/collectd.d/conf.d/processes-config.conf' do
+        should contain_concat('/etc/collectd/conf.d/processes-config.conf').that_requires('File[collectd.d]')
         should contain_concat__fragment('collectd_plugin_processes_conf_header').
           with(content: %r{<Plugin processes>},
                target: '/etc/collectd/conf.d/processes-config.conf',

--- a/spec/classes/collectd_plugin_python_spec.rb
+++ b/spec/classes/collectd_plugin_python_spec.rb
@@ -25,6 +25,8 @@ describe 'collectd::plugin::python', type: :class do
       end
 
       it 'Will create /etc/collectd.d/conf.d/python-config.conf' do
+        should contain_concat('/etc/collectd/conf.d/python-config.conf').
+          that_requires('File[collectd.d]')
         should contain_concat__fragment('collectd_plugin_python_conf_header').
           with(content: %r{<Plugin "python">},
                target: '/etc/collectd/conf.d/python-config.conf',

--- a/spec/classes/collectd_plugin_write_graphite_spec.rb
+++ b/spec/classes/collectd_plugin_write_graphite_spec.rb
@@ -20,6 +20,8 @@ describe 'collectd::plugin::write_graphite', type: :class do
     end
 
     it 'Will create /etc/collectd.d/conf.d/write_graphite-config.conf' do
+      should contain_concat('/etc/collectd/conf.d/write_graphite-config.conf').
+        that_requires('File[collectd.d]')
       should contain_concat__fragment('collectd_plugin_write_graphite_conf_header').
         with(content: %r{<Plugin write_graphite>},
              target: '/etc/collectd/conf.d/write_graphite-config.conf',

--- a/spec/defines/collectd_plugin_filter_chain_spec.rb
+++ b/spec/defines/collectd_plugin_filter_chain_spec.rb
@@ -15,7 +15,8 @@ describe 'collectd::plugin::filter::chain', type: :define do
   context ':ensure => present and default parameters' do
     let(:title) { 'MyChain' }
     it 'Will create /etc/collectd/conf.d/filter-chain-MyChain.conf' do
-      should contain_concat('/etc/collectd/conf.d/filter-chain-MyChain.conf').with(ensure: 'present')
+      should contain_concat('/etc/collectd/conf.d/filter-chain-MyChain.conf').with(ensure: 'present').
+        that_requires('File[collectd.d]')
       should contain_concat__fragment('/etc/collectd/conf.d/filter-chain-MyChain.conf_MyChain_head').with(
         order: '00',
         content: '<Chain "MyChain">',


### PR DESCRIPTION
`Concat` types create a lockfile in the directory where the file will end up. Sometimes the `concat` will run before the `File['/etc/collectd.d']` resource. I added ordering to ensure that all `concat`s will occur after the folder is created.

Here is an example of the error:
```
$ puppet agent -t
...
Error: Could not set 'file' on ensure: No such file or directory - /etc/collectd.d/processes-config.conf20160706-24270-1k3tm2o.lock
Error: Could not set 'file' on ensure: No such file or directory - /etc/collectd.d/processes-config.conf20160706-24270-1k3tm2o.lock
Wrapped exception:
No such file or directory - /etc/collectd.d/processes-config.conf20160706-24270-1k3tm2o.lock
Error: /Stage[main]/Collectd::Plugin::Processes/Concat[/etc/collectd.d/processes-config.conf]/File[/etc/collectd.d/processes-config.conf]/ensure: change from absent to file failed: Could not set 'file' on ensure: No such file or directory - /etc/collectd.d/processes-config.conf20160706-24270-1k3tm2o.lock
Error: Could not set 'file' on ensure: No such file or directory - /etc/collectd.d/exec-config.conf20160706-24270-fs9zuq.lock
Error: Could not set 'file' on ensure: No such file or directory - /etc/collectd.d/exec-config.conf20160706-24270-fs9zuq.lock
Wrapped exception:
No such file or directory - /etc/collectd.d/exec-config.conf20160706-24270-fs9zuq.lock
Error: /Stage[main]/Collectd::Plugin::Exec/Concat[/etc/collectd.d/exec-config.conf]/File[/etc/collectd.d/exec-config.conf]/ensure: change from absent to file failed: Could not set 'file' on ensure: No such file or directory - /etc/collectd.d/exec-config.conf20160706-24270-fs9zuq.lock
Error: Could not set 'file' on ensure: No such file or directory - /etc/collectd.d/write_graphite-config.conf20160706-24270-xdrenq.lock
Error: Could not set 'file' on ensure: No such file or directory - /etc/collectd.d/write_graphite-config.conf20160706-24270-xdrenq.lock
Wrapped exception:
No such file or directory - /etc/collectd.d/write_graphite-config.conf20160706-24270-xdrenq.lock
Error: /Stage[main]/Collectd::Plugin::Write_graphite/Concat[/etc/collectd.d/write_graphite-config.conf]/File[/etc/collectd.d/write_graphite-config.conf]/ensure: change from absent to file failed: Could not set 'file' on ensure: No such file or directory - /etc/collectd.d/write_graphite-config.conf20160706-24270-xdrenq.lock
...
Notice: /Stage[main]/Collectd::Config/File[collectd.d]/mode: mode changed '0755' to '0750'
...
Notice: Finished catalog run in 40.15 seconds
```

I also added tests for all the plugins that use `concat`.