### PR TITLE
add assert_private to private classes

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,6 +22,8 @@ class collectd::config (
   Integer $write_threads                = $collectd::write_threads,
 ) {
 
+  assert_private()
+
   $_conf_content = $purge_config ? {
     true    => template('collectd/collectd.conf.erb'),
     default => $conf_content,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,6 +6,8 @@ class collectd::install (
   $manage_package                           = $collectd::manage_package,
 ) {
 
+  assert_private()
+
   if $manage_package {
     package { $package_name:
       ensure          => $package_ensure,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,6 +5,8 @@ class collectd::service (
   $manage_service = $collectd::manage_service,
 ) {
 
+  assert_private()
+
   if $manage_service {
     service { 'collectd':
       ensure => $service_ensure,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

Those classes are private, they are not supposed to be called directly. The assert_private() methods will throw a compile error if they are accessed from the outside (sadly the Puppet DSL has no concept of public/private classes)

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
