### PR TITLE
Install 'collectd-python' package on Amazon Linux.

### DIFF
--- a/manifests/plugin/python.pp
+++ b/manifests/plugin/python.pp
@@ -38,7 +38,7 @@ class collectd::plugin::python (
     $ensure_real = 'absent'
   }
 
-  if $::operatingsystem == 'Fedora' {
+  if $facts['os']['name'] == 'Fedora' or $facts['os']['name'] == 'Amazon' {
     if $_manage_package {
       package { 'collectd-python':
         ensure => $ensure_real,


### PR DESCRIPTION
When the package installation check in `manifests/plugin/python.pp` changed from all RedHat distress to Fedora the module stopped working on Amazon Linux. This change updates the check to install the module on Amazon Linux.
