### PR TITLE
collectd::plugin::exec::cmd clean up

### DIFF
--- a/manifests/plugin/exec/cmd.pp
+++ b/manifests/plugin/exec/cmd.pp
@@ -1,22 +1,12 @@
 define collectd::plugin::exec::cmd (
-  $user,
-  $group,
+  String $user,
+  String $group,
   Array $exec              = [],
   Array $notification_exec = [],
-  $ensure                  = 'present',
 ) {
 
   include ::collectd
   include ::collectd::plugin::exec
-
-  $conf_dir = $collectd::plugin_conf_dir
-
-  # This is deprecated file naming ensuring old style file removed, and should be removed in next major relese
-  file { "${name}.load-deprecated":
-    ensure => absent,
-    path   => "${conf_dir}/${name}.conf",
-  }
-  # End deprecation
 
   concat::fragment{ "collectd_plugin_exec_conf_${title}":
     order   => '50', # somewhere between header and footer


### PR DESCRIPTION
- Add data types for user and group
- Remove $ensure as it is currently unused
- Remove long deprecated handling of old file path