### PR TITLE
feat: use Stdlib::Fqdn type for package_keyserver

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@ class collectd (
   $minimum_version                                                    = $collectd::params::minimum_version,
   $package_ensure                                                     = $collectd::params::package_ensure,
   $package_install_options                                            = $collectd::params::package_install_options,
-  String $package_keyserver                                           = $collectd::params::package_keyserver,
+  Stdlib::Fqdn $package_keyserver                                     = $collectd::params::package_keyserver,
   $package_name                                                       = $collectd::params::package_name,
   $package_provider                                                   = $collectd::params::package_provider,
   $plugin_conf_dir                                                    = $collectd::params::plugin_conf_dir,

--- a/metadata.json
+++ b/metadata.json
@@ -91,7 +91,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.25.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
As discussed #746 here is a PR to fix the data type for package_keyserver.

This is cannot be merged until there is a release of puppetlabs-stdlib that include the proper datatype (it's only on master right now)
