### PR TITLE
Remove quotes from boolean options

### DIFF
--- a/templates/plugin/network.conf.erb
+++ b/templates/plugin/network.conf.erb
@@ -6,10 +6,10 @@
     MaxPacketSize <%= @maxpacketsize %>
 <% end -%>
 <% unless @forward.nil? -%>
-    Forward "<%= @forward %>"
+    Forward <%= @forward %>
 <% end -%>
 <% unless @reportstats.nil? -%>
-    ReportStats "<%= @reportstats %>"
+    ReportStats <%= @reportstats %>
 <% end -%>
   
 </Plugin>

--- a/templates/plugin/openldap.conf.erb
+++ b/templates/plugin/openldap.conf.erb
@@ -6,7 +6,7 @@
     StartTLS <%= values['starttls'] %>
 <% end -%>
 <% unless values['verifyhost'].nil? -%>
-    VerifyHost "<%= values['verifyhost'] %>"
+    VerifyHost <%= values['verifyhost'] %>
 <% end -%>
 <% if values['cacert'] -%>
     CACert "<%= values['cacert'] %>"

--- a/templates/plugin/sensors.conf.erb
+++ b/templates/plugin/sensors.conf.erb
@@ -8,6 +8,6 @@
 <% end -%>
 <% end -%>
 <% unless @ignoreselected.nil? -%>
-  IgnoreSelected "<%= @ignoreselected %>"
+  IgnoreSelected <%= @ignoreselected %>
 <% end -%>
 </Plugin>

--- a/templates/plugin/write_http.conf.erb
+++ b/templates/plugin/write_http.conf.erb
@@ -8,10 +8,10 @@
     Password "<%= values['password'] %>"
 <% end -%>
 <% unless values['verifypeer'].nil? -%>
-    VerifyPeer "<%= values['verifypeer'] %>"
+    VerifyPeer <%= values['verifypeer'] %>
 <% end -%>
 <% unless values['verifyhost'].nil? -%>
-    VerifyHost "<%= values['verifyhost'] %>"
+    VerifyHost <%= values['verifyhost'] %>
 <% end -%>
 <% if values['cacert'] -%>
     CACert "<%= values['cacert'] %>"


### PR DESCRIPTION
Fixes the #639 issue (broken quoted boolean handling by newer collectd versions)