### PR TITLE
Make it possible to add processes one by one

### DIFF
--- a/manifests/plugin/processes.pp
+++ b/manifests/plugin/processes.pp
@@ -15,14 +15,8 @@ class collectd::plugin::processes (
     interval => $interval,
   }
 
-  if ( $processes or $process_matches ) {
-    $process_config_ensure = 'present'
-  } else {
-    $process_config_ensure = absent
-  }
-
   concat { "${collectd::plugin_conf_dir}/processes-config.conf":
-    ensure         => $process_config_ensure,
+    ensure         => $ensure,
     mode           => '0640',
     owner          => 'root',
     group          => $collectd::root_group,


### PR DESCRIPTION
This fixes a old silent bug that was created by
395036ae332c56800481459fef9f1691a484de9f

This commit makes it possible define single process again like:
collectd::plugin::processes::process { 'collectd' : }
Without also having to create:
class { 'collectd::plugin::processes':
  processes => [ 'foo', 'bar' }

This fixes the issues #652 and #595.