### PR TITLE
Bump puppet minimum version_requirement to 3.8.7

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -78,12 +78,8 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">= 3.2.0"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">= 3.2.0"
+      "version_requirement": ">= 3.8.7 < 5.0.0"
     }
   ],
   "name": "puppet-collectd",


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet 3 versions

Also drop deprecated pe version_requirement field