### PR TITLE
Fix ping plugin interval mixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1241,7 +1241,9 @@ collectd::plugin::perl::plugin {
 ```puppet
 collectd::plugin::ping {
   'example':
-    hosts => ['example.com'],
+    hosts         => ['example.com'],
+    ping_interval => '0.100',
+    timeout       => '0.095',
 }
 ```
 

--- a/manifests/plugin/ping.pp
+++ b/manifests/plugin/ping.pp
@@ -4,6 +4,7 @@ class collectd::plugin::ping (
   $ensure         = 'present',
   $manage_package = undef,
   $interval       = undef,
+  $ping_interval  = undef,
   $timeout        = undef,
   $ttl            = undef,
   $source_address = undef,
@@ -23,6 +24,12 @@ class collectd::plugin::ping (
         ensure => $ensure,
       }
     }
+  }
+
+  if versioncmp($::collectd::collectd_version_real, '5.2') < 0 and $interval and ! $ping_interval {
+    $_ping_interval = $interval
+  } else {
+    $_ping_interval = $ping_interval
   }
 
   collectd::plugin { 'ping':

--- a/spec/classes/collectd_plugin_ping_spec.rb
+++ b/spec/classes/collectd_plugin_ping_spec.rb
@@ -26,22 +26,75 @@ describe 'collectd::plugin::ping', type: :class do
         end
       end
 
-      context ':hosts => [\'google.com\', \'puppetlabs.com\']' do
-        let :params do
-          { hosts: ['google.com', 'puppetlabs.com'] }
-        end
-
-        it "Will create #{options[:plugin_conf_dir]}/10-ping.conf" do
-          is_expected.to contain_file('ping.load').with(
-            ensure: 'present',
-            path: "#{options[:plugin_conf_dir]}/10-ping.conf"
-          ).with_content(
-            %r{Host "google.com"}
-          ).with_content(
-            %r{Host "puppetlabs.com"}
-          )
-        end
+    context ':hosts => [\'google.com\']' do
+      let :params do
+        {
+          hosts: ['google.com'],
+          interval: '0.100'
+        }
       end
+
+      it 'Will create intervals right' do
+        is_expected.to contain_file('ping.load').with(ensure: 'present',
+                                                      path: '/etc/collectd.d/10-ping.conf').with_content(
+                                                        %r{^\s*Interval "0.100"$}
+                                                      )
+      end
+    end
+
+    context ':hosts => [\'google.com\']' do
+      let :params do
+        {
+          hosts: ['google.com'],
+          interval: '60',
+          ping_interval: '0.100'
+        }
+      end
+
+      it 'Will create intervals right' do
+        is_expected.to contain_file('ping.load').with(ensure: 'present',
+                                                      path: '/etc/collectd.d/10-ping.conf').without_content(
+                                                        %r{^\s*Interval 60$}
+                                                      ).with_content(
+                                                        %r{^\s*Interval "0.100"$}
+                                                      )
+      end
+    end
+
+    context ':hosts => [\'google.com\']' do
+      let :params do
+        {
+          hosts: ['google.com'],
+          interval: '60',
+          ping_interval: '0.100'
+        }
+      end
+
+      it 'Will create intervals right' do
+        is_expected.to contain_file('ping.load').with(ensure: 'present',
+                                                      path: '/etc/collectd.d/10-ping.conf').with_content(
+                                                        %r{^\s*Interval 60$}
+                                                      ).with_content(
+                                                        %r{^\s*Interval "0.100"$}
+                                                      )
+      end
+    end
+
+    context ':hosts => [\'google.com\', \'puppetlabs.com\']' do
+      let :params do
+        { hosts: ['google.com', 'puppetlabs.com'] }
+      end
+          it "Will create #{options[:plugin_conf_dir]}/10-ping.conf" do
+            is_expected.to contain_file('ping.load').with(
+              ensure: 'present',
+              path: "#{options[:plugin_conf_dir]}/10-ping.conf"
+            ).with_content(
+              %r{Host "google.com"}
+            ).with_content(
+              %r{Host "puppetlabs.com"}
+            )
+          end
+        end
 
       context ':ensure => absent' do
         let :params do

--- a/templates/plugin/ping.conf.erb
+++ b/templates/plugin/ping.conf.erb
@@ -2,22 +2,22 @@
 <% @hosts.each do |host| -%>
 	Host "<%= host %>"
 <% end -%>
-<% if @interval %>
+<% if @interval -%>
 	Interval "<%= @interval %>"
 <% end -%>
-<% if @timeout %>
+<% if @timeout -%>
 	Timeout "<%= @timeout %>"
 <% end -%>
-<% if @ttl %>
+<% if @ttl -%>
 	TTL "<%= @ttl %>"
 <% end -%>
-<% if @source_address %>
+<% if @source_address -%>
 	SourceAddress "<%= @source_address %>"
 <% end -%>
-<% if @device %>
+<% if @device -%>
 	Device "<%= @device %>"
 <% end -%>
-<% if @max_missed %>
+<% if @max_missed -%>
 	MaxMissed "<%= @max_missed %>"
 <% end -%>
 </Plugin>

--- a/templates/plugin/ping.conf.erb
+++ b/templates/plugin/ping.conf.erb
@@ -2,8 +2,8 @@
 <% @hosts.each do |host| -%>
 	Host "<%= host %>"
 <% end -%>
-<% if @interval -%>
-	Interval "<%= @interval %>"
+<% if @_ping_interval -%>
+	Interval "<%= @_ping_interval %>"
 <% end -%>
 <% if @timeout -%>
 	Timeout "<%= @timeout %>"


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
After collectd 5.2 ping plugin interval was also defined as plugin interval. This patch adds ping_interval to be interval between pings and leaves interval as plugin level interval (how oftern to collect stats).

Other Interval is defined at templates/loadplugin.conf.erb.

This patch tries to be compatible with collecd version before 5.2, but when you do update to 5.2 or newer you need to define ping_interval for ping plugin to work as expected. If support for collectd before 5.2 is dropped, logic can be simplified.

Other cosmetic patch just drops extra newlines from created configuration.