### PR TITLE
Fix python_dir fact for RedHat.

### DIFF
--- a/lib/facter/python_dir.rb
+++ b/lib/facter/python_dir.rb
@@ -5,7 +5,7 @@
 Facter.add(:python_dir) do
   setcode do
     if Facter::Util::Resolution.which('python')
-      if Facter.fact(:osfamily) == 'RedHat'
+      if Facter.value(:osfamily) == 'RedHat'
         Facter::Util::Resolution.exec('python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"')
       else
         Facter::Util::Resolution.exec('python -c "import site; print(site.getsitepackages()[0])"')

--- a/spec/unit/python_dir_spec.rb
+++ b/spec/unit/python_dir_spec.rb
@@ -13,6 +13,17 @@ describe 'python_dir', type: :fact do
         expect(Facter.value(:python_dir)).to eq('/usr/local/lib/python2.7/dist-packages')
       end
     end
+
+    context 'RedHat' do
+      before do
+        Facter.fact(:osfamily).stubs(:value).returns('RedHat')
+        Facter::Util::Resolution.stubs(:which).with('python').returns(true)
+        Facter::Util::Resolution.stubs(:exec).with('python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"').returns('/usr/lib/python2.7/site-packages')
+      end
+      it do
+        expect(Facter.value(:python_dir)).to eq('/usr/lib/python2.7/site-packages')
+      end
+    end
   end
 
   it 'is empty string if python not installed' do


### PR DESCRIPTION
Use the correct method (value) for retrieving osfamily fact.
Add test for RedHat to confirm conditional is working correctly.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.

-->
