### PR TITLE
Bump puppetlabs-stdlib to 4.13.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -92,7 +92,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 5.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
Bump up the puppetlabs-stdlib version so that the Stdlib::Httpurl data type can be used