### PR TITLE
Add SNMPv3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1528,6 +1528,33 @@ class {'collectd::plugin::snmp':
 }
 ```
 
+```puppet
+class { 'collectd::plugin::snmp':
+  data  => {
+    hc_octets => {
+      'type'     => 'if_octets',
+      'table'    => true,
+      'instance' => 'IF-MIB::ifName',
+      'values'   => ['IF-MIB::ifHCInOctets', 'IF-MIB::ifHCOutOctets'],
+    },
+  },
+  hosts => {
+    router => {
+      'address'            => '192.0.2.1',
+      'version'            => 3,
+      'security_level'     => 'authPriv',
+      'username'           => 'collectd',
+      'auth_protocol'      => 'SHA',
+      'auth_passphrase'    => 'mekmitasdigoat',
+      'privacy_protocol'   => 'AES',
+      'privacy_passphrase' => 'mekmitasdigoat',
+      'collect'            => ['hc_octets'],
+      'interval'           => 10,
+    },
+  },
+}
+```
+
 #### Class: `collectd::plugin::statsd`
 
 ```puppet

--- a/manifests/plugin/snmp.pp
+++ b/manifests/plugin/snmp.pp
@@ -1,10 +1,10 @@
 # https://collectd.org/wiki/index.php/Plugin:SNMP
 class collectd::plugin::snmp (
-  $ensure         = 'present',
-  $manage_package = undef,
-  $data           = {},
-  $hosts          = {},
-  $interval       = undef,
+  Enum['present', 'absent']             $ensure         = 'present',
+  Optional[Boolean]                     $manage_package = undef,
+  Hash[String[1], Collectd::SNMP::Data] $data           = {},
+  Hash[String[1], Collectd::SNMP::Host] $hosts          = {},
+  Optional[Integer[0]]                  $interval       = undef,
 ) {
 
   include ::collectd

--- a/manifests/plugin/snmp/data.pp
+++ b/manifests/plugin/snmp/data.pp
@@ -1,22 +1,20 @@
 # https://collectd.org/wiki/index.php/Plugin:SNMP
 define collectd::plugin::snmp::data (
-  $instance,
-  $type,
-  $values,
-  $ensure         = 'present',
-  $instanceprefix = undef,
-  $scale          = undef,
-  $shift          = undef,
-  $table          = false,
-  $ignore         = undef,
-  $invertmatch    = false,
+  String                                            $instance,
+  String[1]                                         $type,
+  Variant[String[1], Array[String[1], 1]]           $values,
+  Enum['present', 'absent']                         $ensure          = 'present',
+  Optional[String[1]]                               $instance_prefix = undef,
+  Optional[Numeric]                                 $scale           = undef,
+  Optional[Numeric]                                 $shift           = undef,
+  Boolean                                           $table           = false,
+  Optional[Variant[String[1], Array[String[1], 1]]] $ignore          = undef,
+  Boolean                                           $invert_match    = false,
 ) {
 
   include ::collectd
   include ::collectd::plugin::snmp
 
-  $table_bool = str2bool($table)
-  $invertmatch_bool = str2bool($invertmatch)
   $conf_dir   = $collectd::plugin_conf_dir
   $root_group = $collectd::root_group
 

--- a/manifests/plugin/snmp/host.pp
+++ b/manifests/plugin/snmp/host.pp
@@ -1,17 +1,24 @@
 # https://collectd.org/wiki/index.php/Plugin:SNMP
 define collectd::plugin::snmp::host (
-  $collect,
-  $ensure    = 'present',
-  $address   = $name,
-  $version   = '1',
-  $community = 'public',
-  $interval  = undef,
+  Variant[String[1], Array[String[1], 1]]   $collect,
+  Enum['present', 'absent']                 $ensure             = 'present',
+  String[1]                                 $address            = $name,
+  Collectd::SNMP::Version                   $version            = '1',
+  Optional[Integer[0]]                      $interval           = undef,
+  # SNMPv1/2c
+  Optional[String[1]]                       $community          = 'public',
+  # SNMPv3
+  Optional[String[1]]                       $username           = undef,
+  Optional[Collectd::SNMP::SecurityLevel]   $security_level     = undef,
+  Optional[String[1]]                       $context            = undef,
+  Optional[Collectd::SNMP::AuthProtocol]    $auth_protocol      = undef,
+  Optional[String[1]]                       $auth_passphrase    = undef,
+  Optional[Collectd::SNMP::PrivacyProtocol] $privacy_protocol   = undef,
+  Optional[String[1]]                       $privacy_passphrase = undef,
 ) {
 
   include ::collectd
   include ::collectd::plugin::snmp
-
-  validate_re($version, '^[12]$', 'only snmp versions 1 and 2 are supported')
 
   $conf_dir   = $collectd::plugin_conf_dir
   $root_group = $collectd::root_group

--- a/spec/classes/collectd_plugin_snmp_spec.rb
+++ b/spec/classes/collectd_plugin_snmp_spec.rb
@@ -75,6 +75,41 @@ describe 'collectd::plugin::snmp', type: :class do
           )
         end
       end
+
+      context 'SNMPv3' do
+        let :params do
+          {
+            data: {
+              'hc_octets' => {
+                'type'     => 'if_octets',
+                'table'    => true,
+                'instance' => 'IF-MIB::ifName',
+                'values'   => ['IF-MIB::ifHCInOctets', 'IF-MIB::ifHCOutOctets']
+              }
+            },
+            hosts: {
+              'router' => {
+                'address'            => '192.0.2.1',
+                'version'            => 3,
+                'username'           => 'collectd',
+                'security_level'     => 'authPriv',
+                'auth_protocol'      => 'SHA',
+                'auth_passphrase'    => 'mekmitasdigoat',
+                'privacy_protocol'   => 'AES',
+                'privacy_passphrase' => 'mekmitasdigoat',
+                'collect'            => ['hc_octets'],
+                'interval'           => 30
+              }
+            }
+          }
+        end
+
+        it "Will create #{options[:plugin_conf_dir]}/10-snmp.conf" do
+          is_expected.to contain_file('snmp.load').with(ensure: 'present',
+                                                        path: "#{options[:plugin_conf_dir]}/10-snmp.conf",
+                                                        content: %r{Data "hc_octets".+Instance "IF-MIB::ifName".+Host "router".+Username "collectd".+SecurityLevel "authPriv".+AuthProtocol "SHA".+PrivacyProtocol "AES"}m)
+        end
+      end
     end
   end
 end

--- a/spec/defines/collectd_plugin_snmp_data_spec.rb
+++ b/spec/defines/collectd_plugin_snmp_data_spec.rb
@@ -93,7 +93,7 @@ describe 'collectd::plugin::snmp::data', type: :define do
       context 'InvertMatch is true' do
         let(:params) do
           {
-            invertmatch: true
+            invert_match: true
           }.merge(required_params)
         end
 
@@ -103,7 +103,7 @@ describe 'collectd::plugin::snmp::data', type: :define do
       context 'InvertMatch is false' do
         let(:params) do
           {
-            invertmatch: false
+            invert_match: false
           }.merge(required_params)
         end
 

--- a/spec/defines/collectd_plugin_snmp_host_spec.rb
+++ b/spec/defines/collectd_plugin_snmp_host_spec.rb
@@ -36,7 +36,7 @@ describe 'collectd::plugin::snmp::host', type: :define do
         it { is_expected.to contain_file(filename).without_content(%r{Interval \d+}) }
       end
 
-      context 'all params set' do
+      context 'all SNMPv2 params set' do
         let(:params) do
           required_params.merge(address: 'bar.example.com',
                                 version: '2',
@@ -47,6 +47,30 @@ describe 'collectd::plugin::snmp::host', type: :define do
         it { is_expected.to contain_file(filename).with_content(%r{Address "bar\.example\.com"}) }
         it { is_expected.to contain_file(filename).with_content(%r{Version 2}) }
         it { is_expected.to contain_file(filename).with_content(%r{Community "opensesame"}) }
+        it { is_expected.to contain_file(filename).with_content(%r{Interval 30}) }
+      end
+
+      context 'all SNMPv3 params set' do
+        let(:params) do
+          required_params.merge(address: 'bar.example.com',
+                                version: 3,
+                                username: 'collectd',
+                                security_level: 'authPriv',
+                                auth_protocol: 'SHA',
+                                auth_passphrase: 'mekmitasdigoat',
+                                privacy_protocol: 'AES',
+                                privacy_passphrase: 'mekmitasdigoat',
+                                interval: 30)
+        end
+
+        it { is_expected.to contain_file(filename).with_content(%r{Address "bar\.example\.com"}) }
+        it { is_expected.to contain_file(filename).with_content(%r{Version 3}) }
+        it { is_expected.to contain_file(filename).with_content(%r{Username "collectd"}) }
+        it { is_expected.to contain_file(filename).with_content(%r{SecurityLevel "authPriv"}) }
+        it { is_expected.to contain_file(filename).with_content(%r{AuthProtocol "SHA"}) }
+        it { is_expected.to contain_file(filename).with_content(%r{AuthPassphrase "mekmitasdigoat"}) }
+        it { is_expected.to contain_file(filename).with_content(%r{PrivacyProtocol "AES"}) }
+        it { is_expected.to contain_file(filename).with_content(%r{PrivacyPassphrase "mekmitasdigoat"}) }
         it { is_expected.to contain_file(filename).with_content(%r{Interval 30}) }
       end
 

--- a/spec/defines/collectd_plugin_snmp_host_spec.rb
+++ b/spec/defines/collectd_plugin_snmp_host_spec.rb
@@ -41,7 +41,7 @@ describe 'collectd::plugin::snmp::host', type: :define do
           required_params.merge(address: 'bar.example.com',
                                 version: '2',
                                 community: 'opensesame',
-                                interval: '30')
+                                interval: 30)
         end
 
         it { is_expected.to contain_file(filename).with_content(%r{Address "bar\.example\.com"}) }

--- a/templates/plugin/snmp.conf.erb
+++ b/templates/plugin/snmp.conf.erb
@@ -1,10 +1,10 @@
 <% if @data or @hosts -%>
 <Plugin snmp>
 <% @data.sort_by {|k,v| k}.each do |key,val| -%>
-  <Data "<%=key %>">
+  <Data "<%= key %>">
     Type "<%= val['type'] %>"
-<% if val['table'] -%>
-    Table <%= val['table'] %>
+<% unless val['table'].nil? -%>
+    Table <%= val['table'] ? 'true' : 'false' %>
 <% end -%>
 <% if val['instance'] -%>
     Instance "<%= val['instance'] %>"
@@ -22,19 +22,37 @@
 <% if val['ignore'] -%>
     Ignore <% Array(val['ignore']).each do |x| -%>"<%= x %>" <% end %>
 <% end -%>
-<% if val['invert_match'] -%>
-    InvertMatch <%= val['invert_match'] %>
+<% unless val['invert_match'].nil? -%>
+    InvertMatch <%= val['invert_match'] ? 'true' : 'false' %>
 <% end -%>
   </Data>
 
 <% end -%>
 <% @hosts.sort_by {|k,v| k}.each do |key,val| -%>
-  <Host "<%=key %>">
+  <Host "<%= key %>">
     Address "<%= val['address'] %>"
     Version <%= val['version'] %>
+<%   if val['version'].to_i < 3 -%>
     Community "<%= val['community'] %>"
+<%   else -%>
+    Username "<%= val['username'] %>"
+<%     if val['context'] -%>
+    Context "<%= val['context'] %>"
+<%     end -%>
+    SecurityLevel "<%= val['security_level'] %>"
+<%     if ['authPriv', 'authNoPriv'].include?(val['security_level']) -%>
+    AuthProtocol "<%= val['auth_protocol'] %>"
+    AuthPassphrase "<%= val['auth_passphrase'] %>"
+<%     end -%>
+<%     if val['security_level'].eql?('authPriv') -%>
+    PrivacyProtocol "<%= val['privacy_protocol'] %>"
+    PrivacyPassphrase "<%= val['privacy_passphrase'] %>"
+<%     end -%>
+<%   end -%>
     Collect <% Array(val['collect']).sort.each do |x| -%>"<%= x -%>" <% end %>
+<%   if val['interval'] -%>
     Interval <%= val['interval'] %>
+<%   end -%>
   </Host>
 <% end -%>
 </Plugin>

--- a/templates/plugin/snmp/data.conf.erb
+++ b/templates/plugin/snmp/data.conf.erb
@@ -1,10 +1,10 @@
 <Plugin snmp>
   <Data "<%= @name %>">
     Type "<%= @type %>"
-    Table <%= @table_bool ? 'true' : 'false' %>
+    Table <%= @table ? 'true' : 'false' %>
     Instance "<%= @instance %>"
-<% if @instanceprefix -%>
-    InstancePrefix "<%= @instanceprefix %>"
+<% if @instance_prefix -%>
+    InstancePrefix "<%= @instance_prefix %>"
 <% end -%>
     Values <%= Array(@values).map { |x| %Q{"#{x}"} }.join(' ') %>
 <% if @scale -%>
@@ -14,9 +14,9 @@
     Shift <%= @shift %>
 <% end -%>
 <% if @ignore -%>
-     Ignore <%= Array(@ignore).map { |x| %Q{"#{x}"} }.join(' ') %>
+   Ignore <%= Array(@ignore).map { |x| %Q{"#{x}"} }.join(' ') %>
 <% end -%>
-    InvertMatch <%= @invertmatch_bool ? 'true' : 'false' %>
+    InvertMatch <%= @invert_match ? 'true' : 'false' %>
   </Data>
 </Plugin>
  

--- a/templates/plugin/snmp/host.conf.erb
+++ b/templates/plugin/snmp/host.conf.erb
@@ -2,10 +2,26 @@
   <Host "<%= @name %>">
     Address "<%= @address %>"
     Version <%= @version %>
+<% if @version.to_i < 3 -%>
     Community "<%= @community %>"
+<% else -%>
+    Username "<%= @username %>"
+<%   if @context -%>
+    Context "<%= @context %>"
+<%   end -%>
+    SecurityLevel "<%= @security_level %>"
+<%   if ['authPriv', 'authNoPriv'].include?(@security_level) -%>
+    AuthProtocol "<%= @auth_protocol %>"
+    AuthPassphrase "<%= @auth_passphrase %>"
+<%   end -%>
+<%   if @security_level.eql?('authPriv') -%>
+    PrivacyProtocol "<%= @privacy_protocol %>"
+    PrivacyPassphrase "<%= @privacy_passphrase %>"
+<%   end -%>
+<% end -%>
     Collect <%= Array(@collect).map { |x| %Q{"#{x}"} }.join(' ') %>
-    <%- if !@interval.nil? -%>
+<% if @interval -%>
     Interval <%= @interval %>
-    <%- end -%>
+<% end -%>
   </Host>
 </Plugin>

--- a/types/snmp/authprotocol.pp
+++ b/types/snmp/authprotocol.pp
@@ -1,0 +1,2 @@
+#
+type Collectd::SNMP::AuthProtocol = Enum['MD5', 'SHA']

--- a/types/snmp/data.pp
+++ b/types/snmp/data.pp
@@ -1,0 +1,2 @@
+#
+type Collectd::SNMP::Data = Struct[{Optional['instance'] => String, NotUndef['type'] => String[1], NotUndef['values'] => Variant[String[1], Array[String[1], 1]], Optional['instance_prefix'] => String[1], Optional['scale'] => Numeric, Optional['shift'] => Numeric, Optional['table'] => Boolean, Optional['ignore'] => Variant[String[1], Array[String[1], 1]], Optional['invert_match'] => Boolean}]

--- a/types/snmp/host.pp
+++ b/types/snmp/host.pp
@@ -1,0 +1,2 @@
+#
+type Collectd::SNMP::Host = Variant[Collectd::SNMP::Host::V2, Collectd::SNMP::Host::V3]

--- a/types/snmp/host/v2.pp
+++ b/types/snmp/host/v2.pp
@@ -1,0 +1,2 @@
+#
+type Collectd::SNMP::Host::V2 = Struct[{NotUndef['address'] => String[1], NotUndef['version'] => Collectd::SNMP::Version::V2, NotUndef['community'] => String[1], NotUndef['collect'] => Variant[String[1], Array[String[1], 1]], Optional['interval'] => Integer[0]}]

--- a/types/snmp/host/v3.pp
+++ b/types/snmp/host/v3.pp
@@ -1,0 +1,2 @@
+#
+type Collectd::SNMP::Host::V3 = Struct[{NotUndef['address'] => String[1], NotUndef['version'] => Collectd::SNMP::Version::V3, NotUndef['username'] => String[1], Optional['context'] => String[1], NotUndef['security_level'] => Collectd::SNMP::SecurityLevel, Optional['auth_protocol'] => Collectd::SNMP::AuthProtocol, Optional['auth_passphrase'] => String[1], Optional['privacy_protocol'] => Collectd::SNMP::PrivacyProtocol, Optional['privacy_passphrase'] => String[1], NotUndef['collect'] => Variant[String[1], Array[String[1], 1]], Optional['interval'] => Integer[0]}]

--- a/types/snmp/privacyprotocol.pp
+++ b/types/snmp/privacyprotocol.pp
@@ -1,0 +1,2 @@
+#
+type Collectd::SNMP::PrivacyProtocol = Enum['AES', 'DES']

--- a/types/snmp/securitylevel.pp
+++ b/types/snmp/securitylevel.pp
@@ -1,0 +1,2 @@
+#
+type Collectd::SNMP::SecurityLevel = Enum['authPriv', 'authNoPriv', 'noAuthNoPriv']

--- a/types/snmp/version.pp
+++ b/types/snmp/version.pp
@@ -1,0 +1,2 @@
+#
+type Collectd::SNMP::Version = Variant[Collectd::SNMP::Version::V2, Collectd::SNMP::Version::V3]

--- a/types/snmp/version/v2.pp
+++ b/types/snmp/version/v2.pp
@@ -1,0 +1,2 @@
+#
+type Collectd::SNMP::Version::V2 = Variant[Integer[1, 2], Enum['1', '2']]

--- a/types/snmp/version/v3.pp
+++ b/types/snmp/version/v3.pp
@@ -1,0 +1,2 @@
+#
+type Collectd::SNMP::Version::V3 = Variant[Integer[3, 3], Enum['3']]


### PR DESCRIPTION
This PR adds SNMPv3 support to the SNMP plugin which should fix #236, I also took the opportunity to refactor the plugin to use Puppet 4.x data types.

The only breaking change AFAICT is that I renamed the `invertmatch` and `instanceprefix` parameters to `invert_match` and `instance_prefix` respectively in the `collectd::plugin::snmp::data` defined type to match the hash keys passed in the `data` parameter in `collectd::plugin::snmp` class given everything else matched up.

To keep my employers legal team happy, I have to include the following:
>This contribution is provided 'as is' and without any warranty or guarantee of any kind, express or implied, including in relation to its quality, suitability for a particular purpose or non-infringement. To the extent permitted by law, in no event shall the creator of this contribution be liable for any claim, damage or other liability, whether arising in contract, tort or otherwise, arising out of or in connection with this contribution.
