### PR TITLE
plugin::filecount::directory - data type changes

### DIFF
--- a/manifests/plugin/filecount/directory.pp
+++ b/manifests/plugin/filecount/directory.pp
@@ -1,21 +1,19 @@
 # https://collectd.org/wiki/index.php/Plugin:FileCount
 define collectd::plugin::filecount::directory (
-  $ensure                    = 'present',
-  $instance                  = $name,
-  Stdlib::Absolutepath $path = undef,
-  $pattern                   = undef,
-  $mtime                     = undef,
-  $size                      = undef,
-  $recursive                 = undef,
-  $includehidden             = undef
+  Stdlib::Absolutepath $path,
+  Enum['present', 'absent'] $ensure = 'present',
+  String $instance                  = $name,
+  Optional[String] $pattern         = undef,
+  Optional[String] $mtime           = undef,
+  Optional[String] $size            = undef,
+  Optional[Boolean] $recursive      = undef,
+  Optional[Boolean] $includehidden  = undef,
 ) {
 
   include ::collectd
   include ::collectd::plugin::filecount
 
-  $conf_dir = $collectd::plugin_conf_dir
-
-  file { "${conf_dir}/15-filecount-${name}.conf":
+  file { "${collectd::plugin_conf_dir}/15-filecount-${name}.conf":
     ensure  => $ensure,
     mode    => '0640',
     owner   => 'root',


### PR DESCRIPTION
- Add more data types
- $path is a required parameter, not optional
- Also be explict with $collectd::plugin_conf_dir reference