### PR TITLE
Python purge configuration isolation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@ class collectd (
   $plugin_conf_dir_mode    = $collectd::params::plugin_conf_dir_mode,
   $purge                   = $collectd::params::purge,
   $purge_config            = $collectd::params::purge_config,
+  $purge_config_python     = $collectd::params::purge_config_python,
   $read_threads            = $collectd::params::read_threads,
   $recurse                 = $collectd::params::recurse,
   $root_group              = $collectd::params::root_group,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class collectd::params {
   $internal_stats            = false
   $purge                     = undef
   $purge_config              = false
+  $purge_config_python       = false  
   $recurse                   = undef
   $read_threads              = 5
   $write_threads             = 5

--- a/manifests/plugin/python.pp
+++ b/manifests/plugin/python.pp
@@ -63,7 +63,7 @@ class collectd::plugin::python (
       'ensure'  => $ensure_modulepath,
       'mode'    => '0755',
       'owner'   => 'root',
-      'purge'   => $::collectd::purge_config,
+      'purge'   => $::collectd::purge_config_python,
       'force'   => true,
       'group'   => $collectd::root_group,
       'require' => Package[$collectd::package_name]


### PR DESCRIPTION
* Python purge configuration is now independent from the collectd
  purge configuration.

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>