### PR TITLE
plugin/write_kafka.pp:

### DIFF
--- a/manifests/plugin/write_kafka.pp
+++ b/manifests/plugin/write_kafka.pp
@@ -12,11 +12,10 @@ class collectd::plugin::write_kafka (
   validate_hash($topics)
   validate_array($kafka_hosts)
 
-  if ($kafka_host or $kafka_hosts) {
-    if($kafka_host) {
-      $real_kafka_host = [ "${kafka_host}:${kafka_port}" ]
-    }
-    $real_kafka_hosts = concat($kafka_hosts, $real_kafka_host)
+  if($kafka_host) {
+    $real_kafka_hosts = [ "${kafka_host}:${kafka_port}" ]
+  } else {
+    $real_kafka_hosts = $kafka_hosts
   }
   $kafka_broker = join($real_kafka_hosts, ',')
 

--- a/manifests/plugin/write_kafka.pp
+++ b/manifests/plugin/write_kafka.pp
@@ -12,7 +12,7 @@ class collectd::plugin::write_kafka (
   validate_hash($topics)
   validate_array($kafka_hosts)
 
-  if($kafka_host && $kafka_port) {
+  if($kafka_host and $kafka_port) {
     $real_kafka_hosts = [ "${kafka_host}:${kafka_port}" ]
   } else {
     $real_kafka_hosts = $kafka_hosts

--- a/manifests/plugin/write_kafka.pp
+++ b/manifests/plugin/write_kafka.pp
@@ -1,7 +1,7 @@
 class collectd::plugin::write_kafka (
   $ensure     = 'present',
   $kafka_host = undef,
-  $kafka_hosts = ['localhost'],
+  $kafka_hosts = ['localhost:9092'],
   $kafka_port = 9092,
   $topics     = {},
   $interval   = undef,
@@ -12,7 +12,7 @@ class collectd::plugin::write_kafka (
   validate_hash($topics)
   validate_array($kafka_hosts)
 
-  if($kafka_host) {
+  if($kafka_host && $kafka_port) {
     $real_kafka_hosts = [ "${kafka_host}:${kafka_port}" ]
   } else {
     $real_kafka_hosts = $kafka_hosts

--- a/manifests/plugin/write_kafka.pp
+++ b/manifests/plugin/write_kafka.pp
@@ -1,6 +1,7 @@
 class collectd::plugin::write_kafka (
   $ensure     = 'present',
-  $kafka_host = 'localhost',
+  $kafka_host = undef,
+  $kafka_hosts = ['localhost'],
   $kafka_port = 9092,
   $topics     = {},
   $interval   = undef,
@@ -9,8 +10,15 @@ class collectd::plugin::write_kafka (
   include ::collectd
 
   validate_hash($topics)
+  validate_array($kafka_hosts)
 
-  $kafka_broker = "${kafka_host}:${kafka_port}"
+  if ($kafka_host or $kafka_hosts) {
+    if($kafka_host) {
+      $real_kafka_host = [ "${kafka_host}:${kafka_port}" ]
+    }
+    $real_kafka_hosts = concat($kafka_hosts, $real_kafka_host)
+  }
+  $kafka_broker = join($real_kafka_hosts, ',')
 
   collectd::plugin { 'write_kafka':
     ensure   => $ensure,


### PR DESCRIPTION
This should fix #539

added kafka_hosts param which allows usage of hosts-array
kafka_host is still valid and will be merged correctly
default (if nothing else given) will still be localhost