### PR TITLE
Add support for ReportNumCpu in CPU plugin introduced in collectd 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ class { 'collectd::plugin::conntrack':
 * `reportbystate` available from collectd version >= 5.5
 * `reportbycpu` available from collectd version >= 5.5
 * `valuespercentage` available from collectd version >= 5.5
+* `reportnumcpu` available from collectd version >= 5.6
 
  See [collectd plugin_cpu documentation](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_cpu)
  for more details.

--- a/manifests/plugin/cpu.pp
+++ b/manifests/plugin/cpu.pp
@@ -4,6 +4,7 @@ class collectd::plugin::cpu (
   $reportbystate    = true,
   $reportbycpu      = true,
   $valuespercentage = false,
+  $reportnumcpu     = false,
   $interval         = undef,
 ) {
 
@@ -13,6 +14,7 @@ class collectd::plugin::cpu (
     $reportbystate,
     $reportbycpu,
     $valuespercentage,
+    $reportnumcpu,
   )
 
   collectd::plugin { 'cpu':

--- a/spec/classes/collectd_plugin_cpu_spec.rb
+++ b/spec/classes/collectd_plugin_cpu_spec.rb
@@ -58,6 +58,25 @@ describe 'collectd::plugin::cpu', type: :class do
         is_expected.to contain_file('cpu.load').with_content(%r{ValuesPercentage true})
       end
     end
+
+    context 'cpu options should be set with collectd 5.6' do
+      let :facts do
+        {
+          osfamily: 'RedHat',
+          collectd_version: '5.6',
+          operatingsystemmajrelease: '7'
+        }
+      end
+      let :params do
+        {
+          reportnumcpu: true
+        }
+      end
+
+      it 'Will include ValuesPercentage in /etc/collectd.d/10-cpu.conf' do
+        should contain_file('cpu.load').with_content(%r{ReportNumCpu true})
+      end
+    end
   end
 
   context 'default parameters are not booleans' do
@@ -65,7 +84,8 @@ describe 'collectd::plugin::cpu', type: :class do
       {
         reportbystate: 'string_a',
         reportbycpu: 'string_b',
-        valuespercentage: 'string_c'
+        valuespercentage: 'string_c',
+        reportnumcpu: 'string_d'
       }
     end
 

--- a/templates/plugin/cpu.conf.erb
+++ b/templates/plugin/cpu.conf.erb
@@ -3,5 +3,8 @@
   ReportByState <%= @reportbystate %>
   ReportByCpu <%= @reportbycpu %>
   ValuesPercentage <%= @valuespercentage %>
+<% if scope.lookupvar('collectd::collectd_version_real') and scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.6']) >= 0 -%>
+  ReportNumCpu <%= @reportnumcpu %>
+<% end -%>
 </Plugin>
 <% end -%>


### PR DESCRIPTION
As title says, this PR adds support for ReportNumCpu. From collectd site: When set to true, reports the number of available CPUs.
