### PR TITLE
Fallback to empty string if Python is not installed

### DIFF
--- a/lib/facter/python_dir.rb
+++ b/lib/facter/python_dir.rb
@@ -1,5 +1,13 @@
+# Fact: python_dir
+#
+# Purpose: Retrieve python package dir used by pip install
+#
 Facter.add(:python_dir) do
   setcode do
-    Facter::Util::Resolution.exec('python -c "import site; print(site.getsitepackages()[0])"')
+    if Facter::Util::Resolution.which('python')
+      Facter::Util::Resolution.exec('python -c "import site; print(site.getsitepackages()[0])"')
+    else
+      ''
+    end
   end
 end

--- a/spec/unit/python_dir_spec.rb
+++ b/spec/unit/python_dir_spec.rb
@@ -14,4 +14,9 @@ describe 'python_dir', type: :fact do
       end
     end
   end
+
+  it 'is empty string if python not installed' do
+    Facter::Util::Resolution.stubs(:which).with('python').returns(nil)
+    expect(Facter.fact(:python_dir).value).to eq('')
+  end
 end


### PR DESCRIPTION
Avoids issue with variable undefined. Previous behavior resolved to 'nil', causing;

    Error: Evaluation Error: Unknown variable: '::python_dir'.