### PR TITLE
Add CounterSum support to statsd config

### DIFF
--- a/manifests/plugin/statsd.pp
+++ b/manifests/plugin/statsd.pp
@@ -7,6 +7,7 @@ class collectd::plugin::statsd (
   $deletetimers    = undef,
   $deletegauges    = undef,
   $deletesets      = undef,
+  $countersum      = undef,
   $interval        = undef,
   $timerpercentile = undef,
   $timerlower      = undef,

--- a/spec/classes/collectd_plugin_statsd_spec.rb
+++ b/spec/classes/collectd_plugin_statsd_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::statsd', type: :class do
+  let :facts do
+    {
+      osfamily: 'RedHat',
+      collectd_version: '4.8.0',
+      operatingsystemmajrelease: '7',
+      python_dir: '/usr/local/lib/python2.7/dist-packages'
+    }
+  end
+
+  let :pre_condition do
+    'include ::collectd'
+  end
+
+  context ':ensure => present' do
+    context ':ensure => present and default parameters' do
+      it 'Will create /etc/collectd.d/10-statsd.conf' do
+        is_expected.to contain_file('statsd.load').with(ensure: 'present',
+                                                        path: '/etc/collectd.d/10-statsd.conf',
+                                                        content: %r{<Plugin statsd>\n</Plugin>})
+      end
+    end
+
+    context ':ensure => present and hostname and port' do
+      let :params do
+        {
+          ensure: 'present',
+          host: '192.0.0.1',
+          port: '9876'
+        }
+      end
+      it 'Will create /etc/collectd.d/10-statsd.conf' do
+        is_expected.to contain_file('statsd.load').with(ensure: 'present',
+                                                        path: '/etc/collectd.d/10-statsd.conf',
+                                                        content: %r{Host "192.0.0.1".+Port 9876}m)
+      end
+    end
+
+    context ':ensure => present and countersum' do
+      let :params do
+        {
+          ensure: 'present',
+          countersum: true
+        }
+      end
+      it 'Will create /etc/collectd.d/10-statsd.conf' do
+        is_expected.to contain_file('statsd.load').with(ensure: 'present',
+                                                        path: '/etc/collectd.d/10-statsd.conf',
+                                                        content: %r{CounterSum true}m)
+      end
+    end
+  end
+
+  context ':ensure => absent' do
+    let :params do
+      {
+        ensure: 'absent'
+      }
+    end
+    it 'Will not create /etc/collectd.d/10-statsd.conf' do
+      is_expected.to contain_file('statsd.load').with(ensure: 'absent',
+                                                      path: '/etc/collectd.d/10-statsd.conf')
+    end
+  end
+end

--- a/templates/plugin/statsd.conf.erb
+++ b/templates/plugin/statsd.conf.erb
@@ -17,6 +17,9 @@
 <% unless @deletesets.nil? -%>
   Deletesets <%= @deletesets %>
 <% end -%>
+<% unless @countersum.nil? -%>
+  CounterSum <%= @countersum %>
+<% end -%>
 <% @timerpercentile_real.each do |percentile| -%>
   TimerPercentile <%= percentile %>
 <% end -%>


### PR DESCRIPTION
Collectd has add a 'CounterSum' configration which is not currently supported by
puppetd-collected. More information on:

* Current config options: https://github.com/collectd/collectd/blob/master/src/collectd.conf.pod#plugin-statsd
* PR introducing CounterSum: https://github.com/collectd/collectd/pull/1363
* Commit adding CounterSum: https://github.com/octo/collectd/commit/eaf8c7a28723dc81fc035e3a15a0ca1dbb46090c

This PR adds support for CounterSum and a basic spec for statsd, which was
previously missing.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
