### PR TITLE
Add rabbitmq types to collectd types database on install

### DIFF
--- a/manifests/plugin/rabbitmq.pp
+++ b/manifests/plugin/rabbitmq.pp
@@ -97,6 +97,15 @@ class collectd::plugin::rabbitmq (
     install_options => $install_options,
   }
 
+  $rt = '/usr/local/share/collectd-rabbitmq/types.db.custom' # RabbitMQ addon types file
+  $ct = '/usr/share/collectd/types.db'                       # CollectD types file
+
+  exec { 'update_typesdb':
+    command => "/bin/cat ${rt} >> ${ct}",
+    unless  => "[ `cat ${ct} | sort -u | wc -l` -eq `cat ${rt} ${ct} | sort -u | wc -l` ] || exit 1",
+    path    => ['/usr/bin', '/bin'],
+  }
+
   collectd::plugin::python::module { 'collectd_rabbitmq.collectd_plugin':
     ensure => $ensure,
     config => $config,

--- a/manifests/plugin/rabbitmq.pp
+++ b/manifests/plugin/rabbitmq.pp
@@ -101,9 +101,10 @@ class collectd::plugin::rabbitmq (
   $ct = '/usr/share/collectd/types.db'                       # CollectD types file
 
   exec { 'update_typesdb':
-    command => "/bin/cat ${rt} >> ${ct}",
-    unless  => "true && case $(cat ${ct}) in *$(cat ${rt})*) exit 0;; *) exit 1;; esac",
-    path    => ['/usr/bin', '/bin'],
+    command  => "/bin/cat ${rt} >> ${ct}",
+    unless   => "case $(cat ${ct}) in *$(cat ${rt})*) exit 0;; *) exit 1;; esac",
+    path     => ['/usr/bin', '/bin'],
+    provider => 'shell',
   }
 
   collectd::plugin::python::module { 'collectd_rabbitmq.collectd_plugin':

--- a/manifests/plugin/rabbitmq.pp
+++ b/manifests/plugin/rabbitmq.pp
@@ -102,7 +102,7 @@ class collectd::plugin::rabbitmq (
 
   exec { 'update_typesdb':
     command => "/bin/cat ${rt} >> ${ct}",
-    unless  => "[ `cat ${ct} | sort -u | wc -l` -eq `cat ${rt} ${ct} | sort -u | wc -l` ] || exit 1",
+    unless  => "true && case $(cat ${ct}) in *$(cat ${rt})*) exit 0;; *) exit 1;; esac",
     path    => ['/usr/bin', '/bin'],
   }
 

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -36,5 +36,10 @@ describe 'collectd class' do
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end
+
+    describe file('/usr/share/collectd/types.db') do
+      it { is_expected.to be_file }
+      it { is_expected.to contain 'rabbitmq_memory' }
+    end
   end
 end


### PR DESCRIPTION
Rabbitmq plugin use custom types that needs to be added to CollectD types database for collection to work
