### PR TITLE
Add install_options for RedHat Family in sensors plugin

### DIFF
--- a/manifests/plugin/sensors.pp
+++ b/manifests/plugin/sensors.pp
@@ -1,21 +1,27 @@
 # https://collectd.org/wiki/index.php/Plugin:Sensors
 class collectd::plugin::sensors (
-  $ensure           = 'present',
-  $manage_package   = undef,
-  $sensorconfigfile = undef,
-  $sensor           = undef,
-  $ignoreselected   = undef,
-  $interval         = undef,
+  $ensure                  = 'present',
+  $manage_package          = undef,
+  $sensorconfigfile        = undef,
+  $sensor                  = undef,
+  $ignoreselected          = undef,
+  $interval                = undef,
+  $package_install_options = $collectd::package_install_options,
 ) {
 
   include ::collectd
 
   $_manage_package = pick($manage_package, $::collectd::manage_package)
 
+  if $package_install_options != undef {
+    validate_array($package_install_options)
+  }
+
   if $::osfamily == 'Redhat' {
     if $_manage_package {
       package { 'collectd-sensors':
-        ensure => $ensure,
+        ensure          => $ensure,
+        install_options => $package_install_options,
       }
     }
   }


### PR DESCRIPTION
This patch adds the global specified installation options for the sensors plugin
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
