### PR TITLE
Bump required puppet version 4.6.1->4.7.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -79,7 +79,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.6.1 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 5.0.0"
     }
   ],
   "name": "puppet-collectd",


### PR DESCRIPTION
4.6.1 was recommended while we did our upgrade from puppet3 to puppet4.
However: There were some bugs in 4.6 and puppetlabs made 4.7.0 the new
recommended and LTS version.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
