### PR TITLE
Change 'Redhat' to 'RedHat' when comparing against the osfamily fact

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,7 +56,7 @@ class collectd::params {
       $default_python_dir = '/opt/csw/share/collectd/python'
       $manage_repo        = false
     }
-    'Redhat': {
+    'RedHat': {
       $package_name       = 'collectd'
       $package_provider   = 'yum'
       $collectd_dir       = '/etc/collectd.d'

--- a/manifests/plugin/amqp.pp
+++ b/manifests/plugin/amqp.pp
@@ -25,7 +25,7 @@ class collectd::plugin::amqp (
 
   validate_bool($amqppersistent, $graphiteseparateinstances, $graphitealwaysappendds)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-amqp':
         ensure => $ensure,

--- a/manifests/plugin/bind.pp
+++ b/manifests/plugin/bind.pp
@@ -29,7 +29,7 @@ class collectd::plugin::bind (
   )
   validate_array($views)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-bind':
         ensure => $ensure,

--- a/manifests/plugin/curl.pp
+++ b/manifests/plugin/curl.pp
@@ -10,7 +10,7 @@ class collectd::plugin::curl (
 
   $_manage_package = pick($manage_package, $::collectd::manage_package)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-curl':
         ensure => $ensure,

--- a/manifests/plugin/curl_json.pp
+++ b/manifests/plugin/curl_json.pp
@@ -34,7 +34,7 @@ define collectd::plugin::curl_json (
       ensure_packages($libyajl_package)
     }
 
-    if $::osfamily == 'Redhat' {
+    if $::osfamily == 'RedHat' {
       ensure_packages('collectd-curl_json')
     }
   }

--- a/manifests/plugin/dbi.pp
+++ b/manifests/plugin/dbi.pp
@@ -12,7 +12,7 @@ class collectd::plugin::dbi (
 
   $_manage_package = pick($manage_package, $::collectd::manage_package)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-dbi':
         ensure => $ensure,

--- a/manifests/plugin/genericjmx.pp
+++ b/manifests/plugin/genericjmx.pp
@@ -13,7 +13,7 @@ class collectd::plugin::genericjmx (
 
   $_manage_package = pick($manage_package, $::collectd::manage_package)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-generic-jmx':
         ensure => $ensure,

--- a/manifests/plugin/ipmi.pp
+++ b/manifests/plugin/ipmi.pp
@@ -24,7 +24,7 @@ class collectd::plugin::ipmi (
     $notify_sensor_remove,
   )
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $manage_package_real {
       package { 'collectd-ipmi':
         ensure => $ensure_package,

--- a/manifests/plugin/iptables.pp
+++ b/manifests/plugin/iptables.pp
@@ -13,7 +13,7 @@ class collectd::plugin::iptables (
 
   validate_hash($chains)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-iptables':
         ensure => $ensure_package,

--- a/manifests/plugin/java.pp
+++ b/manifests/plugin/java.pp
@@ -12,7 +12,7 @@ class collectd::plugin::java (
 
   $_manage_package = pick($manage_package, $::collectd::manage_package)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-java':
         ensure => $ensure,

--- a/manifests/plugin/lvm.pp
+++ b/manifests/plugin/lvm.pp
@@ -15,7 +15,7 @@ class collectd::plugin::lvm (
     $ensure_real = 'absent'
   }
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-lvm':
         ensure => $ensure_real,

--- a/manifests/plugin/mysql.pp
+++ b/manifests/plugin/mysql.pp
@@ -10,7 +10,7 @@ class collectd::plugin::mysql (
 
   $_manage_package = pick($manage_package, $::collectd::manage_package)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-mysql':
         ensure => $ensure,

--- a/manifests/plugin/netlink.pp
+++ b/manifests/plugin/netlink.pp
@@ -18,7 +18,7 @@ class collectd::plugin::netlink (
   validate_array($interfaces, $verboseinterfaces, $qdiscs, $classes, $filters)
   validate_bool($ignoreselected)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-netlink':
         ensure => $ensure,

--- a/manifests/plugin/nginx.pp
+++ b/manifests/plugin/nginx.pp
@@ -15,7 +15,7 @@ class collectd::plugin::nginx (
 
   $_manage_package = pick($manage_package, $::collectd::manage_package)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-nginx':
         ensure => $ensure,

--- a/manifests/plugin/perl.pp
+++ b/manifests/plugin/perl.pp
@@ -12,7 +12,7 @@ class collectd::plugin::perl (
 
   $conf_dir = $collectd::plugin_conf_dir
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-perl':
         ensure => $ensure,

--- a/manifests/plugin/ping.pp
+++ b/manifests/plugin/ping.pp
@@ -17,7 +17,7 @@ class collectd::plugin::ping (
 
   validate_array($hosts)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-ping':
         ensure => $ensure,

--- a/manifests/plugin/postgresql.pp
+++ b/manifests/plugin/postgresql.pp
@@ -12,7 +12,7 @@ class collectd::plugin::postgresql (
 
   $_manage_package = pick($manage_package, $::collectd::manage_package)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-postgresql':
         ensure => $ensure,

--- a/manifests/plugin/rrdcached.pp
+++ b/manifests/plugin/rrdcached.pp
@@ -19,7 +19,7 @@ class collectd::plugin::rrdcached (
 
   $_manage_package = pick($manage_package, $::collectd::manage_package)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-rrdcached':
         ensure => $ensure,

--- a/manifests/plugin/sensors.pp
+++ b/manifests/plugin/sensors.pp
@@ -12,7 +12,7 @@ class collectd::plugin::sensors (
 
   $_manage_package = pick($manage_package, $::collectd::manage_package)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-sensors':
         ensure => $ensure,

--- a/manifests/plugin/snmp.pp
+++ b/manifests/plugin/snmp.pp
@@ -11,7 +11,7 @@ class collectd::plugin::snmp (
 
   $_manage_package = pick($manage_package, $::collectd::manage_package)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-snmp':
         ensure => $ensure,

--- a/manifests/plugin/varnish.pp
+++ b/manifests/plugin/varnish.pp
@@ -15,7 +15,7 @@ class collectd::plugin::varnish (
 
   validate_hash($instances)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-varnish':
         ensure => $ensure,

--- a/manifests/plugin/write_riemann.pp
+++ b/manifests/plugin/write_riemann.pp
@@ -27,7 +27,7 @@ class collectd::plugin::write_riemann (
   validate_array($tags)
   validate_hash($attributes)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-write_riemann':
         ensure => $ensure,

--- a/manifests/plugin/write_sensu.pp
+++ b/manifests/plugin/write_sensu.pp
@@ -20,7 +20,7 @@ class collectd::plugin::write_sensu (
   validate_bool($store_rates)
   validate_bool($always_append_ds)
 
-  if $::osfamily == 'Redhat' {
+  if $::osfamily == 'RedHat' {
     if $_manage_package {
       package { 'collectd-write_sensu':
         ensure => $ensure,

--- a/spec/classes/collectd_plugin_cgroups_spec.rb
+++ b/spec/classes/collectd_plugin_cgroups_spec.rb
@@ -31,7 +31,7 @@ describe 'collectd::plugin::cgroups', type: :class do
   context ':ensure => present, specific params, collectd version 5.4.0' do
     let :facts do
       {
-        osfamily: 'Redhat',
+        osfamily: 'RedHat',
         collectd_version: '5.4.0',
         operatingsystemmajrelease: '7',
         python_dir: '/usr/local/lib/python2.7/dist-packages'

--- a/spec/classes/collectd_plugin_logfile_spec.rb
+++ b/spec/classes/collectd_plugin_logfile_spec.rb
@@ -29,7 +29,7 @@ describe 'collectd::plugin::logfile', type: :class do
   context ':ensure => present, specific params, collectd version 4.9' do
     let :facts do
       {
-        osfamily: 'Redhat',
+        osfamily: 'RedHat',
         collectd_version: '4.9.0',
         operatingsystemmajrelease: '7',
         python_dir: '/usr/local/lib/python2.7/dist-packages'
@@ -48,7 +48,7 @@ describe 'collectd::plugin::logfile', type: :class do
   context ':ensure => present, default params, collectd version 4.10' do
     let :facts do
       {
-        osfamily: 'Redhat',
+        osfamily: 'RedHat',
         collectd_version: '4.10.0',
         operatingsystemmajrelease: '7',
         python_dir: '/usr/local/lib/python2.7/dist-packages'
@@ -65,7 +65,7 @@ describe 'collectd::plugin::logfile', type: :class do
   context ':ensure => present, specific params, collectd version 4.10' do
     let :facts do
       {
-        osfamily: 'Redhat',
+        osfamily: 'RedHat',
         collectd_version: '4.10.0',
         operatingsystemmajrelease: '7',
         python_dir: '/usr/local/lib/python2.7/dist-packages'

--- a/spec/classes/collectd_plugin_memory_spec.rb
+++ b/spec/classes/collectd_plugin_memory_spec.rb
@@ -30,7 +30,7 @@ describe 'collectd::plugin::memory', type: :class do
   context ':ensure => present, specific params, collectd version 5.4.2' do
     let :facts do
       {
-        osfamily: 'Redhat',
+        osfamily: 'RedHat',
         collectd_version: '5.4.2',
         operatingsystemmajrelease: '7',
         python_dir: '/usr/local/lib/python2.7/dist-packages'
@@ -51,7 +51,7 @@ describe 'collectd::plugin::memory', type: :class do
   context ':ensure => present, specific params, collectd version 5.5.0' do
     let :facts do
       {
-        osfamily: 'Redhat',
+        osfamily: 'RedHat',
         collectd_version: '5.5.0',
         operatingsystemmajrelease: '7',
         python_dir: '/usr/local/lib/python2.7/dist-packages'

--- a/spec/classes/collectd_plugin_swap_spec.rb
+++ b/spec/classes/collectd_plugin_swap_spec.rb
@@ -31,7 +31,7 @@ describe 'collectd::plugin::swap', type: :class do
   context ':ensure => present, specific params, collectd version 5.0' do
     let :facts do
       {
-        osfamily: 'Redhat',
+        osfamily: 'RedHat',
         collectd_version: '5.0',
         operatingsystemmajrelease: '7',
         python_dir: '/usr/local/lib/python2.7/dist-packages'
@@ -49,7 +49,7 @@ describe 'collectd::plugin::swap', type: :class do
   context ':ensure => present, specific params, collectd version 5.2.0' do
     let :facts do
       {
-        osfamily: 'Redhat',
+        osfamily: 'RedHat',
         collectd_version: '5.2.0',
         operatingsystemmajrelease: '7',
         python_dir: '/usr/local/lib/python2.7/dist-packages'
@@ -67,7 +67,7 @@ describe 'collectd::plugin::swap', type: :class do
   context ':ensure => present, specific params, collectd version 5.5.0' do
     let :facts do
       {
-        osfamily: 'Redhat',
+        osfamily: 'RedHat',
         collectd_version: '5.5.0',
         operatingsystemmajrelease: '7',
         python_dir: '/usr/local/lib/python2.7/dist-packages'

--- a/spec/defines/collectd_plugin_network_listener_spec.rb
+++ b/spec/defines/collectd_plugin_network_listener_spec.rb
@@ -4,7 +4,7 @@ describe 'collectd::plugin::network::listener', type: :define do
   context ':ensure => present, collectd version 4.6' do
     let :facts do
       {
-        osfamily: 'Redhat',
+        osfamily: 'RedHat',
         collectd_version: '4.6',
         operatingsystemmajrelease: '7',
         python_dir: '/usr/local/lib/python2.7/dist-packages'
@@ -28,7 +28,7 @@ describe 'collectd::plugin::network::listener', type: :define do
   context ':ensure => present, collectd version 5.1.0' do
     let :facts do
       {
-        osfamily: 'Redhat',
+        osfamily: 'RedHat',
         collectd_version: '5.1.0',
         operatingsystemmajrelease: '7',
         python_dir: '/usr/local/lib/python2.7/dist-packages'

--- a/spec/defines/collectd_plugin_network_server_spec.rb
+++ b/spec/defines/collectd_plugin_network_server_spec.rb
@@ -4,7 +4,7 @@ describe 'collectd::plugin::network::server', type: :define do
   context ':ensure => present, create one complex server, collectd 5.1.0' do
     let :facts do
       {
-        osfamily: 'Redhat',
+        osfamily: 'RedHat',
         collectd_version: '5.1.0',
         operatingsystemmajrelease: '7',
         python_dir: '/usr/local/lib/python2.7/dist-packages'


### PR DESCRIPTION
I was tracking down why we had forked our own copy of this module and found one of the changes was simply changing the case of `Redhat` to `RedHat` in some common places. Before I remembered that Puppet helpfully compares strings case insensitively I updated all occurrences given the module uses both forms throughout. Should Puppet ever change its behaviour the latter form matches exactly what facter returns.

To keep my employers legal team happy, I have to include the following:
> This contribution is provided 'as is' and without any warranty or guarantee of any kind, express or implied, including in relation to its quality, suitability for a particular purpose or non-infringement. To the extent permitted by law, in no event shall the creator of this contribution be liable for any claim, damage or other liability, whether arising in contract, tort or otherwise, arising out of or in connection with this contribution.

