### PR TITLE
Add support for Chain6 directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,7 +885,10 @@ class { 'collectd::plugin::ipmi':
 class { 'collectd::plugin::iptables':
   chains  => {
     'nat'    => 'In_SSH',
-    'filter' => 'HTTP'
+    'filter' => 'HTTP',
+  },
+  chains6 => {
+    'filter' => 'HTTP6',
   },
 }
 ```

--- a/examples/plugins/iptables.pp
+++ b/examples/plugins/iptables.pp
@@ -6,7 +6,6 @@ class { '::collectd::plugin::iptables':
     'filter' => 'HTTP',
   },
   chains6 => {
-    'nat'    => 'In6_SSH',
     'filter' => 'HTTP6',
   },
 }

--- a/examples/plugins/iptables.pp
+++ b/examples/plugins/iptables.pp
@@ -1,8 +1,12 @@
 include ::collectd
 
 class { '::collectd::plugin::iptables':
-  chains => {
+  chains  => {
     'nat'    => 'In_SSH',
     'filter' => 'HTTP',
+  },
+  chains6 => {
+    'nat'    => 'In6_SSH',
+    'filter' => 'HTTP6',
   },
 }

--- a/manifests/plugin/iptables.pp
+++ b/manifests/plugin/iptables.pp
@@ -4,6 +4,7 @@ class collectd::plugin::iptables (
   $ensure_package = 'present',
   $manage_package = undef,
   $chains         = {},
+  $chains6        = {},
   $interval       = undef,
 ) {
 
@@ -12,6 +13,7 @@ class collectd::plugin::iptables (
   $_manage_package = pick($manage_package, $::collectd::manage_package)
 
   validate_hash($chains)
+  validate_hash($chains6)
 
   if $::osfamily == 'RedHat' {
     if $_manage_package {

--- a/spec/classes/collectd_plugin_iptables_spec.rb
+++ b/spec/classes/collectd_plugin_iptables_spec.rb
@@ -26,16 +26,16 @@ describe 'collectd::plugin::iptables', type: :class do
         end
       end
 
-      context ':ensure => present and :chains6 => { \'nat\' => \'In6_SSH\' }' do
+      context ':ensure => present and :chains6 => { \'filter\' => \'In6_SSH\' }' do
         let :params do
-          { chains6: { 'nat' => 'In6_SSH' } }
+          { chains6: { 'filter' => 'In6_SSH' } }
         end
 
         it "Will create #{options[:plugin_conf_dir]}/10-iptables.conf" do
           is_expected.to contain_file('iptables.load').with(
             ensure: 'present',
             path: "#{options[:plugin_conf_dir]}/10-iptables.conf",
-            content: %r{Chain6 nat In6_SSH}
+            content: %r{Chain6 filter In6_SSH}
           )
         end
       end

--- a/spec/classes/collectd_plugin_iptables_spec.rb
+++ b/spec/classes/collectd_plugin_iptables_spec.rb
@@ -26,6 +26,20 @@ describe 'collectd::plugin::iptables', type: :class do
         end
       end
 
+      context ':ensure => present and :chains6 => { \'nat\' => \'In6_SSH\' }' do
+        let :params do
+          { chains6: { 'nat' => 'In6_SSH' } }
+        end
+
+        it "Will create #{options[:plugin_conf_dir]}/10-iptables.conf" do
+          is_expected.to contain_file('iptables.load').with(
+            ensure: 'present',
+            path: "#{options[:plugin_conf_dir]}/10-iptables.conf",
+            content: %r{Chain6 nat In6_SSH}
+          )
+        end
+      end
+
       context ':ensure => present and :chains has two chains from the same table' do
         let :params do
           { chains: {

--- a/templates/plugin/iptables.conf.erb
+++ b/templates/plugin/iptables.conf.erb
@@ -1,9 +1,16 @@
-<% if @chains -%>
 <Plugin iptables>
+<% if @chains -%>
 <%   @chains.each_pair do |table,chains|
        Array(chains).each do |chain| -%>
   Chain <%= table %> <%= chain %>
 <%     end -%>
 <%   end -%>
-</Plugin>
 <% end -%>
+<% if @chains6 -%>
+<%   @chains6.each_pair do |table6,chains6|
+       Array(chains6).each do |chain6| -%>
+  Chain6 <%= table6 %> <%= chain6 %>
+<%     end -%>
+<%   end -%>
+<% end -%>
+</Plugin>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->

This PR is related to issue #693 and adds support for the `Chain6` configuration directive of the `iptables` Collectd plugin.

Closes GH-693