### PR TITLE
Oracle Database definition must be at bottom

### DIFF
--- a/manifests/plugin/oracle/database.pp
+++ b/manifests/plugin/oracle/database.pp
@@ -17,7 +17,7 @@ define collectd::plugin::oracle::database (
   validate_array($query)
 
   concat::fragment { "collectd_plugin_oracle_database_${name}":
-    order   => '10',
+    order   => '20',
     content => template('collectd/plugin/oracle/database.conf.erb'),
     target  => $collectd::plugin::oracle::config_file,
   }

--- a/spec/defines/collectd_plugin_oracle_database_spec.rb
+++ b/spec/defines/collectd_plugin_oracle_database_spec.rb
@@ -32,7 +32,7 @@ describe 'collectd::plugin::oracle::database', type: :define do
     let(:params) { default_params }
     it 'provides an oracle database stanza concat fragment' do
       is_expected.to contain_concat__fragment(concat_fragment_name).with(target: config_filename,
-                                                                         order: '10')
+                                                                         order: '20')
     end
 
     it { is_expected.to contain_concat__fragment(concat_fragment_name).with_content(%r{<Database "foo">\s+ConnectID "connect_id"\s+Username "username"\s+Password "password"}m) }


### PR DESCRIPTION
Hi,

today, we test the module against a real oracle database and we figure out, the database configuration must be at the bottom.