### PR TITLE
Fix documentation for aggregation type parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,7 @@ documentation for each plugin for configurable attributes.
 collectd::plugin::aggregation::aggregator {
   cpu':
     plugin           => 'cpu',
-    
-    => 'cpu',
+    agg_type         => 'cpu',
     groupby          => ["Host", "TypeInstance",],
     calculateaverage => true,
 }

--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ documentation for each plugin for configurable attributes.
 collectd::plugin::aggregation::aggregator {
   cpu':
     plugin           => 'cpu',
-    type             => 'cpu',
+    
+    => 'cpu',
     groupby          => ["Host", "TypeInstance",],
     calculateaverage => true,
 }
@@ -214,7 +215,7 @@ class { 'collectd::plugin::aggregation':
   aggregators => {
     cpu' => {
       plugin           => 'cpu',
-      type             => 'cpu',
+      agg_type         => 'cpu',
       groupby          => ["Host", "TypeInstance",],
       calculateaverage => true,
     },


### PR DESCRIPTION
Commit c0faa91ffdd7ffdd6d0bc815e001fddb340dd21e has renamed `type` => `agg_type`. Fixing README.md