### PR TITLE
plugin::genericjmx::connection - Use data types

### DIFF
--- a/manifests/plugin/genericjmx/connection.pp
+++ b/manifests/plugin/genericjmx/connection.pp
@@ -1,11 +1,11 @@
 # https://collectd.org/wiki/index.php/Plugin:GenericJMX
 define collectd::plugin::genericjmx::connection (
-  $collect,
-  $service_url,
-  $host            = undef,
-  $user            = undef,
-  $password        = undef,
-  $instance_prefix = undef,
+  Array $collect,
+  String $service_url,
+  Optional[String] $host            = undef,
+  Optional[String] $user            = undef,
+  Optional[String] $password        = undef,
+  Optional[String] $instance_prefix = undef,
 ) {
 
   include ::collectd

--- a/spec/defines/collectd_plugin_genericjmx_connection_spec.rb
+++ b/spec/defines/collectd_plugin_genericjmx_connection_spec.rb
@@ -51,7 +51,7 @@ describe 'collectd::plugin::genericjmx::connection', type: :define do
         it { is_expected.to contain_concat__fragment(concat_fragment_name).with_content(%r{Host "bar\.example\.com"}) }
       end
 
-      context 'collect array' do
+      context 'with a collect array of multiple values' do
         let(:params) do
           default_params.merge(collect: %w[foo bar baz])
         end
@@ -59,9 +59,9 @@ describe 'collectd::plugin::genericjmx::connection', type: :define do
         it { is_expected.to contain_concat__fragment(concat_fragment_name).with_content(%r{Collect "foo".*Collect "bar".*Collect "baz"}m) }
       end
 
-      context 'collect string' do
+      context 'with a collect array of one value' do
         let(:params) do
-          default_params.merge(collect: 'bat')
+          default_params.merge(collect: %w[bat])
         end
 
         it { is_expected.to contain_concat__fragment(concat_fragment_name).with_content(%r{Collect "bat"}) }

--- a/templates/plugin/genericjmx/connection.conf.erb
+++ b/templates/plugin/genericjmx/connection.conf.erb
@@ -3,7 +3,7 @@
   Host "<%= @host %>"
   <% end -%>
   ServiceURL "<%= @service_url %>"
-  <% Array(@collect).each do |collect| -%>
+  <% @collect.each do |collect| -%>
   Collect "<%= collect %>"
   <% end -%>
   <% if @user -%>


### PR DESCRIPTION
- Breaking change: $collect now only accepts an array, not either an array or string