### PR TITLE
Parametrize destination of python config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1317,6 +1317,8 @@ class { 'collectd::plugin::protocols':
   that reads from and writes to the terminal (default: `false`)
 * `logtraces` if a Python script throws an exception it will be logged by
   collectd with the name of the exception and the message (default: `false`)
+* `conf_name` name of the file that will contain the python module configuration
+  (default: `python-config.conf`)
 
  See [collectd-python documentation](https://collectd.org/documentation/manpages/collectd-python.5.shtml)
  for more details.

--- a/manifests/plugin/python.pp
+++ b/manifests/plugin/python.pp
@@ -13,6 +13,7 @@ class collectd::plugin::python (
   $modulepaths    = [],
   $modules        = {},
   $order          = '10',
+  $conf_name      = 'python-config.conf',
 ) {
 
   include ::collectd
@@ -70,7 +71,7 @@ class collectd::plugin::python (
   )
 
   # should be loaded after global plugin configuration
-  $python_conf = "${collectd::plugin_conf_dir}/python-config.conf"
+  $python_conf = "${collectd::plugin_conf_dir}/${conf_name}"
 
   concat { $python_conf:
     ensure         => $ensure,

--- a/spec/classes/collectd_plugin_python_spec.rb
+++ b/spec/classes/collectd_plugin_python_spec.rb
@@ -169,6 +169,23 @@ describe 'collectd::plugin::python', type: :class do
                path: '/var/lib/collectd/python/elasticsearch.py')
       end
     end
+
+    context ':ensure => present and custom python config location' do
+      let :params do
+        {
+          conf_name: 'custom-location-config.conf'
+        }
+      end
+
+      it 'Will create /etc/collectd.d/conf.d/custom-location-config.conf' do
+        is_expected.to contain_concat('/etc/collectd/conf.d/custom-location-config.conf').
+          that_requires('File[collectd.d]')
+        is_expected.to contain_concat__fragment('collectd_plugin_python_conf_header').
+          with(content: %r{<Plugin "python">},
+               target: '/etc/collectd/conf.d/custom-location-config.conf',
+               order: '00')
+      end
+    end
   end
 
   context 'change globals parameter' do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->

It would very helpful for us to have a custom parameter to put a custom location of the python module configuration.