### PR TITLE
BREAKING: Fix and simplify write_network plugin definition

### DIFF
--- a/manifests/plugin/write_network.pp
+++ b/manifests/plugin/write_network.pp
@@ -1,23 +1,22 @@
 # A define to make a generic network output for collectd
 class collectd::plugin::write_network (
   $ensure  = 'present',
-  $servers = { 'localhost'  =>  { 'serverport' => '25826' } },
+  $server = 'localhost',
+  $port = '25826',
 ) {
 
   include ::collectd
 
-  validate_hash($servers)
+  validate_string($server)
+  validate_re($port, '^\d{1,5}$')
 
-  $servernames = keys($servers)
-  if empty($servernames) {
-    fail('servers cannot be empty')
+  if empty($server) {
+    fail('server cannot be empty')
   }
 
-  $servername = $servernames[0]
-  $serverport = $servers[$servername]['serverport']
-
-  class { '::collectd::plugin::network':
-    server     => $servername,
-    serverport => $serverport,
+  ::collectd::plugin::network::server {$server :
+    ensure => $ensure,
+    port   => $port,
   }
+
 }


### PR DESCRIPTION
The plugin expects a hash to be passed, yet, only the first element is being used.

Means that a lot of redundancy can be removed.

Also fixed an issue with passing the wrong value to ::collectd::plugin::network which expects servers instead of server.

Signed-off-by: Christophe Vanlancker <christophe.vanlancker@inuits.eu>