### PR TITLE
plugin::apache - Use data types

### DIFF
--- a/manifests/plugin/apache/instance.pp
+++ b/manifests/plugin/apache/instance.pp
@@ -1,12 +1,12 @@
 # https://collectd.org/wiki/index.php/Plugin:Apache
 define collectd::plugin::apache::instance (
-  $url,
-  $ensure = present,
-  $user = undef,
-  $password = undef,
-  $verifypeer = undef,
-  $verifyhost = undef,
-  $cacert = undef,
+  Stdlib::Httpurl $url,
+  String $ensure                         = present,
+  Optional[String] $user                 = undef,
+  Optional[String] $password             = undef,
+  Optional[Boolean] $verifypeer          = undef,
+  Optional[Boolean] $verifyhost          = undef,
+  Optional[Stdlib::Absolutepath] $cacert = undef,
 ) {
   include ::collectd
   include ::collectd::plugin::apache

--- a/metadata.json
+++ b/metadata.json
@@ -92,7 +92,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 5.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
- Use data types for the Apache plugin
- Bump up the puppetlabs-stdlib version so that Stdlib::Httpurl can be
  used