### PR TITLE
pin puppet-yum to < 1.0.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,5 +9,6 @@ fixtures:
       ref: '2.1.0'
     yum:
       repo: 'https://github.com/voxpupuli/puppet-yum.git'
+      ref: 'v0.10.0'
   symlinks:
     'collectd': "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -106,7 +106,7 @@
     },
     {
       "name": "puppet-yum",
-      "version_requirement": ">= 0.9.15"
+      "version_requirement": ">= 0.9.15 < 1.0.0"
     },
     {
       "name": "puppetlabs-apt",


### PR DESCRIPTION
this version is puppet 4 only and doesn't work with this module since it
still supports Puppet 3. Also updated the .fixture.yml to get the
correct version for rspec tests

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
