### PR TITLE
Add Support for older versions of `libyajl`

### DIFF
--- a/manifests/plugin/curl_json.pp
+++ b/manifests/plugin/curl_json.pp
@@ -23,7 +23,11 @@ define collectd::plugin::curl_json (
 
   if $_manage_package {
     if $::osfamily == 'Debian' {
-      ensure_packages('libyajl2')
+      $libyajl_package = $::lsbdistcodename ? {
+        'precise' => 'libyajl1',
+        default   => 'libyajl2'
+      }
+      ensure_packages($libyajl_package)
     }
 
     if $::osfamily == 'Redhat' {

--- a/spec/acceptance/curl_json_spec.rb
+++ b/spec/acceptance/curl_json_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper_acceptance'
+
+describe 'curl_json defined type' do
+  context 'basic parameters' do
+    # Using puppet_apply as a helper
+    it 'works idempotently with no errors' do
+      pp = <<-EOS
+      collectd::plugin::curl_json {
+        'date_json_request':
+          url => 'http://date.jsontest.com/',
+          instance => 'date_json_request',
+          interval => '300',
+          keys => {
+            'milliseconds_since_epoch' => {
+              'type'     => 'count',
+              'instance' => 'epoch',
+            },
+          }
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    case fact(:osfamily)
+    when 'Debian'
+      if fact(:lsbdistcodename) == 'precise'
+        curl_json_package = 'libyajl1'
+      else
+        curl_json_package = 'libyajl2'
+      end
+    when 'RedHat'
+      curl_json_package = 'collectd-curl_json'
+    end
+
+    describe package(curl_json_package) do
+      it { is_expected.to be_installed }
+    end
+
+  end
+end

--- a/spec/acceptance/curl_json_spec.rb
+++ b/spec/acceptance/curl_json_spec.rb
@@ -38,6 +38,5 @@ describe 'curl_json defined type' do
     describe package(curl_json_package) do
       it { is_expected.to be_installed }
     end
-
   end
 end

--- a/spec/acceptance/curl_json_spec.rb
+++ b/spec/acceptance/curl_json_spec.rb
@@ -26,11 +26,11 @@ describe 'curl_json defined type' do
 
     case fact(:osfamily)
     when 'Debian'
-      if fact(:lsbdistcodename) == 'precise'
-        curl_json_package = 'libyajl1'
-      else
-        curl_json_package = 'libyajl2'
-      end
+      curl_json_package = if fact(:lsbdistcodename) == 'precise'
+                            'libyajl1'
+                          else
+                            'libyajl2'
+                          end
     when 'RedHat'
       curl_json_package = 'collectd-curl_json'
     end

--- a/spec/acceptance/nodesets/docker/ubuntu-12.04.yml
+++ b/spec/acceptance/nodesets/docker/ubuntu-12.04.yml
@@ -12,6 +12,8 @@ HOSTS:
     docker_image_commands:
       - 'apt-get install -y net-tools wget'
       - 'locale-gen en_US.UTF-8'
+      - 'ln -s /opt/puppetlabs/bin/facter /usr/bin/facter'
+      - 'ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet'
 CONFIG:
   trace_limit: 200
   masterless: true

--- a/spec/defines/collectd_plugin_curl_json_spec.rb
+++ b/spec/defines/collectd_plugin_curl_json_spec.rb
@@ -71,6 +71,5 @@ describe 'collectd::plugin::curl_json', type: :define do
     it do
       is_expected.to contain_package('libyajl1')
     end
-
   end
 end

--- a/spec/defines/collectd_plugin_curl_json_spec.rb
+++ b/spec/defines/collectd_plugin_curl_json_spec.rb
@@ -39,6 +39,10 @@ describe 'collectd::plugin::curl_json', type: :define do
       )
     end
 
+    it do
+      is_expected.to contain_package('libyajl2')
+    end
+
     it { is_expected.to contain_file(filename).that_notifies('Service[collectd]') }
     it { is_expected.to contain_file(filename).with_content(%r{LoadPlugin "curl_json"}) }
     it { is_expected.to contain_file(filename).with_content(%r{URL "http://localhost:55672/api/overview">}) }
@@ -49,5 +53,24 @@ describe 'collectd::plugin::curl_json', type: :define do
     it { is_expected.to contain_file(filename).with_content(%r{Key "message_stats/publish">}) }
     it { is_expected.to contain_file(filename).with_content(%r{Type "gauge"}) }
     it { is_expected.to contain_file(filename).with_content(%r{Instance "overview"}) }
+  end
+
+  context 'on precise' do
+    let(:params) { my_params }
+
+    let :facts do
+      {
+        osfamily: 'Debian',
+        collectd_version: '4.8.0',
+        lsbdistcodename: 'precise',
+        operatingsystemmajrelease: '12.04',
+        python_dir: '/usr/local/lib/python2.7/dist-packages'
+      }
+    end
+
+    it do
+      is_expected.to contain_package('libyajl1')
+    end
+
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,6 +1,7 @@
 require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
 
-install_puppet_agent_on hosts, {} unless ENV['BEAKER_provision'] == 'no'
+run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
 
 RSpec.configure do |c|
   # Project root


### PR DESCRIPTION
* Ubuntu 12.04 uses "libyajl1", others use "libyajl2"
* Adds spec for which package is present
* Also adds acceptance tests for differences

Rebase of https://github.com/voxpupuli/puppet-collectd/pull/626 with tests 👍 