### PR TITLE
Adds Collectd CI Package repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,28 @@ collectd::plugin { 'battery': }
 where 'battery' is the name of the plugin. Note, this should only be done in the
 case of a class for the plugin not existing in this module.
 
+## Repo management
+
+The module will enable a repo by default.
+
+On CentOS that will be EPEL:
+* http://rpms.famillecollet.com/rpmphp/zoom.php?rpm=collectd
+
+On Ubuntu that'll be the CollectD PPA:
+* https://launchpad.net/~collectd/+archive/ubuntu/collectd-5.5
+
+### CI Packages
+
+Recently, Collectd CI packages are also avaliable from the CI repo
+
+More information is avaliable here:
+* https://github.com/collectd/collectd-ci
+
+You can choose the CI repo with the `$ci_package_repo` parameter.
+
+`$ci_package_repo` has to match '5.4', '5.5', '5.6', '5.7' or 'master' (RC for next release) as
+these are the current branches being built in the Collectd CI.
+
 ## Configurable Plugins
 
 Parameters will vary widely between plugins. See the collectd

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@ class collectd (
   $internal_stats          = $collectd::params::internal_stats,
   $manage_package          = $collectd::params::manage_package,
   $manage_repo             = $collectd::params::manage_repo,
+  $ci_package_repo         = $collectd::params::ci_package_repo,
   $manage_service          = $collectd::params::manage_service,
   $minimum_version         = $collectd::params::minimum_version,
   $package_ensure          = $collectd::params::package_ensure,
@@ -39,12 +40,17 @@ class collectd (
     package_install_options => $package_install_options,
   }
 
+  class { '::collectd::repo': }
+
   class { '::collectd::config': }
 
   class { '::collectd::service': }
 
   anchor { 'collectd::begin': }
   anchor { 'collectd::end': }
+
+  Class['::collectd::repo'] ~>
+  Class['::collectd::install']
 
   Anchor['collectd::begin'] ->
   Class['collectd::install'] ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,32 +9,6 @@ class collectd::install (
     validate_array($package_install_options)
   }
 
-  if $::collectd::manage_repo {
-    if $::osfamily == 'RedHat' {
-      if !defined(Yum::Install['epel-release']) {
-        yum::install { 'epel-release':
-          ensure => 'present',
-          source => "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${::operatingsystemmajrelease}.noarch.rpm",
-        }
-      }
-      Package <| title == $package_name |> {
-        require => Yum::Install['epel-release']
-      }
-    } elsif $::operatingsystemmajrelease =~ /('12.04'|'14.04'|'16.04')/ {
-      apt::source { 'ppa_collectd':
-        location => 'http://ppa.launchpad.net/collectd/collectd-5.5/ubuntu',
-        repos    => 'main',
-        key      => {
-          'id'     => '7543C08D555DC473B9270ACDAF7ECBB3476ACEB3',
-          'server' => 'keyserver.ubuntu.com',
-        },
-      }
-      Package <| title == $package_name |> {
-        require => Apt::Source['ppa_collectd']
-      }
-    }
-  }
-
   if $manage_package {
     package { $package_name:
       ensure          => $package_ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,7 @@ class collectd::params {
   $manage_service            = true
   $package_install_options   = undef
   $plugin_conf_dir_mode      = '0750'
+  $ci_package_repo           = undef
 
   case getvar('::kernel') {
     'OpenBSD': { $has_wordexp   = false }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,0 +1,20 @@
+# collectd::repo
+# Handle package repo configuration
+class collectd::repo {
+
+  if $collectd::manage_repo {
+    if $::collectd::ci_package_repo != undef {
+      validate_re($::collectd::ci_package_repo, [ '^5.4', '^5.5', '^5.6', '5.7', '^master' ], "ci_package_repo has to match '5.4', '5.5', '5.6', '5.7' or 'master' (RC for next release), got: ${::collectd::ci_package_repo}")
+    }
+
+    $osfamily_downcase = downcase($::osfamily)
+
+    if defined("::collectd::repo::${osfamily_downcase}") {
+      include "::collectd::repo::${osfamily_downcase}"
+    } else {
+      notify{"You have asked to manage_repo on a system that doesn't have a repo class specified: ${::osfamily}":}
+    }
+  }
+
+}
+

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,0 +1,31 @@
+class collectd::repo::debian {
+
+  contain ::apt
+
+  if $::collectd::ci_package_repo {
+
+    apt::source { 'collectd-ci':
+      location => 'https://pkg.ci.collectd.org/deb/',
+      repos    => "collectd-${$::collectd::ci_package_repo}",
+      key      => {
+        'id'     => 'F806817DC3F5EA417F9FA2963994D24FB8543576',
+        'server' => 'pgp.mit.edu',
+      },
+    }
+  } else {
+    if $::operatingsystem == 'Debian' {
+      warning('Youre trying to use the Ubuntu PPA on a Debian Server, which may cause errors')
+      warning('We recomend you use the $ci_package_repo parameter if you with to use an upstream repo on Debian')
+    } else {
+      apt::source { 'ppa_collectd':
+        location => 'http://ppa.launchpad.net/collectd/collectd-5.5/ubuntu',
+        repos    => 'main',
+        key      => {
+          'id'     => '7543C08D555DC473B9270ACDAF7ECBB3476ACEB3',
+          'server' => 'keyserver.ubuntu.com',
+        },
+      }
+    }
+  }
+
+}

--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -1,0 +1,27 @@
+class collectd::repo::redhat {
+
+  if $::collectd::ci_package_repo {
+
+    yumrepo { 'collectd-ci':
+      ensure  => present,
+      enabled => '1',
+      baseurl => "https://pkg.ci.collectd.org/rpm/collectd-${::collectd::ci_package_repo}/epel-${::operatingsystemmajrelease}-${::architecture}",
+      gpgkey  => 'https://pkg.ci.collectd.org/pubkey.asc',
+    }
+
+  } else {
+
+    # TODO: Replace this with EPEL module requirement in Major version bump
+
+    if !defined(Yum::Install['epel-release']) {
+      yum::install { 'epel-release':
+        ensure => 'present',
+        source => "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${::operatingsystemmajrelease}.noarch.rpm",
+        before => Package[$::collectd::package_name],
+      }
+    }
+
+
+  }
+
+}

--- a/spec/classes/collectd_init_spec.rb
+++ b/spec/classes/collectd_init_spec.rb
@@ -188,9 +188,34 @@ describe 'collectd', type: :class do
         end
 
         context 'when manage_repo is true' do
-          let(:params) { { manage_repo: true } }
-          if facts[:osfamily] == 'RedHat'
-            it { is_expected.to contain_yum__install('epel-release') }
+          context 'and ci_package_repo empty' do
+            let(:params) { { manage_repo: true } }
+            if facts[:osfamily] == 'RedHat'
+              it { is_expected.to contain_yum__install('epel-release') }
+            end
+          end
+
+          context 'and ci_package_repo set to a version' do
+            let(:params) do
+              {
+                manage_repo: true,
+                ci_package_repo: '5.6'
+              }
+            end
+            if facts[:osfamily] == 'RedHat'
+              it { is_expected.to contain_yumrepo('collectd-ci').with_gpgkey('https://pkg.ci.collectd.org/pubkey.asc').with_baseurl("https://pkg.ci.collectd.org/rpm/collectd-5.6/epel-#{facts[:operatingsystemmajrelease]}-x86_64") }
+            end
+            if facts[:osfamily] == 'Debian'
+              it do
+                is_expected.to contain_apt__source('collectd-ci').
+                  with_location('https://pkg.ci.collectd.org/deb/').
+                  with_key(
+                    'id'     => 'F806817DC3F5EA417F9FA2963994D24FB8543576',
+                    'server' => 'pgp.mit.edu'
+                  ).
+                  with_repos('collectd-5.6')
+              end
+            end
           end
         end
 

--- a/spec/default_module_facts.yml
+++ b/spec/default_module_facts.yml
@@ -1,3 +1,6 @@
 ---
 collectd_version: '5.5.0'
 python_dir: '/usr/local/lib/python2.7/dist-packages'
+operatingsystem: 'Debian'
+lsbdistid: 'Debian'
+lsbdistcodename: 'wheezy'


### PR DESCRIPTION
* Allows installation of 5.6 version of Collectd or master release (potential 5.7)
* Refactor repo management behaviour into it's own classes
* Add parameter to specify version from bleeding edge repos from CI

Closes https://github.com/voxpupuli/puppet-collectd/issues/578