### PR TITLE
Fix: curl_json broken when facter version < 3

### DIFF
--- a/manifests/plugin/curl_json.pp
+++ b/manifests/plugin/curl_json.pp
@@ -25,7 +25,12 @@ define collectd::plugin::curl_json (
 
   if $_manage_package {
     if $facts['os']['family'] == 'Debian' {
-      $libyajl_package = $facts['os']['distro']['codename'] ? {
+      if $facts['facterversion'] >= '3'  {
+        $codename = $facts['os']['distro']['codename']
+      } else {
+        $codename = $facts['os']['lsb']['distcodename']
+      }
+      $libyajl_package = $codename ? {
         'precise' => 'libyajl1',
         default   => 'libyajl2'
       }


### PR DESCRIPTION
Fix puppet agent error : Error: Could not retrieve catalog from remote
server: Error 500 on SERVER: Server Error: Evaluation Error: Error while
evaluating a Resource Statement, Evaluation Error: Operator '[]' is not
applicable to an Undef Value.

In facter "os" map, the "distro" key does not exists before facter 3.0
