### PR TITLE
Support older version of libyajl on Ubuntu 12.04 (precise)

### DIFF
--- a/manifests/plugin/curl_json.pp
+++ b/manifests/plugin/curl_json.pp
@@ -23,7 +23,11 @@ define collectd::plugin::curl_json (
 
   if $_manage_package {
     if $::osfamily == 'Debian' {
-      ensure_packages('libyajl2')
+      $libyajl_package = $::lsbdistcodename ? {
+        'precise' => 'libyajl1',
+        default   => 'libyajl2'
+      }
+      ensure_packages($libyajl_package)
     }
 
     if $::osfamily == 'Redhat' {


### PR DESCRIPTION
Hello all !

This is my first PR, so please advice if there's something missing.

I've run with an issue trying to configure curl_json plugin on an old Ubuntu 12.04 server. It was unable to find libyajl package because it was looking for version 2

`Error: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install libyajl2' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package libyajl2
`

and I only have version 1 of this library

`libyajl1 - Yet Another JSON Library
`

So I've made an exception for this distribution.
Every comment, suggestion, etc is welcome.

Cheers,

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
