### PR TITLE
Add intel_pmu plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ documentation for each plugin for configurable attributes.
 * `genericjmx` (see [collectd::plugin::genericjmx](#class-collectdplugingenericjmx)
   below)
 * `hddtemp` (see [collectd::plugin::hddtemp](#class-collectdpluginhddtemp) below)
+* `intel_pmu` (see [collectd::plugin::intel_pmu](#class-collectdpluginintel_pmu) below)
 * `interface` (see [collectd::plugin::interface](#class-collectdplugininterface)
   below)
 * `ipmi` (see [collectd::plugin::ipmi](#class-collectdpluginipmi) below)
@@ -852,6 +853,15 @@ collectd::plugin::genericjmx::connection {
 class { 'collectd::plugin::hddtemp':
   host => '127.0.0.1',
   port => 7634,
+}
+```
+
+#### Class: `collectd::plugin::intel_pmu`
+```puppet
+class { 'collectd::plugin::intel_pmu':
+  report_hardware_cache_events => true,
+  report_kernel_pmu_events => true,
+  report_software_events => true,
 }
 ```
 

--- a/manifests/plugin/intel_pmu.pp
+++ b/manifests/plugin/intel_pmu.pp
@@ -9,7 +9,7 @@ class collectd::plugin::intel_pmu (
 ) {
 
   include ::collectd
-  
+
   if $hardware_events and $event_list == undef {
     fail('event_list must be defined if hardware_events is used.')
   }

--- a/manifests/plugin/intel_pmu.pp
+++ b/manifests/plugin/intel_pmu.pp
@@ -1,0 +1,15 @@
+# https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_intel_pmu
+class collectd::plugin::intel_pmu (
+  Enum['present', 'absent'] $ensure                       = 'present',
+  Optional[Boolean]         $report_hardware_cache_events = undef,
+  Optional[Boolean]         $report_kernel_pmu_events     = undef,
+  Optional[Boolean]         $report_software_events       = undef,
+  Optional[String]          $event_list                   = undef,
+  Optional[Array[String]]   $hardware_events              = undef,
+) {
+  include ::collectd
+  collectd::plugin { 'intel_pmu':
+    ensure  => $ensure,
+    content => template('collectd/plugin/intel_pmu.conf.erb'),
+  }
+}

--- a/manifests/plugin/intel_pmu.pp
+++ b/manifests/plugin/intel_pmu.pp
@@ -1,13 +1,19 @@
 # https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_intel_pmu
 class collectd::plugin::intel_pmu (
   Enum['present', 'absent'] $ensure                       = 'present',
-  Optional[Boolean]         $report_hardware_cache_events = undef,
-  Optional[Boolean]         $report_kernel_pmu_events     = undef,
-  Optional[Boolean]         $report_software_events       = undef,
+  Optional[Boolean]         $report_hardware_cache_events = false,
+  Optional[Boolean]         $report_kernel_pmu_events     = false,
+  Optional[Boolean]         $report_software_events       = false,
   Optional[String]          $event_list                   = undef,
   Optional[Array[String]]   $hardware_events              = undef,
 ) {
+
   include ::collectd
+  
+  if $hardware_events and $event_list == undef {
+    fail('event_list must be defined if hardware_events is used.')
+  }
+
   collectd::plugin { 'intel_pmu':
     ensure  => $ensure,
     content => template('collectd/plugin/intel_pmu.conf.erb'),

--- a/spec/classes/collectd_plugin_intel_pmu_spec.rb
+++ b/spec/classes/collectd_plugin_intel_pmu_spec.rb
@@ -93,8 +93,8 @@ describe 'collectd::plugin::intel_pmu', type: :class do
           { hardware_events: ['L2_RQSTS.CODE_RD_HIT', 'L2_RQSTS.CODE_RD_MISS'] }
         end
 
-        it "Will raise error" do
-          is_expected.to compile.and_raise_error(/event_list must be defined if hardware_events is used/)
+        it 'Will raise error' do
+          is_expected.to compile.and_raise_error(%r{event_list must be defined if hardware_events is used})
         end
       end
     end

--- a/spec/classes/collectd_plugin_intel_pmu_spec.rb
+++ b/spec/classes/collectd_plugin_intel_pmu_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::intel_pmu', type: :class do
+  on_supported_os(test_on).each do |os, facts|
+    context "on #{os} " do
+      let :facts do
+        facts
+      end
+
+      options = os_specific_options(facts)
+      context ':ensure => present, default params' do
+        it "Will create #{options[:plugin_conf_dir]}/10-intel_pmu.conf" do
+          is_expected.to contain_file('intel_pmu.load').with(
+            ensure: 'present',
+            path: "#{options[:plugin_conf_dir]}/10-intel_pmu.conf"
+          )
+        end
+      end
+
+      context ':ensure => present and :report_hardware_cache_events => true' do
+        let :params do
+          { report_hardware_cache_events: true }
+        end
+
+        it "Will create #{options[:plugin_conf_dir]}/10-intel_pmu.conf" do
+          is_expected.to contain_file('intel_pmu.load').with(
+            ensure: 'present',
+            path: "#{options[:plugin_conf_dir]}/10-intel_pmu.conf",
+            content: %r{ReportHardwareCacheEvents "true"}m
+          )
+        end
+      end
+
+      context ':ensure => present and :report_kernel_pmu_events => true' do
+        let :params do
+          { report_kernel_pmu_events: true }
+        end
+
+        it "Will create #{options[:plugin_conf_dir]}/10-intel_pmu.conf" do
+          is_expected.to contain_file('intel_pmu.load').with(
+            ensure: 'present',
+            path: "#{options[:plugin_conf_dir]}/10-intel_pmu.conf",
+            content: %r{ReportKernelPMUEvents "true"}m
+          )
+        end
+      end
+
+      context ':ensure => present and :report_software_events => true' do
+        let :params do
+          { report_software_events: true }
+        end
+
+        it "Will create #{options[:plugin_conf_dir]}/10-intel_pmu.conf" do
+          is_expected.to contain_file('intel_pmu.load').with(
+            ensure: 'present',
+            path: "#{options[:plugin_conf_dir]}/10-intel_pmu.conf",
+            content: %r{ReportSoftwareEvents "true"}m
+          )
+        end
+      end
+
+      context ':ensure => present and :event_list => /var/cache/pmu/GenuineIntel-6-2D-core.json' do
+        let :params do
+          { event_list: '/var/cache/pmu/GenuineIntel-6-2D-core.json' }
+        end
+
+        it "Will create #{options[:plugin_conf_dir]}/10-intel_pmu.conf" do
+          is_expected.to contain_file('intel_pmu.load').with(
+            ensure: 'present',
+            path: "#{options[:plugin_conf_dir]}/10-intel_pmu.conf",
+            content: %r{EventList "/var/cache/pmu/GenuineIntel-6-2D-core.json"}m
+          )
+        end
+      end
+
+      context ':ensure => present and :hardware_events => L2_RQSTS.CODE_RD_HIT,L2_RQSTS.CODE_RD_MISS' do
+        let :params do
+          { hardware_events: ['L2_RQSTS.CODE_RD_HIT', 'L2_RQSTS.CODE_RD_MISS'] }
+        end
+
+        it "Will create #{options[:plugin_conf_dir]}/10-intel_pmu.conf" do
+          is_expected.to contain_file('intel_pmu.load').with(
+            ensure: 'present',
+            path: "#{options[:plugin_conf_dir]}/10-intel_pmu.conf",
+            content: %r{HardwareEvents "L2_RQSTS.CODE_RD_HIT,L2_RQSTS.CODE_RD_MISS"}m
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/collectd_plugin_intel_pmu_spec.rb
+++ b/spec/classes/collectd_plugin_intel_pmu_spec.rb
@@ -73,9 +73,10 @@ describe 'collectd::plugin::intel_pmu', type: :class do
         end
       end
 
-      context ':ensure => present and :hardware_events => L2_RQSTS.CODE_RD_HIT,L2_RQSTS.CODE_RD_MISS' do
+      context ':ensure => present and :hardware_events => L2_RQSTS.CODE_RD_HIT,L2_RQSTS.CODE_RD_MISS with event_list' do
         let :params do
-          { hardware_events: ['L2_RQSTS.CODE_RD_HIT', 'L2_RQSTS.CODE_RD_MISS'] }
+          { hardware_events: ['L2_RQSTS.CODE_RD_HIT', 'L2_RQSTS.CODE_RD_MISS'],
+            event_list: '/var/cache/pmu/GenuineIntel-6-2D-core.json' }
         end
 
         it "Will create #{options[:plugin_conf_dir]}/10-intel_pmu.conf" do
@@ -84,6 +85,16 @@ describe 'collectd::plugin::intel_pmu', type: :class do
             path: "#{options[:plugin_conf_dir]}/10-intel_pmu.conf",
             content: %r{HardwareEvents "L2_RQSTS.CODE_RD_HIT,L2_RQSTS.CODE_RD_MISS"}m
           )
+        end
+      end
+
+      context ':ensure => present and :hardware_events => L2_RQSTS.CODE_RD_HIT,L2_RQSTS.CODE_RD_MISS without event_list' do
+        let :params do
+          { hardware_events: ['L2_RQSTS.CODE_RD_HIT', 'L2_RQSTS.CODE_RD_MISS'] }
+        end
+
+        it "Will raise error" do
+          is_expected.to compile.and_raise_error(/event_list must be defined if hardware_events is used/)
         end
       end
     end

--- a/spec/classes/collectd_plugin_intel_pmu_spec.rb
+++ b/spec/classes/collectd_plugin_intel_pmu_spec.rb
@@ -26,7 +26,7 @@ describe 'collectd::plugin::intel_pmu', type: :class do
           is_expected.to contain_file('intel_pmu.load').with(
             ensure: 'present',
             path: "#{options[:plugin_conf_dir]}/10-intel_pmu.conf",
-            content: %r{ReportHardwareCacheEvents "true"}m
+            content: %r{ReportHardwareCacheEvents true}m
           )
         end
       end
@@ -40,7 +40,7 @@ describe 'collectd::plugin::intel_pmu', type: :class do
           is_expected.to contain_file('intel_pmu.load').with(
             ensure: 'present',
             path: "#{options[:plugin_conf_dir]}/10-intel_pmu.conf",
-            content: %r{ReportKernelPMUEvents "true"}m
+            content: %r{ReportKernelPMUEvents true}m
           )
         end
       end
@@ -54,7 +54,7 @@ describe 'collectd::plugin::intel_pmu', type: :class do
           is_expected.to contain_file('intel_pmu.load').with(
             ensure: 'present',
             path: "#{options[:plugin_conf_dir]}/10-intel_pmu.conf",
-            content: %r{ReportSoftwareEvents "true"}m
+            content: %r{ReportSoftwareEvents true}m
           )
         end
       end

--- a/templates/plugin/intel_pmu.conf.erb
+++ b/templates/plugin/intel_pmu.conf.erb
@@ -1,12 +1,12 @@
 <Plugin intel_pmu>
 <% unless @report_hardware_cache_events.nil? -%>
-  ReportHardwareCacheEvents "<%= @report_hardware_cache_events %>"
+  ReportHardwareCacheEvents <%= @report_hardware_cache_events %>
 <% end -%>
 <% unless @report_kernel_pmu_events.nil? -%>
-  ReportKernelPMUEvents "<%= @report_kernel_pmu_events %>"
+  ReportKernelPMUEvents <%= @report_kernel_pmu_events %>
 <% end -%>
 <% unless @report_software_events.nil? -%>
-  ReportSoftwareEvents "<%= @report_software_events %>"
+  ReportSoftwareEvents <%= @report_software_events %>
 <% end -%>
 <% if @event_list -%>
   EventList "<%= @event_list %>"

--- a/templates/plugin/intel_pmu.conf.erb
+++ b/templates/plugin/intel_pmu.conf.erb
@@ -1,0 +1,17 @@
+<Plugin intel_pmu>
+<% unless @report_hardware_cache_events.nil? -%>
+  ReportHardwareCacheEvents "<%= @report_hardware_cache_events %>"
+<% end -%>
+<% unless @report_kernel_pmu_events.nil? -%>
+  ReportKernelPMUEvents "<%= @report_kernel_pmu_events %>"
+<% end -%>
+<% unless @report_software_events.nil? -%>
+  ReportSoftwareEvents "<%= @report_software_events %>"
+<% end -%>
+<% if @event_list -%>
+  EventList "<%= @event_list %>"
+<% end -%>
+<% if @hardware_events -%>
+  HardwareEvents "<%= @hardware_events.join(',') %>"
+<% end -%>
+</Plugin>


### PR DESCRIPTION
This PR adds support for the intel_pmu plugin.

It supports the parameters that are documented here: https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_intel_pmu

The implementation uses the standard pattern as seen in other plugins using modern puppet types (also seen in other plugins).

I'd be glad to get any feedback on this. Thank you!