### PR TITLE
Do not set a value for the collectd_version fact if collectd is not y…

### DIFF
--- a/lib/facter/collectd_version.rb
+++ b/lib/facter/collectd_version.rb
@@ -11,8 +11,6 @@ Facter.add(:collectd_version) do
     if Facter::Util::Resolution.which('collectd')
       collectd_help = Facter::Util::Resolution.exec('collectd -h')
       %r{^collectd ([\w\.]+), http://collectd\.org/}.match(collectd_help)[1]
-    else
-      ''
     end
   end
 end

--- a/spec/unit/collectd_real_version_spec.rb
+++ b/spec/unit/collectd_real_version_spec.rb
@@ -18,8 +18,8 @@ describe 'collectd_version', type: :fact do
     expect(Facter.fact(:collectd_version).value).to eq('5.1.0.git')
   end
 
-  it 'is empty string if collectd not installed' do
+  it 'is not defined if collectd not installed' do
     Facter::Util::Resolution.stubs(:which).with('collectd').returns(nil)
-    expect(Facter.fact(:collectd_version).value).to eq('')
+    expect(Facter.fact(:collectd_version).value).to be_nil
   end
 end


### PR DESCRIPTION
…et installed

Right now the value of that fact is set to an empty string when collectd is not installed, so on an initial run on a new machine the code in init manifest
```
$collectd_version_real = pick($::collectd_version, $minimum_version) 
```
will set  $collectd_version_real to an empty string, and as a result, on an initial run the modules that have templates that reference this value will be broken. Not setting this value in the fact will make $collectd_version_real to take the value of $minimum_version which I believe is the intended behaviour. The second run will fix the problem, but it means you must run puppet twice for the initial provisioning.

Another question if should we transform the referenced line in
```
$collectd_version_real = pick($minimum_version,$::collectd_version) 
```
so that $collectd_version_real will always have the value of $minimum_version if $minimum_version is defined. This will also provide us a (strange) fix for the problem, but I'm not sure if it's the intended behaviour.

I tested if it works :
```
[root@vagrant ~]# puppet facts --modulepath /tmp/vagrant-puppet/modules-9be8ec6dcc5d06cd00bef0a0f1c5eaa0/ | grep collectd
[root@vagrant ~]# yum install -y -q collectd
[root@vagrant ~]# puppet facts --modulepath /tmp/vagrant-puppet/modules-9be8ec6dcc5d06cd00bef0a0f1c5eaa0/ | grep collectd
    "collectd_version": "5.5.2.48.g55ef277",
[root@vagrant ~]# cat /tmp/vagrant-puppet/modules-9be8ec6dcc5d06cd00bef0a0f1c5eaa0/collectd/lib/facter/collectd_version.rb 
# Fact: collectd_version
#
# Purpose: Retrieve collectd version if installed
#
# Resolution:
#
# Caveats:  not well tested
#
Facter.add(:collectd_version) do
  setcode do
    if Facter::Util::Resolution.which('collectd')
      collectd_help = Facter::Util::Resolution.exec('collectd -h')
      %r{^collectd ([\w\.]+), http://collectd\.org/}.match(collectd_help)[1]
    end
  end
end
```
