### PR TITLE
plugin::genericjmx::mbean - Use data types

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,7 +817,7 @@ collectd::plugin::genericjmx::mbean {
   'garbage_collector':
     object_name     => 'java.lang:type=GarbageCollector,*',
     instance_prefix => 'gc-',
-    instance_from   => 'name',
+    instance_from   => ['name'],
     values          => [
       {
         mbean_type => 'invocations',

--- a/manifests/plugin/genericjmx/mbean.pp
+++ b/manifests/plugin/genericjmx/mbean.pp
@@ -1,9 +1,9 @@
 # https://collectd.org/wiki/index.php/Plugin:GenericJMX
 define collectd::plugin::genericjmx::mbean (
-  $object_name,
+  String $object_name,
   Array $values,
-  $instance_prefix = undef,
-  $instance_from   = undef,
+  Optional[String] $instance_prefix = undef,
+  Array $instance_from              = [],
 ) {
 
   include ::collectd

--- a/spec/defines/collectd_plugin_genericjmx_mbean_spec.rb
+++ b/spec/defines/collectd_plugin_genericjmx_mbean_spec.rb
@@ -41,7 +41,7 @@ describe 'collectd::plugin::genericjmx::mbean', type: :define do
         it { is_expected.to contain_concat__fragment(concat_fragment_name).with_content(%r{InstancePrefix "baz"}) }
       end
 
-      context 'instance_from array' do
+      context 'with an instance_from array of multiple values' do
         let(:params) do
           default_params.merge(instance_from: %w[foo bar baz])
         end
@@ -49,9 +49,9 @@ describe 'collectd::plugin::genericjmx::mbean', type: :define do
         it { is_expected.to contain_concat__fragment(concat_fragment_name).with_content(%r{InstanceFrom "foo"\s+InstanceFrom "bar"\s+InstanceFrom "baz"}) }
       end
 
-      context 'instance_from string' do
+      context 'with an instance_from array of one value' do
         let(:params) do
-          default_params.merge(instance_from: 'bat')
+          default_params.merge(instance_from: %w[bat])
         end
 
         it { is_expected.to contain_concat__fragment(concat_fragment_name).with_content(%r{InstanceFrom "bat"}) }
@@ -95,7 +95,7 @@ describe 'collectd::plugin::genericjmx::mbean', type: :define do
           it { is_expected.to contain_concat__fragment(concat_fragment_name).without_content(%r{InstanceFrom}) }
         end
 
-        context 'value section instance_from array' do
+        context 'value section instance_from array, multiple values' do
           let(:params) do
             default_params.merge(values: [default_values_args.merge('instance_from' => %w[alice bob carol])])
           end
@@ -106,9 +106,9 @@ describe 'collectd::plugin::genericjmx::mbean', type: :define do
           it { is_expected.to contain_concat__fragment(concat_fragment_name).without_content(%r{InstancePrefix}) }
         end
 
-        context 'value section instance_from string' do
+        context 'value section instance_from array, single value' do
           let(:params) do
-            default_params.merge(values: [default_values_args.merge('instance_from' => 'dave')])
+            default_params.merge(values: [default_values_args.merge('instance_from' => %w[dave])])
           end
 
           it { is_expected.to contain_concat__fragment(concat_fragment_name).with_content(%r{InstanceFrom "dave"}) }

--- a/templates/plugin/genericjmx/mbean.conf.erb
+++ b/templates/plugin/genericjmx/mbean.conf.erb
@@ -3,10 +3,8 @@
   <% if @instance_prefix -%>
   InstancePrefix "<%= @instance_prefix %>"
   <% end -%>
-  <% if @instance_from -%>
-    <% Array(@instance_from).each do |instance_from_item| -%>
+  <% @instance_from.each do |instance_from_item| -%>
   InstanceFrom "<%= instance_from_item %>"
-    <% end -%>
   <% end -%>
 
   <% @values.each do |value| -%>
@@ -16,7 +14,7 @@
     InstancePrefix "<%= value['instance_prefix'] %>"
     <% end -%>
     <% if value['instance_from'] -%>
-      <% Array(value['instance_from']).each do |instance_from_item| -%>
+      <% value['instance_from'].each do |instance_from_item| -%>
     InstanceFrom "<%= instance_from_item %>"
       <% end -%>
     <% end -%>


### PR DESCRIPTION
- Breaking change: $instance_from can now only be an array, not array or string