### PR TITLE
Fixes #549: Unable to define a multi-value type

### DIFF
--- a/spec/defines/collectd_type_spec.rb
+++ b/spec/defines/collectd_type_spec.rb
@@ -29,4 +29,32 @@ describe 'collectd::type', type: :define do
                                                                                    content: "index\tsome_name:ABSOLUTE:4:5")
     end
   end
+
+  context 'define a multiple type' do
+    let(:title) { 'index' }
+    let :params do
+      {
+        target: '/etc/collectd/types.db',
+        types: [
+          {
+            'ds_type' => 'ABSOLUTE',
+            'min' => 4,
+            'max' => 5,
+            'ds_name' => 'some_name'
+          },
+          {
+            'ds_type' => 'COUNTER',
+            'min' => 7,
+            'max' => 'U',
+            'ds_name' => 'other_name'
+          }
+        ]
+      }
+    end
+
+    it 'creates an entry' do
+      is_expected.to contain_concat__fragment('/etc/collectd/types.db/index').with(target: '/etc/collectd/types.db',
+                                                                                   content: "index\tsome_name:ABSOLUTE:4:5, other_name:COUNTER:7:U")
+    end
+  end
 end


### PR DESCRIPTION
Hi,

this pr implement #549 in a **dirty** way. It should be refactor if puppet 3 is dropped. (https://github.com/voxpupuli/plumbing/issues/21 hopefully gets voted in the near feature... )

If you reject this because inline_template is not the state of the art I rewrite it to own defines for every type definition.