### PR TITLE
Install package with options in sensors and disk plugins

### DIFF
--- a/manifests/plugin/disk.pp
+++ b/manifests/plugin/disk.pp
@@ -7,6 +7,7 @@ class collectd::plugin::disk (
   $manage_package         = undef,
   $package_name           = 'collectd-disk',
   $udevnameattr           = undef,
+  Optional[Array[String]] $package_install_options = undef
 ) {
 
   include ::collectd
@@ -30,8 +31,9 @@ class collectd::plugin::disk (
 
     if $_manage_package {
       package { 'collectd-disk':
-        ensure => $ensure_real,
-        name   => $package_name,
+        ensure          => $ensure_real,
+        name            => $package_name,
+        install_options => $package_install_options,
       }
     }
   }

--- a/manifests/plugin/sensors.pp
+++ b/manifests/plugin/sensors.pp
@@ -6,6 +6,7 @@ class collectd::plugin::sensors (
   $sensors          = undef,
   $ignoreselected   = undef,
   $interval         = undef,
+  Optional[Array[String]] $package_install_options = undef
 ) {
 
   include ::collectd
@@ -15,7 +16,8 @@ class collectd::plugin::sensors (
   if $facts['os']['family'] == 'RedHat' {
     if $_manage_package {
       package { 'collectd-sensors':
-        ensure => $ensure,
+        ensure          => $ensure,
+        install_options => $package_install_options,
       }
     }
   }

--- a/spec/classes/collectd_plugin_disk_spec.rb
+++ b/spec/classes/collectd_plugin_disk_spec.rb
@@ -136,6 +136,20 @@ describe 'collectd::plugin::disk', type: :class do
             )
           end
         end
+        context ':install_options install package with install options' do
+          let :params do
+            {
+              package_install_options: ['--enablerepo=mycollectd-repo']
+            }
+          end
+
+          it 'Will install the package with install options' do
+            is_expected.to contain_package('collectd-disk').with(
+              ensure: 'present',
+              install_options: ['--enablerepo=mycollectd-repo']
+            )
+          end
+        end
       end
     end
   end

--- a/spec/classes/collectd_plugin_sensors.rb
+++ b/spec/classes/collectd_plugin_sensors.rb
@@ -105,4 +105,26 @@ describe 'collectd::plugin::sensors', type: :class do
                                                        path: '/etc/collectd.d/10-sensors.conf')
     end
   end
+
+  context ':install_options install package with install options' do
+    let :facts do
+      {
+        osfamily: 'RedHat',
+        collectd_version: '5.4',
+        operatingsystemmajrelease: '7',
+        python_dir: '/usr/local/lib/python2.7/dist-packages'
+      }
+    end
+    let :params do
+      { ensure: 'present',
+        install_options: ['--enablerepo=mycollectd-repo'] }
+    end
+
+    it 'Will install the package with install options' do
+      is_expected.to contain_package('collectd-sensors').with(
+        ensure: 'present',
+        install_options: ['--enablerepo=mycollectd-repo']
+      )
+    end
+  end
 end


### PR DESCRIPTION
We need to be able to specify some options when installing plugins package (e.g. --enablerepo) when we are using Redhat.

Replacement for #664

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
