### PR TITLE
Remove interval parameter from write plugins.

### DIFF
--- a/manifests/plugin/write_graphite.pp
+++ b/manifests/plugin/write_graphite.pp
@@ -2,7 +2,6 @@
 class collectd::plugin::write_graphite (
   $carbons           = {},
   $carbon_defaults   = {},
-  $interval          = undef,
   $ensure            = 'present',
   $globals           = false,
 ) {
@@ -14,7 +13,6 @@ class collectd::plugin::write_graphite (
   collectd::plugin { 'write_graphite':
     ensure   => $ensure,
     globals  => $globals,
-    interval => $interval,
   }
 
   # should be loaded after global plugin configuration

--- a/manifests/plugin/write_graphite.pp
+++ b/manifests/plugin/write_graphite.pp
@@ -11,8 +11,8 @@ class collectd::plugin::write_graphite (
   validate_hash($carbons)
 
   collectd::plugin { 'write_graphite':
-    ensure   => $ensure,
-    globals  => $globals,
+    ensure  => $ensure,
+    globals => $globals,
   }
 
   # should be loaded after global plugin configuration

--- a/manifests/plugin/write_http.pp
+++ b/manifests/plugin/write_http.pp
@@ -1,7 +1,6 @@
 # https://collectd.org/wiki/index.php/Plugin:Write_HTTP
 class collectd::plugin::write_http (
   $ensure   = 'present',
-  $interval = undef,
   $urls     = {},
 ) {
 
@@ -12,6 +11,5 @@ class collectd::plugin::write_http (
   collectd::plugin { 'write_http':
     ensure   => $ensure,
     content  => template('collectd/plugin/write_http.conf.erb'),
-    interval => $interval,
   }
 }

--- a/manifests/plugin/write_http.pp
+++ b/manifests/plugin/write_http.pp
@@ -9,7 +9,7 @@ class collectd::plugin::write_http (
   validate_hash($urls)
 
   collectd::plugin { 'write_http':
-    ensure   => $ensure,
-    content  => template('collectd/plugin/write_http.conf.erb'),
+    ensure  => $ensure,
+    content => template('collectd/plugin/write_http.conf.erb'),
   }
 }

--- a/manifests/plugin/write_kafka.pp
+++ b/manifests/plugin/write_kafka.pp
@@ -4,7 +4,6 @@ class collectd::plugin::write_kafka (
   $kafka_hosts = ['localhost:9092'],
   $kafka_port = 9092,
   $topics     = {},
-  $interval   = undef,
 ) {
 
   include ::collectd
@@ -22,6 +21,5 @@ class collectd::plugin::write_kafka (
   collectd::plugin { 'write_kafka':
     ensure   => $ensure,
     content  => template('collectd/plugin/write_kafka.conf.erb'),
-    interval => $interval,
   }
 }

--- a/manifests/plugin/write_kafka.pp
+++ b/manifests/plugin/write_kafka.pp
@@ -19,7 +19,7 @@ class collectd::plugin::write_kafka (
   $kafka_broker = join($real_kafka_hosts, ',')
 
   collectd::plugin { 'write_kafka':
-    ensure   => $ensure,
-    content  => template('collectd/plugin/write_kafka.conf.erb'),
+    ensure  => $ensure,
+    content => template('collectd/plugin/write_kafka.conf.erb'),
   }
 }

--- a/manifests/plugin/write_log.pp
+++ b/manifests/plugin/write_log.pp
@@ -1,7 +1,6 @@
 class collectd::plugin::write_log (
   $format   = 'JSON',
   $ensure   = 'present',
-  $interval = undef,
 ) {
 
   include ::collectd
@@ -11,6 +10,5 @@ class collectd::plugin::write_log (
   collectd::plugin { 'write_log':
     ensure   => $ensure,
     content  => template('collectd/plugin/write_log.conf.erb'),
-    interval => $interval,
   }
 }

--- a/manifests/plugin/write_log.pp
+++ b/manifests/plugin/write_log.pp
@@ -8,7 +8,7 @@ class collectd::plugin::write_log (
   validate_string($format)
 
   collectd::plugin { 'write_log':
-    ensure   => $ensure,
-    content  => template('collectd/plugin/write_log.conf.erb'),
+    ensure  => $ensure,
+    content => template('collectd/plugin/write_log.conf.erb'),
   }
 }

--- a/manifests/plugin/write_riemann.pp
+++ b/manifests/plugin/write_riemann.pp
@@ -35,7 +35,7 @@ class collectd::plugin::write_riemann (
   }
 
   collectd::plugin { 'write_riemann':
-    ensure   => $ensure,
-    content  => template('collectd/plugin/write_riemann.conf.erb'),
+    ensure  => $ensure,
+    content => template('collectd/plugin/write_riemann.conf.erb'),
   }
 }

--- a/manifests/plugin/write_riemann.pp
+++ b/manifests/plugin/write_riemann.pp
@@ -8,7 +8,6 @@ class collectd::plugin::write_riemann (
   $batch            = true,
   $store_rates      = false,
   $always_append_ds = false,
-  $interval         = undef,
   $ttl_factor       = '2.0',
   $check_thresholds = false,
   $tags             = [],
@@ -38,6 +37,5 @@ class collectd::plugin::write_riemann (
   collectd::plugin { 'write_riemann':
     ensure   => $ensure,
     content  => template('collectd/plugin/write_riemann.conf.erb'),
-    interval => $interval,
   }
 }

--- a/manifests/plugin/write_sensu.pp
+++ b/manifests/plugin/write_sensu.pp
@@ -6,7 +6,6 @@ class collectd::plugin::write_sensu (
   $sensu_port       = 3030,
   $store_rates      = false,
   $always_append_ds = false,
-  $interval         = undef,
   $metrics          = false,
   $metrics_handler  = 'example_metric_handler',
   $notifications    = false,
@@ -31,6 +30,5 @@ class collectd::plugin::write_sensu (
   collectd::plugin { 'write_sensu':
     ensure   => $ensure,
     content  => template('collectd/plugin/write_sensu.conf.erb'),
-    interval => $interval,
   }
 }

--- a/manifests/plugin/write_sensu.pp
+++ b/manifests/plugin/write_sensu.pp
@@ -28,7 +28,7 @@ class collectd::plugin::write_sensu (
   }
 
   collectd::plugin { 'write_sensu':
-    ensure   => $ensure,
-    content  => template('collectd/plugin/write_sensu.conf.erb'),
+    ensure  => $ensure,
+    content => template('collectd/plugin/write_sensu.conf.erb'),
   }
 }


### PR DESCRIPTION
Hello, to my knowledge it makes no sense to configure interval for write plugins. Collectd has no concept of interval for write plugins and if configured, it is silently ignored. It is therefore better to remove it from the configuration so that manifests don't give a false impression that this parameter does something useful.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
