### PR TITLE
Escape json posts in curl_json plugin

### DIFF
--- a/spec/classes/collectd_plugin_fscache_spec.rb
+++ b/spec/classes/collectd_plugin_fscache_spec.rb
@@ -13,6 +13,7 @@ describe 'collectd::plugin::fscache', type: :class do
     let :facts do
       {
         osfamily: 'FreeBSD',
+        operatingsystem: 'FreeBSD',
         os: { family: 'FreeBSD' },
         collectd_version: '4.7.0',
         operatingsystemmajrelease: '7',
@@ -31,6 +32,7 @@ describe 'collectd::plugin::fscache', type: :class do
     let :facts do
       {
         osfamily: 'FreeBSD',
+        operatingsystem: 'FreeBSD',
         os: { family: 'FreeBSD' },
         collectd_version: '4.7.0',
         operatingsystemmajrelease: '7',

--- a/spec/defines/collectd_plugin_curl_json_spec.rb
+++ b/spec/defines/collectd_plugin_curl_json_spec.rb
@@ -28,8 +28,8 @@ describe 'collectd::plugin::curl_json', type: :define do
           verifypeer: 'false',
           verifyhost: 'false',
           cacert: '/path/to/ca.crt',
-          header: 'Accept: application/json',
-          post: '{secret: \"mysecret\"}',
+          header: 'Content-Type: application/x-www-form-urlencoded',
+          post: 'secret=mysecret&foo=bar',
           timeout: 1000,
           keys: {
             'message_stats/publish' => {
@@ -106,8 +106,8 @@ describe 'collectd::plugin::curl_json', type: :define do
         it { is_expected.to contain_file(filename).with_content(%r{VerifyPeer false}) }
         it { is_expected.to contain_file(filename).with_content(%r{VerifyHost false}) }
         it { is_expected.to contain_file(filename).with_content(%r{CACert "/path/to/ca.crt"}) }
-        it { is_expected.to contain_file(filename).with_content(%r{Header "Accept: application/json"}) }
-        it { is_expected.to contain_file(filename).with_content(%r|Post "{secret: \\"mysecret\\"}"|) }
+        it { is_expected.to contain_file(filename).with_content(%r{Header "Content-Type: application/x-www-form-urlencoded"}) }
+        it { is_expected.to contain_file(filename).with_content(%r{Post "secret=mysecret&foo=bar"}) }
         it { is_expected.to contain_file(filename).without_content(%r{Timeout}) }
         it { is_expected.to contain_file(filename).with_content(%r{Key "message_stats/publish">}) }
         it { is_expected.to contain_file(filename).with_content(%r{Type "gauge"}) }
@@ -139,8 +139,8 @@ describe 'collectd::plugin::curl_json', type: :define do
         it { is_expected.to contain_file(filename).with_content(%r{VerifyPeer false}) }
         it { is_expected.to contain_file(filename).with_content(%r{VerifyHost false}) }
         it { is_expected.to contain_file(filename).with_content(%r{CACert "/path/to/ca.crt"}) }
-        it { is_expected.to contain_file(filename).with_content(%r{Header "Accept: application/json"}) }
-        it { is_expected.to contain_file(filename).with_content(%r|Post "{secret: \\"mysecret\\"}"|) }
+        it { is_expected.to contain_file(filename).with_content(%r{Header "Content-Type: application/x-www-form-urlencoded"}) }
+        it { is_expected.to contain_file(filename).with_content(%r{Post "secret=mysecret&foo=bar"}) }
         it { is_expected.to contain_file(filename).with_content(%r{Timeout 1000}) }
         it { is_expected.to contain_file(filename).with_content(%r{Key "message_stats/publish">}) }
         it { is_expected.to contain_file(filename).with_content(%r{Type "gauge"}) }
@@ -172,8 +172,8 @@ describe 'collectd::plugin::curl_json', type: :define do
         it { is_expected.to contain_file(filename).with_content(%r{VerifyPeer false}) }
         it { is_expected.to contain_file(filename).with_content(%r{VerifyHost false}) }
         it { is_expected.to contain_file(filename).with_content(%r{CACert "/path/to/ca.crt"}) }
-        it { is_expected.to contain_file(filename).with_content(%r{Header "Accept: application/json"}) }
-        it { is_expected.to contain_file(filename).with_content(%r|Post "{secret: \\"mysecret\\"}"|) }
+        it { is_expected.to contain_file(filename).with_content(%r{Header "Content-Type: application/x-www-form-urlencoded"}) }
+        it { is_expected.to contain_file(filename).with_content(%r{Post "secret=mysecret&foo=bar"}) }
         it { is_expected.to contain_file(filename).with_content(%r{Timeout 1000}) }
         it { is_expected.to contain_file(filename).with_content(%r{Key "message_stats/publish">}) }
         it { is_expected.to contain_file(filename).with_content(%r{Type "gauge"}) }
@@ -210,6 +210,28 @@ describe 'collectd::plugin::curl_json', type: :define do
         it { is_expected.to contain_file(filename).with_content(%r{Key "message_stats/publish">}) }
         it { is_expected.to contain_file(filename).with_content(%r{Type "gauge"}) }
         it { is_expected.to contain_file(filename).with_content(%r{Instance "overview"}) }
+      end
+
+      context 'json posts' do
+        let(:post) do
+          {
+            'type' => 'read',
+            'mbean' => 'Catalina:name="http-nio-127.0.0.1-8080",type=GlobalRequestProcessor'
+          }.to_json
+        end
+
+        let(:params) do
+          my_params.merge(header: 'Content-Type: application/json', post: post)
+        end
+
+        let :facts do
+          facts.merge(collectd_version: '5.6.0')
+        end
+
+        it { is_expected.to contain_file(filename).with_content(%r{Header "Content-Type: application/json"}) }
+
+        # In the regex below, we have to escape the backslashes in "{\"type\":\"read\",\"mbean\":\"Catalina:name=\\\"http-nio-127.0.0.1-8080\\\",type=GlobalRequestProcessor\"}"
+        it { is_expected.to contain_file(filename).with_content(%r|Post "{\\"type\\":\\"read\\",\\"mbean\\":\\"Catalina:name=\\\\\\"http-nio-127\.0\.0\.1-8080\\\\\\",type=GlobalRequestProcessor\\"}"|) }
       end
     end
   end

--- a/templates/curl_json.conf.erb
+++ b/templates/curl_json.conf.erb
@@ -40,8 +40,20 @@ LoadPlugin "curl_json"
 <% if @header -%>
     Header "<%= @header %>"
 <% end -%>
+<%-
+  def valid_json?(json)
+    JSON.parse(json)
+    return true
+  rescue JSON::ParserError
+    return false
+  end
+-%>
 <% unless @post.nil? -%>
+<% if valid_json?(@post) -%>
+    Post "<%= @post.gsub('\\"','\\\\\\\\\"').gsub!(%r{(?<!\\)"},'\"') %>"
+<% else -%>
     Post "<%= @post %>"
+<% end -%>
 <% end -%>
 <% end -%>
 <% if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.5']) >= 0) -%>


### PR DESCRIPTION
*If* in the 'post' parameter we've been given a valid json string, it
definately won't work unless we do some escaping of double quotes.

If any strings in the JSON also contain (correctly escaped) double
quotes, even more backslashes are needed.

eg. The following JSON

```
{"param1":"something with a double quote \" in it"}
```

Would end up in the config file as

```
Post "{\"param1\":\"something with a double quote \\\" in it\"}"
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
