### PR TITLE
Stop specifying $name as the default host value

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -302,7 +302,7 @@ Style/EmptyLiteral:
 Metrics/LineLength:
   Enabled: False
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Enabled: True
 
 Style/MethodDefParentheses:

--- a/manifests/plugin/genericjmx/connection.pp
+++ b/manifests/plugin/genericjmx/connection.pp
@@ -2,7 +2,7 @@
 define collectd::plugin::genericjmx::connection (
   $collect,
   $service_url,
-  $host            = $name,
+  $host            = undef,
   $user            = undef,
   $password        = undef,
   $instance_prefix = undef,

--- a/spec/defines/collectd_plugin_genericjmx_connection_spec.rb
+++ b/spec/defines/collectd_plugin_genericjmx_connection_spec.rb
@@ -35,7 +35,6 @@ describe 'collectd::plugin::genericjmx::connection', type: :define do
     end
 
     it { is_expected.to contain_concat__fragment(concat_fragment_name).with_content(%r{<Connection>.*</Connection>}m) }
-    it { is_expected.to contain_concat__fragment(concat_fragment_name).with_content(%r{Host "foo\.example\.com"}) }
     it { is_expected.to contain_concat__fragment(concat_fragment_name).with_content(%r{ServiceURL "foo:bar:baz"}) }
     it { is_expected.to contain_concat__fragment(concat_fragment_name).without_content(%r{User}) }
     it { is_expected.to contain_concat__fragment(concat_fragment_name).without_content(%r{Password}) }

--- a/templates/plugin/genericjmx/connection.conf.erb
+++ b/templates/plugin/genericjmx/connection.conf.erb
@@ -1,5 +1,7 @@
 <Connection>
+  <% if @host -%>
   Host "<%= @host %>"
+  <% end -%>
   ServiceURL "<%= @service_url %>"
   <% Array(@collect).each do |collect| -%>
   Collect "<%= collect %>"


### PR DESCRIPTION
This should not be the default, it doesn't make sense for localhost
bound JMX connections.