### PR TITLE
feat: add package_keyserver parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ On CentOS that will be EPEL:
 On Ubuntu that'll be the CollectD PPA:
 * https://launchpad.net/~collectd/+archive/ubuntu/collectd-5.5
 
+### Public key keyserver
+In case you need to change the server where to download the public key from for
+whatever reason (AKA: server is down) you can use the parameter
+`$package_keyserver`
+
 ### CI Packages
 
 Recently, Collectd CI packages are also avaliable from the CI repo

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class collectd (
   $minimum_version                                                    = $collectd::params::minimum_version,
   $package_ensure                                                     = $collectd::params::package_ensure,
   $package_install_options                                            = $collectd::params::package_install_options,
+  String $package_keyserver                                           = $collectd::params::package_keyserver,
   $package_name                                                       = $collectd::params::package_name,
   $package_provider                                                   = $collectd::params::package_provider,
   $plugin_conf_dir                                                    = $collectd::params::plugin_conf_dir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,7 @@ class collectd::params {
   $package_install_options   = undef
   $plugin_conf_dir_mode      = '0750'
   $ci_package_repo           = undef
+  $package_keyserver         = 'keyserver.ubuntu.com'
 
   case $facts['kernel'] {
     'OpenBSD': { $has_wordexp = false }

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -9,7 +9,7 @@ class collectd::repo::debian {
       repos    => "collectd-${$::collectd::ci_package_repo}",
       key      => {
         'id'     => 'F806817DC3F5EA417F9FA2963994D24FB8543576',
-        'server' => 'pgp.mit.edu',
+        'server' => $::collectd::package_keyserver,
       },
     }
   } else {
@@ -22,7 +22,7 @@ class collectd::repo::debian {
         repos    => 'main',
         key      => {
           'id'     => '7543C08D555DC473B9270ACDAF7ECBB3476ACEB3',
-          'server' => 'keyserver.ubuntu.com',
+          'server' => $::collectd::package_keyserver,
         },
       }
     }

--- a/spec/classes/collectd_init_spec.rb
+++ b/spec/classes/collectd_init_spec.rb
@@ -199,25 +199,51 @@ describe 'collectd', type: :class do
           end
 
           context 'and ci_package_repo set to a version' do
-            let(:params) do
-              {
-                manage_repo: true,
-                ci_package_repo: '5.6'
-              }
-            end
+            context 'and package_keyserver is default' do
+              let(:params) do
+                {
+                  manage_repo: true,
+                  ci_package_repo: '5.6'
+                }
+              end
 
-            if facts[:osfamily] == 'RedHat'
-              it { is_expected.to contain_yumrepo('collectd-ci').with_gpgkey('https://pkg.ci.collectd.org/pubkey.asc').with_baseurl("https://pkg.ci.collectd.org/rpm/collectd-5.6/epel-#{facts[:operatingsystemmajrelease]}-x86_64") }
+              if facts[:osfamily] == 'RedHat'
+                it { is_expected.to contain_yumrepo('collectd-ci').with_gpgkey('https://pkg.ci.collectd.org/pubkey.asc').with_baseurl("https://pkg.ci.collectd.org/rpm/collectd-5.6/epel-#{facts[:operatingsystemmajrelease]}-x86_64") }
+              end
+              if facts[:osfamily] == 'Debian'
+                it do
+                  is_expected.to contain_apt__source('collectd-ci').
+                    with_location('https://pkg.ci.collectd.org/deb/').
+                    with_key(
+                      'id'     => 'F806817DC3F5EA417F9FA2963994D24FB8543576',
+                      'server' => 'keyserver.ubuntu.com'
+                    ).
+                    with_repos('collectd-5.6')
+                end
+              end
             end
-            if facts[:osfamily] == 'Debian'
-              it do
-                is_expected.to contain_apt__source('collectd-ci').
-                  with_location('https://pkg.ci.collectd.org/deb/').
-                  with_key(
-                    'id'     => 'F806817DC3F5EA417F9FA2963994D24FB8543576',
-                    'server' => 'pgp.mit.edu'
-                  ).
-                  with_repos('collectd-5.6')
+            context 'and package_keyserver is set' do
+              let(:params) do
+                {
+                  manage_repo: true,
+                  ci_package_repo: '5.6',
+                  package_keyserver: 'pgp.mit.edu'
+                }
+              end
+
+              if facts[:osfamily] == 'RedHat'
+                it { is_expected.to contain_yumrepo('collectd-ci').with_gpgkey('https://pkg.ci.collectd.org/pubkey.asc').with_baseurl("https://pkg.ci.collectd.org/rpm/collectd-5.6/epel-#{facts[:operatingsystemmajrelease]}-x86_64") }
+              end
+              if facts[:osfamily] == 'Debian'
+                it do
+                  is_expected.to contain_apt__source('collectd-ci').
+                    with_location('https://pkg.ci.collectd.org/deb/').
+                    with_key(
+                      'id'     => 'F806817DC3F5EA417F9FA2963994D24FB8543576',
+                      'server' => 'pgp.mit.edu'
+                    ).
+                    with_repos('collectd-5.6')
+                end
               end
             end
           end


### PR DESCRIPTION
We have noticed sometimes puppet fails to provision our servers due to failing connectivity to pgp.mit.edu.

This MR allows you to choose the keyserver in case such an event happens.

Thanks to [Erasys GmbH](https://www.erasys.de/)