### PR TITLE
Fix the MySQL plugin's WsrepStats parameter

### DIFF
--- a/spec/defines/collectd_plugin_mysql_database_spec.rb
+++ b/spec/defines/collectd_plugin_mysql_database_spec.rb
@@ -30,6 +30,39 @@ describe 'collectd::plugin::mysql::database', type: :define do
           is_expected.to contain_file('test.conf').without_content(%r{Socket})
         end
       end
+
+      context 'without wsrepstats enabled' do
+        let(:title) { 'test' }
+        let :params do
+          { wsrepstats: :undef }
+        end
+
+        it "Will create #{options[:plugin_conf_dir]}/mysql-test.conf" do
+          is_expected.to contain_file('test.conf').without_content(%r{WsrepStats})
+        end
+      end
+
+      context 'with wsrepstats enabled' do
+        let(:title) { 'test' }
+        let :params do
+          { wsrepstats: true }
+        end
+
+        it "Will create #{options[:plugin_conf_dir]}/mysql-test.conf" do
+          is_expected.to contain_file('test.conf').with_content(%r{WsrepStats true})
+        end
+      end
+
+      context 'with wsrepstats disabled' do
+        let(:title) { 'test' }
+        let :params do
+          { wsrepstats: false }
+        end
+
+        it "Will create #{options[:plugin_conf_dir]}/mysql-test.conf" do
+          is_expected.to contain_file('test.conf').with_content(%r{WsrepStats false})
+        end
+      end
     end
   end
 end

--- a/templates/mysql-database.conf.erb
+++ b/templates/mysql-database.conf.erb
@@ -20,7 +20,7 @@
     InnodbStats <%= @innodbstats %>
 <%- end -%>
 <%- if not @wsrepstats.nil? -%>
-    WsrepStatsStats <%= @WsrepStats %>
+    WsrepStats <%= @wsrepstats %>
 <%- end -%>
 <%- end -%>
 <%- if not @slavenotifications.nil? -%>


### PR DESCRIPTION
This fixes voxpupuli/puppet-collectd#757 by correcting both the parameter name and the variable name in `templates/mysql-database.conf.erb`.