### PR TITLE
Bump minimum version dependencies (for Puppet 4)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -98,11 +98,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.2.0"
+      "version_requirement": ">= 4.6.0"
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.0.4"
+      "version_requirement": ">= 1.2.5"
     },
     {
       "name": "puppet-yum",


### PR DESCRIPTION
Bump dependencies to the minimum version that should work under
Puppet 4, based on the metadata