### PR TITLE
Genericjmx class path

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,7 +837,22 @@ collectd::plugin::genericjmx::connection {
     service_url     => 'service:jmx:rmi:///jndi/rmi://localhost:3637/jmxrmi',
     collect         => [ 'memory-heap', 'memory-nonheap','garbage_collector' ],
 }
+```
 
+Use jboss-cli-client.jar to collect values from newer jboss. You need
+to provide the jar.
+```
+class { 'collectd::plugin::genericjmx':
+  class_path_prepend => '/usr/lib/java/jboss-cli-client.jar',
+  class_path_append => '/usr/lib/java/local.jar',
+}
+
+collectd::plugin::genericjmx::connection {
+  'jboss':
+    service_url => 'service:jmx:remote+http://127.0.0.1:9990',
+    user        => 'admin'
+    password    => 'admin',
+}
 ```
 
 #### Class: `collectd::plugin::hddtemp`

--- a/manifests/plugin/genericjmx.pp
+++ b/manifests/plugin/genericjmx.pp
@@ -3,12 +3,24 @@ class collectd::plugin::genericjmx (
   $ensure         = 'present',
   $jvmarg         = [],
   $manage_package = undef,
+  Array[String[1]] $class_path_prepend = [],
+  Array[String[1]] $class_path_default = [],
+  Array[String[1]] $class_path_append = [],
 ) {
 
   include ::collectd
   include ::collectd::plugin::java
 
-  $class_path  = "${collectd::java_dir}/collectd-api.jar:${collectd::java_dir}/generic-jmx.jar"
+  if empty($class_path_default) {
+    $_class_path_default = [
+      "${collectd::java_dir}/collectd-api.jar",
+      "${collectd::java_dir}/generic-jmx.jar",
+    ]
+  } else {
+    $_class_path_default = $class_path_default
+  }
+
+  $class_path = join([] + $class_path_prepend + $_class_path_default + $class_path_append, ':')
   $config_file = "${collectd::plugin_conf_dir}/15-genericjmx.conf"
 
   $_manage_package = pick($manage_package, $::collectd::manage_package)

--- a/spec/classes/collectd_plugin_genericjmx_spec.rb
+++ b/spec/classes/collectd_plugin_genericjmx_spec.rb
@@ -50,6 +50,20 @@ describe 'collectd::plugin::genericjmx', type: :class do
             with_content(%r{JVMArg "foo".*JVMArg "bar".*JVMArg "baz"}m)
         end
       end
+  context 'class_path' do
+    let(:params) do
+      {
+        class_path_prepend: ['/usr/lib/java/prepend.jar'],
+        class_path_default: ['/usr/lib/java/default.jar'],
+        class_path_append: ['/usr/lib/java/append.jar']
+      }
+    end
+
+    it 'class_path can be prepended and appended' do
+      is_expected.to contain_concat__fragment('collectd_plugin_genericjmx_conf_header').
+        with_content(%r{JVMArg "-Djava\.class\.path=/usr/lib/java/prepend\.jar:/usr/lib/java/default\.jar:/usr/lib/java/append\.jar"})
+    end
+  end
 
       context 'jvmarg parameter string' do
         let(:params) { { jvmarg: 'bat' } }
@@ -66,7 +80,7 @@ describe 'collectd::plugin::genericjmx', type: :class do
         let(:params) { { jvmarg: [] } }
 
         it 'does not have any jvmarg parameters other than classpath' do
-          is_expected.to contain_concat__fragment('collectd_plugin_genericjmx_conf_header').without_content(%r{(.*JVMArg.*){2,}}m)
+            is_expected.to contain_concat__fragment('collectd_plugin_genericjmx_conf_header').without_content(%r{(.*JVMArg.*){2,}}m)
         end
       end
     end

--- a/templates/plugin/genericjmx/connection.conf.erb
+++ b/templates/plugin/genericjmx/connection.conf.erb
@@ -1,18 +1,18 @@
-<Connection>
-  <% if @host -%>
-  Host "<%= @host %>"
-  <% end -%>
-  ServiceURL "<%= @service_url %>"
-  <% Array(@collect).each do |collect| -%>
-  Collect "<%= collect %>"
-  <% end -%>
-  <% if @user -%>
-  User "<%= @user %>"
-  <% end -%>
-  <% if @password -%>
-  Password "<%= @password %>"
-  <% end -%>
-  <% if @instance_prefix -%>
-  InstancePrefix "<%= @instance_prefix %>"
-  <% end -%>
-</Connection>
+    <Connection>
+<% if @host -%>
+      Host "<%= @host %>"
+<% end -%>
+      ServiceURL "<%= @service_url %>"
+<% Array(@collect).each do |collect| -%>
+      Collect "<%= collect %>"
+<% end -%>
+<% if @user -%>
+      User "<%= @user %>"
+<% end -%>
+<% if @password -%>
+      Password "<%= @password %>"
+<% end -%>
+<% if @instance_prefix -%>
+      InstancePrefix "<%= @instance_prefix %>"
+<% end -%>
+    </Connection>

--- a/templates/plugin/genericjmx/mbean.conf.erb
+++ b/templates/plugin/genericjmx/mbean.conf.erb
@@ -1,29 +1,28 @@
-<MBean "<%= @name %>">
-  ObjectName "<%= @object_name %>"
-  <% if @instance_prefix -%>
-  InstancePrefix "<%= @instance_prefix %>"
-  <% end -%>
-  <% if @instance_from -%>
-    <% Array(@instance_from).each do |instance_from_item| -%>
-  InstanceFrom "<%= instance_from_item %>"
-    <% end -%>
-  <% end -%>
-
-  <% @values.each do |value| -%>
-  <Value>
-    Type "<%= value['mbean_type'] %>"
-    <% if value['instance_prefix'] -%>
-    InstancePrefix "<%= value['instance_prefix'] %>"
-    <% end -%>
-    <% if value['instance_from'] -%>
-      <% Array(value['instance_from']).each do |instance_from_item| -%>
-    InstanceFrom "<%= instance_from_item %>"
-      <% end -%>
-    <% end -%>
-    Table <%= scope.function_str2bool([value['table'] || false ]) ? 'true' : 'false' %>
-    <% Array(value['attribute']).each do |attribute_item| -%>
-    Attribute "<%= attribute_item %>"
-    <% end -%>
-  </Value>
-  <% end -%>
-</MBean>
+    <MBean "<%= @name %>">
+      ObjectName "<%= @object_name %>"
+<% if @instance_prefix -%>
+      InstancePrefix "<%= @instance_prefix %>"
+<% end -%>
+<% if @instance_from -%>
+<% Array(@instance_from).each do |instance_from_item| -%>
+      InstanceFrom "<%= instance_from_item %>"
+<% end -%>
+<% end -%>
+<% @values.each do |value| -%>
+      <Value>
+        Type "<%= value['mbean_type'] %>"
+<% if value['instance_prefix'] -%>
+        InstancePrefix "<%= value['instance_prefix'] %>"
+<% end -%>
+<% if value['instance_from'] -%>
+<% Array(value['instance_from']).each do |instance_from_item| -%>
+        InstanceFrom "<%= instance_from_item %>"
+<% end -%>
+<% end -%>
+        Table <%= scope.function_str2bool([value['table'] || false ]) ? 'true' : 'false' %>
+<% Array(value['attribute']).each do |attribute_item| -%>
+        Attribute "<%= attribute_item %>"
+<% end -%>
+      </Value>
+<% end -%>
+    </MBean>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
I needed to collect metrics from jboss and to do that I needed to add jboss-cli-client.jar to be able to use service::jmx::remote+http://<ip>:<port> type service_url. This would have been possible by redefining class path again, but it is kind of kludgy as then you need to know default class_path. Another way to do this could be to fix current collectd jar files. But for now I think this way should fix most problems.

I've also added another patch to fix indent of generated configuration.