### PR TITLE
provide sane defaults for manage_repo

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,6 @@ class collectd::params {
   $service_enable            = true
   $minimum_version           = '4.8'
   $manage_package            = true
-  $manage_repo               = true
   $manage_service            = true
   $package_install_options   = undef
   $plugin_conf_dir_mode      = '0750'
@@ -43,6 +42,7 @@ class collectd::params {
       $root_group         = 'root'
       $java_dir           = '/usr/share/collectd/java'
       $default_python_dir = '/usr/local/lib/python2.7/dist-packages'
+      $manage_repo        = true
     }
     'Solaris': {
       $package_name       = 'CSWcollectd'
@@ -54,6 +54,7 @@ class collectd::params {
       $root_group         = 'root'
       $java_dir           = undef
       $default_python_dir = '/opt/csw/share/collectd/python'
+      $manage_repo        = false
     }
     'Redhat': {
       $package_name       = 'collectd'
@@ -65,6 +66,7 @@ class collectd::params {
       $root_group         = 'root'
       $java_dir           = '/usr/share/collectd/java'
       $default_python_dir = '/usr/lib/python2.7/site-packages'
+      $manage_repo        = true
     }
     'Suse': {
       $package_name       = 'collectd'
@@ -76,6 +78,7 @@ class collectd::params {
       $root_group         = 'root'
       $java_dir           = undef
       $default_python_dir = '/usr/share/collectd/python'
+      $manage_repo        = false
     }
     'FreeBSD': {
       $package_name       = 'collectd5'
@@ -87,6 +90,7 @@ class collectd::params {
       $root_group         = 'wheel'
       $java_dir           = undef
       $default_python_dir = '/usr/local/share/collectd/python'
+      $manage_repo        = false
     }
     'OpenBSD': {
       $package_name       = 'collectd'
@@ -98,6 +102,7 @@ class collectd::params {
       $root_group         = '_collectd'
       $java_dir           = undef
       $default_python_dir = '/usr/local/share/collectd/python'
+      $manage_repo        = false
     }
     'Archlinux': {
       $package_name       = 'collectd'
@@ -109,6 +114,7 @@ class collectd::params {
       $root_group         = 'wheel'
       $java_dir           = undef
       $default_python_dir = '/usr/share/collectd/python'
+      $manage_repo        = false
     }
     'Gentoo': {
       $package_name       = 'app-admin/collectd'
@@ -120,6 +126,7 @@ class collectd::params {
       $root_group         = 'collectd'
       $java_dir           = undef
       $default_python_dir = '/usr/share/collectd/python'
+      $manage_repo        = false
     }
 
     default: {


### PR DESCRIPTION
this is only available on debian/redhat osfamily. So we should only
enable it on these platforms, not on all.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
