### PR TITLE
Use one operating system for most RSpec tests

### DIFF
--- a/spec/classes/collectd_init_spec.rb
+++ b/spec/classes/collectd_init_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os.each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_amqp_spec.rb
+++ b/spec/classes/collectd_plugin_amqp_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::amqp', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_ceph_spec.rb
+++ b/spec/classes/collectd_plugin_ceph_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::ceph', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_cgroups_spec.rb
+++ b/spec/classes/collectd_plugin_cgroups_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::cgroups', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_cpu_spec.rb
+++ b/spec/classes/collectd_plugin_cpu_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::cpu', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_cuda_spec.rb
+++ b/spec/classes/collectd_plugin_cuda_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::cuda', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_curl_spec.rb
+++ b/spec/classes/collectd_plugin_curl_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::curl', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_dbi_spec.rb
+++ b/spec/classes/collectd_plugin_dbi_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::dbi', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_df_spec.rb
+++ b/spec/classes/collectd_plugin_df_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::df', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_disk_spec.rb
+++ b/spec/classes/collectd_plugin_disk_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::disk', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_dns_spec.rb
+++ b/spec/classes/collectd_plugin_dns_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::dns', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_ethstat.rb
+++ b/spec/classes/collectd_plugin_ethstat.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::ethstat', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_exec_spec.rb
+++ b/spec/classes/collectd_plugin_exec_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::exec', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_fhcount_spec.rb
+++ b/spec/classes/collectd_plugin_fhcount_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::fhcount', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_filecount_spec.rb
+++ b/spec/classes/collectd_plugin_filecount_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::filecount', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_filter_spec.rb
+++ b/spec/classes/collectd_plugin_filter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::filter', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_genericjmx_spec.rb
+++ b/spec/classes/collectd_plugin_genericjmx_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::genericjmx', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       options = os_specific_options(facts)
       let :facts do

--- a/spec/classes/collectd_plugin_hddtemp_spec.rb
+++ b/spec/classes/collectd_plugin_hddtemp_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::hddtemp', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_intel_pmu_spec.rb
+++ b/spec/classes/collectd_plugin_intel_pmu_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::intel_pmu', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_interface_spec.rb
+++ b/spec/classes/collectd_plugin_interface_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::interface', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_ipmi.rb
+++ b/spec/classes/collectd_plugin_ipmi.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::ipmi', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       options = os_specific_options(facts)
       let :facts do

--- a/spec/classes/collectd_plugin_iptables_spec.rb
+++ b/spec/classes/collectd_plugin_iptables_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::iptables', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_irq_spec.rb
+++ b/spec/classes/collectd_plugin_irq_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::irq', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_iscdhcp_spec.rb
+++ b/spec/classes/collectd_plugin_iscdhcp_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::cuda', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_java_spec.rb
+++ b/spec/classes/collectd_plugin_java_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::java', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_load_spec.rb
+++ b/spec/classes/collectd_plugin_load_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::load', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_logfile_spec.rb
+++ b/spec/classes/collectd_plugin_logfile_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::logfile', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_memcached_spec.rb
+++ b/spec/classes/collectd_plugin_memcached_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::memcached', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_memory_spec.rb
+++ b/spec/classes/collectd_plugin_memory_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::memory', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_mongodb_spec.rb
+++ b/spec/classes/collectd_plugin_mongodb_spec.rb
@@ -12,7 +12,7 @@ describe 'collectd::plugin::mongodb', type: :class do
     }
   end
 
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_netlink_spec.rb
+++ b/spec/classes/collectd_plugin_netlink_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::netlink', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_network_spec.rb
+++ b/spec/classes/collectd_plugin_network_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::network', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_openldap_spec.rb
+++ b/spec/classes/collectd_plugin_openldap_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::openldap', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_openvpn_spec.rb
+++ b/spec/classes/collectd_plugin_openvpn_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::openvpn', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_oracle_spec.rb
+++ b/spec/classes/collectd_plugin_oracle_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::oracle', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       options = os_specific_options(facts)
       let :facts do

--- a/spec/classes/collectd_plugin_ovs_events_spec.rb
+++ b/spec/classes/collectd_plugin_ovs_events_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::ovs_events', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_ovs_stats_spec.rb
+++ b/spec/classes/collectd_plugin_ovs_stats_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::ovs_stats', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_ping_spec.rb
+++ b/spec/classes/collectd_plugin_ping_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::ping', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_postgresql_spec.rb
+++ b/spec/classes/collectd_plugin_postgresql_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::postgresql', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_processes_spec.rb
+++ b/spec/classes/collectd_plugin_processes_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::processes', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_protocols_spec.rb
+++ b/spec/classes/collectd_plugin_protocols_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::protocols', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_python_spec.rb
+++ b/spec/classes/collectd_plugin_python_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::python', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_rabbitmq_spec.rb
+++ b/spec/classes/collectd_plugin_rabbitmq_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::rabbitmq', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_redis_spec.rb
+++ b/spec/classes/collectd_plugin_redis_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::redis', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_rrdtool_spec.rb
+++ b/spec/classes/collectd_plugin_rrdtool_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::rrdtool', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_smart_spec.rb
+++ b/spec/classes/collectd_plugin_smart_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::smart', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_snmp_spec.rb
+++ b/spec/classes/collectd_plugin_snmp_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::snmp', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_statsd_spec.rb
+++ b/spec/classes/collectd_plugin_statsd_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::statsd', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_swap_spec.rb
+++ b/spec/classes/collectd_plugin_swap_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::swap', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_tcpconns_spec.rb
+++ b/spec/classes/collectd_plugin_tcpconns_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::tcpconns', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_thermal_spec.rb
+++ b/spec/classes/collectd_plugin_thermal_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::thermal', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_threshold_spec.rb
+++ b/spec/classes/collectd_plugin_threshold_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::threshold', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_turbostat_spec.rb
+++ b/spec/classes/collectd_plugin_turbostat_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::turbostat', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_unixsock_spec.rb
+++ b/spec/classes/collectd_plugin_unixsock_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::unixsock', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_uuid_spec.rb
+++ b/spec/classes/collectd_plugin_uuid_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::uuid', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_varnish_spec.rb
+++ b/spec/classes/collectd_plugin_varnish_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::varnish', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_virt_spec.rb
+++ b/spec/classes/collectd_plugin_virt_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::virt', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_write_graphite_spec.rb
+++ b/spec/classes/collectd_plugin_write_graphite_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::write_graphite', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts.merge(collectd_version: '5.0')

--- a/spec/classes/collectd_plugin_write_kafka_spec.rb
+++ b/spec/classes/collectd_plugin_write_kafka_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::write_kafka', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_write_log_spec.rb
+++ b/spec/classes/collectd_plugin_write_log_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::write_log', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_write_prometheus_spec.rb
+++ b/spec/classes/collectd_plugin_write_prometheus_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::write_prometheus', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts.merge(collectd_version: '5.7')

--- a/spec/classes/collectd_plugin_write_riemann_spec.rb
+++ b/spec/classes/collectd_plugin_write_riemann_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::write_riemann', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_write_tsdb_spec.rb
+++ b/spec/classes/collectd_plugin_write_tsdb_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::write_tsdb', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/classes/collectd_plugin_zfs_arc_spec.rb
+++ b/spec/classes/collectd_plugin_zfs_arc_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::zfs_arc', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts.merge(collectd_version: '4.8')

--- a/spec/classes/collectd_plugin_zookeeper_spec.rb
+++ b/spec/classes/collectd_plugin_zookeeper_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::zookeeper', type: :class do
-  on_supported_os(test_on).each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/defines/collectd_plugin_apache_instance_spec.rb
+++ b/spec/defines/collectd_plugin_apache_instance_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::apache::instance', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/defines/collectd_plugin_curl_page_spec.rb
+++ b/spec/defines/collectd_plugin_curl_page_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::curl::page', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/defines/collectd_plugin_exec_cmd_spec.rb
+++ b/spec/defines/collectd_plugin_exec_cmd_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::exec::cmd', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/defines/collectd_plugin_filecount_directory_spec.rb
+++ b/spec/defines/collectd_plugin_filecount_directory_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::filecount::directory', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/defines/collectd_plugin_filter_chain_spec.rb
+++ b/spec/defines/collectd_plugin_filter_chain_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::filter::chain', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/defines/collectd_plugin_filter_match_spec.rb
+++ b/spec/defines/collectd_plugin_filter_match_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::filter::match', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       options = os_specific_options(facts)
       let :facts do

--- a/spec/defines/collectd_plugin_filter_rule_spec.rb
+++ b/spec/defines/collectd_plugin_filter_rule_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::filter::rule', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/defines/collectd_plugin_filter_target_spec.rb
+++ b/spec/defines/collectd_plugin_filter_target_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::filter::target', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       options = os_specific_options(facts)
       let :facts do

--- a/spec/defines/collectd_plugin_genericjmx_connection_spec.rb
+++ b/spec/defines/collectd_plugin_genericjmx_connection_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::genericjmx::connection', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       options = os_specific_options(facts)
       let :facts do

--- a/spec/defines/collectd_plugin_genericjmx_mbean_spec.rb
+++ b/spec/defines/collectd_plugin_genericjmx_mbean_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::genericjmx::mbean', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       options = os_specific_options(facts)
       let :facts do

--- a/spec/defines/collectd_plugin_mysql_database_spec.rb
+++ b/spec/defines/collectd_plugin_mysql_database_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::mysql::database', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/defines/collectd_plugin_network_listener_spec.rb
+++ b/spec/defines/collectd_plugin_network_listener_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::network::listener', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/defines/collectd_plugin_network_server_spec.rb
+++ b/spec/defines/collectd_plugin_network_server_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::network::server', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/defines/collectd_plugin_oracle_database_spec.rb
+++ b/spec/defines/collectd_plugin_oracle_database_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::oracle::database', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       options = os_specific_options(facts)
       let :facts do

--- a/spec/defines/collectd_plugin_oracle_query_spec.rb
+++ b/spec/defines/collectd_plugin_oracle_query_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::oracle::query', 'type' => :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       options = os_specific_options(facts)
       let :facts do

--- a/spec/defines/collectd_plugin_python_module_spec.rb
+++ b/spec/defines/collectd_plugin_python_module_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::python::module', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/defines/collectd_plugin_snmp_data_spec.rb
+++ b/spec/defines/collectd_plugin_snmp_data_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::snmp::data', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/defines/collectd_plugin_snmp_host_spec.rb
+++ b/spec/defines/collectd_plugin_snmp_host_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::snmp::host', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/defines/collectd_plugin_spec.rb
+++ b/spec/defines/collectd_plugin_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/defines/collectd_plugin_tail_file_spec.rb
+++ b/spec/defines/collectd_plugin_tail_file_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::tail::file', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/defines/collectd_plugin_write_graphite_spec.rb
+++ b/spec/defines/collectd_plugin_write_graphite_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::write_graphite::carbon', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/defines/collectd_typesdb_spec.rb
+++ b/spec/defines/collectd_typesdb_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'collectd::typesdb', type: :define do
-  on_supported_os.each do |os, facts|
+  on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts

--- a/spec/spec_helper_methods.rb
+++ b/spec/spec_helper_methods.rb
@@ -15,7 +15,7 @@ def os_specific_options(facts)
   end
 end
 
-def test_on
+def all_supported_os_hash
   {
     supported_os: [
       {
@@ -36,6 +36,17 @@ def test_on
       },
       {
         'operatingsystem' => 'Archlinux'
+      }
+    ]
+  }
+end
+
+def baseline_os_hash
+  {
+    supported_os: [
+      {
+        'operatingsystem' => 'CentOS',
+        'operatingsystemrelease' => ['7']
       }
     ]
   }


### PR DESCRIPTION
The majority of Puppet classes and defined types in this module do not
have behaviour which changes depending on the operating system. Mock one
operating system for most tests, except for collectd_init_spec when
mocking multiple operating systems makes sense.

This attempts to address #633 , and should reduce test runtimes
considerably with little change in the confidence of tests actually
picking up problems.