### PR TITLE
remove write_graphite-config.conf on absent (fixes #533)

### DIFF
--- a/manifests/plugin/write_graphite.pp
+++ b/manifests/plugin/write_graphite.pp
@@ -20,25 +20,35 @@ class collectd::plugin::write_graphite (
   # should be loaded after global plugin configuration
   $graphite_conf = "${collectd::plugin_conf_dir}/write_graphite-config.conf"
 
-  concat { $graphite_conf:
-    mode           => '0640',
-    owner          => 'root',
-    group          => $collectd::root_group,
-    notify         => Service['collectd'],
-    ensure_newline => true,
-  }
+  case $ensure {
+    'present': {
+      concat { $graphite_conf:
+        mode           => '0640',
+        owner          => 'root',
+        group          => $collectd::root_group,
+        notify         => Service['collectd'],
+        ensure_newline => true,
+      }
 
-  concat::fragment { 'collectd_plugin_write_graphite_conf_header':
-    order   => '00',
-    content => '<Plugin write_graphite>',
-    target  => $graphite_conf,
-  }
+      concat::fragment { 'collectd_plugin_write_graphite_conf_header':
+        order   => '00',
+        content => '<Plugin write_graphite>',
+        target  => $graphite_conf,
+      }
 
-  concat::fragment { 'collectd_plugin_write_graphite_conf_footer':
-    order   => '99',
-    content => '</Plugin>',
-    target  => $graphite_conf,
-  }
+      concat::fragment { 'collectd_plugin_write_graphite_conf_footer':
+        order   => '99',
+        content => '</Plugin>',
+        target  => $graphite_conf,
+      }
 
-  create_resources(collectd::plugin::write_graphite::carbon, $carbons, $carbon_defaults)
+      create_resources(collectd::plugin::write_graphite::carbon, $carbons, $carbon_defaults)
+    }
+    'absent': {
+      file { $graphite_conf:
+        ensure => absent,
+      }
+    }
+    default: { fail('ensure must be \'absent\' or \'present\'') }
+  }
 }

--- a/spec/classes/collectd_plugin_write_graphite_spec.rb
+++ b/spec/classes/collectd_plugin_write_graphite_spec.rb
@@ -102,4 +102,26 @@ describe 'collectd::plugin::write_graphite', type: :class do
              target: '/etc/collectd/conf.d/write_graphite-config.conf')
     end
   end
+
+  context 'ensure is absent' do
+    let :params do
+      {
+        ensure: 'absent'
+      }
+    end
+
+    it 'Will not create /etc/collectd.d/conf.d/write_graphite-config.conf' do
+      should_not contain_concat__fragment('collectd_plugin_write_graphite_conf_header').
+        with(content: %r{<Plugin write_graphite>},
+             target: '/etc/collectd/conf.d/write_graphite-config.conf',
+             order: '00')
+    end
+
+    it 'Will not create /etc/collectd.d/conf.d/write_graphite-config' do
+      should_not contain_concat__fragment('collectd_plugin_write_graphite_conf_footer').
+        with(content: %r{</Plugin>},
+             target: '/etc/collectd/conf.d/write_graphite-config.conf',
+             order: '99')
+    end
+  end
 end


### PR DESCRIPTION
Ensures that `/etc/collectd/conf.d/write_graphite-config.conf` can be set to `absent` without failing on a puppet run.

This is neccessary for encrypted communication to the graphite server.

See #533 