### PR TITLE
Use $collectd::service_name consistently

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -20,7 +20,7 @@ define collectd::plugin (
     group   => $collectd::config_group,
     mode    => $collectd::config_mode,
     content => template('collectd/loadplugin.conf.erb'),
-    notify  => Service['collectd'],
+    notify  => Service[$collectd::service_name],
   }
 
   # Older versions of this module didn't use the "00-" prefix.
@@ -28,7 +28,7 @@ define collectd::plugin (
   file { "older_${plugin}.load":
     ensure => absent,
     path   => "${conf_dir}/${plugin}.conf",
-    notify => Service['collectd'],
+    notify => Service[$collectd::service_name],
   }
 
   # Older versions of this module use the "00-" prefix by default.
@@ -37,7 +37,7 @@ define collectd::plugin (
     file { "old_${plugin}.load":
       ensure => absent,
       path   => "${conf_dir}/00-${plugin}.conf",
-      notify => Service['collectd'],
+      notify => Service[$collectd::service_name],
     }
   }
 }

--- a/manifests/plugin/aggregation/aggregator.pp
+++ b/manifests/plugin/aggregation/aggregator.pp
@@ -30,6 +30,6 @@ define collectd::plugin::aggregation::aggregator (
     owner   => $collectd::config_owner,
     group   => $collectd::config_group,
     content => template('collectd/plugin/aggregation-aggregator.conf.erb'),
-    notify  => Service['collectd'],
+    notify  => Service[$collectd::service_name],
   }
 }

--- a/manifests/plugin/apache/instance.pp
+++ b/manifests/plugin/apache/instance.pp
@@ -18,6 +18,6 @@ define collectd::plugin::apache::instance (
     group   => $collectd::config_group,
     mode    => $collectd::config_mode,
     content => template('collectd/plugin/apache/instance.conf.erb'),
-    notify  => Service['collectd'],
+    notify  => Service[$collectd::service_name],
   }
 }

--- a/manifests/plugin/chain.pp
+++ b/manifests/plugin/chain.pp
@@ -16,6 +16,6 @@ class collectd::plugin::chain (
     owner   => $collectd::config_owner,
     group   => $collectd::config_group,
     content => template('collectd/plugin/chain.conf.erb'),
-    notify  => Service['collectd'],
+    notify  => Service[$collectd::service_name],
   }
 }

--- a/manifests/plugin/curl/page.pp
+++ b/manifests/plugin/curl/page.pp
@@ -25,6 +25,6 @@ define collectd::plugin::curl::page (
     owner   => $collectd::config_owner,
     group   => $collectd::config_group,
     content => template('collectd/plugin/curl-page.conf.erb'),
-    notify  => Service['collectd'],
+    notify  => Service[$collectd::service_name],
   }
 }

--- a/manifests/plugin/curl_json.pp
+++ b/manifests/plugin/curl_json.pp
@@ -53,6 +53,6 @@ define collectd::plugin::curl_json (
       group   => $collectd::config_group,
       mode    => $collectd::config_mode,
       content => template('collectd/curl_json.conf.erb'),
-      notify  => Service['collectd'],
+      notify  => Service[$collectd::service_name],
   }
 }

--- a/manifests/plugin/dbi.pp
+++ b/manifests/plugin/dbi.pp
@@ -37,7 +37,7 @@ class collectd::plugin::dbi (
     mode           => $collectd::config_mode,
     owner          => $collectd::config_owner,
     group          => $collectd::config_group,
-    notify         => Service['collectd'],
+    notify         => Service[$collectd::service_name],
     ensure_newline => true,
   }
 

--- a/manifests/plugin/exec.pp
+++ b/manifests/plugin/exec.pp
@@ -22,7 +22,7 @@ class collectd::plugin::exec (
     mode           => $collectd::config_mode,
     owner          => $collectd::config_owner,
     group          => $collectd::config_group,
-    notify         => Service['collectd'],
+    notify         => Service[$collectd::service_name],
     ensure_newline => true,
   }
 

--- a/manifests/plugin/filecount/directory.pp
+++ b/manifests/plugin/filecount/directory.pp
@@ -19,6 +19,6 @@ define collectd::plugin::filecount::directory (
     owner   => $collectd::config_owner,
     group   => $collectd::config_group,
     content => template('collectd/plugin/filecount-directory.conf.erb'),
-    notify  => Service['collectd'],
+    notify  => Service[$collectd::service_name],
   }
 }

--- a/manifests/plugin/filter.pp
+++ b/manifests/plugin/filter.pp
@@ -16,7 +16,7 @@ class collectd::plugin::filter (
     group   => $collectd::config_group,
     mode    => $collectd::config_mode,
     content => "PreCacheChain \"${precachechain}\"\nPostCacheChain \"${postcachechain}\"\n\n",
-    notify  => Service['collectd'],
+    notify  => Service[$collectd::service_name],
   }
 
   unless $ensure == 'present' {

--- a/manifests/plugin/filter/chain.pp
+++ b/manifests/plugin/filter/chain.pp
@@ -15,7 +15,7 @@ define collectd::plugin::filter::chain (
     mode           => $collectd::config_mode,
     owner          => $collectd::config_owner,
     group          => $collectd::config_group,
-    notify         => Service['collectd'],
+    notify         => Service[$collectd::service_name],
     ensure_newline => true,
   }
 

--- a/manifests/plugin/genericjmx.pp
+++ b/manifests/plugin/genericjmx.pp
@@ -25,7 +25,7 @@ class collectd::plugin::genericjmx (
     mode           => $collectd::config_mode,
     owner          => $collectd::config_owner,
     group          => $collectd::config_group,
-    notify         => Service['collectd'],
+    notify         => Service[$collectd::service_name],
     ensure_newline => true,
   }
 

--- a/manifests/plugin/mysql/database.pp
+++ b/manifests/plugin/mysql/database.pp
@@ -24,6 +24,6 @@ define collectd::plugin::mysql::database (
     owner   => $collectd::config_owner,
     group   => $collectd::config_group,
     content => template('collectd/mysql-database.conf.erb'),
-    notify  => Service['collectd'],
+    notify  => Service[$collectd::service_name],
   }
 }

--- a/manifests/plugin/network/listener.pp
+++ b/manifests/plugin/network/listener.pp
@@ -18,6 +18,6 @@ define collectd::plugin::network::listener (
     owner   => $collectd::config_owner,
     group   => $collectd::config_group,
     content => template('collectd/plugin/network/listener.conf.erb'),
-    notify  => Service['collectd'],
+    notify  => Service[$collectd::service_name],
   }
 }

--- a/manifests/plugin/network/server.pp
+++ b/manifests/plugin/network/server.pp
@@ -21,6 +21,6 @@ define collectd::plugin::network::server (
     owner   => $collectd::config_owner,
     group   => $collectd::config_group,
     content => template('collectd/plugin/network/server.conf.erb'),
-    notify  => Service['collectd'],
+    notify  => Service[$collectd::service_name],
   }
 }

--- a/manifests/plugin/oracle.pp
+++ b/manifests/plugin/oracle.pp
@@ -25,7 +25,7 @@ class collectd::plugin::oracle (
     mode           => $collectd::config_mode,
     owner          => $collectd::config_owner,
     group          => $collectd::config_group,
-    notify         => Service['collectd'],
+    notify         => Service[$collectd::service_name],
     ensure_newline => true,
   }
 

--- a/manifests/plugin/postgresql.pp
+++ b/manifests/plugin/postgresql.pp
@@ -30,7 +30,7 @@ class collectd::plugin::postgresql (
     mode           => $collectd::config_mode,
     owner          => $collectd::config_owner,
     group          => $collectd::config_group,
-    notify         => Service['collectd'],
+    notify         => Service[$collectd::service_name],
     ensure_newline => true,
   }
 

--- a/manifests/plugin/processes.pp
+++ b/manifests/plugin/processes.pp
@@ -20,7 +20,7 @@ class collectd::plugin::processes (
     mode           => $collectd::config_mode,
     owner          => $collectd::config_owner,
     group          => $collectd::config_group,
-    notify         => Service['collectd'],
+    notify         => Service[$collectd::service_name],
     ensure_newline => true,
   }
   concat::fragment { 'collectd_plugin_processes_conf_header':

--- a/manifests/plugin/python.pp
+++ b/manifests/plugin/python.pp
@@ -72,7 +72,7 @@ class collectd::plugin::python (
     mode           => $collectd::config_mode,
     owner          => $collectd::config_owner,
     group          => $collectd::config_group,
-    notify         => Service['collectd'],
+    notify         => Service[$collectd::service_name],
     ensure_newline => true,
     require        => File['collectd.d'],
   }

--- a/manifests/plugin/python/module.pp
+++ b/manifests/plugin/python/module.pp
@@ -30,7 +30,7 @@ define collectd::plugin::python::module (
       mode    => $collectd::config_mode,
       source  => $script_source,
       require => File[$module_dir],
-      notify  => Service['collectd'],
+      notify  => Service[$collectd::service_name],
     }
   }
 

--- a/manifests/plugin/rabbitmq.pp
+++ b/manifests/plugin/rabbitmq.pp
@@ -112,7 +112,7 @@ class collectd::plugin::rabbitmq (
     group   => $collectd::config_group,
     mode    => $collectd::config_mode,
     content => template('collectd/plugin/rabbitmq.conf.erb'),
-    notify  => Service['collectd'],
+    notify  => Service[$collectd::service_name],
   }
 
   collectd::plugin::python::module { 'collectd_rabbitmq.collectd_plugin':

--- a/manifests/plugin/snmp/data.pp
+++ b/manifests/plugin/snmp/data.pp
@@ -24,6 +24,6 @@ define collectd::plugin::snmp::data (
     group   => $collectd::config_group,
     mode    => $collectd::config_mode,
     content => template('collectd/plugin/snmp/data.conf.erb'),
-    notify  => Service['collectd'];
+    notify  => Service[$collectd::service_name];
   }
 }

--- a/manifests/plugin/snmp/host.pp
+++ b/manifests/plugin/snmp/host.pp
@@ -29,6 +29,6 @@ define collectd::plugin::snmp::host (
     group   => $collectd::config_group,
     mode    => $collectd::config_mode,
     content => template('collectd/plugin/snmp/host.conf.erb'),
-    notify  => Service['collectd'];
+    notify  => Service[$collectd::service_name];
   }
 }

--- a/manifests/plugin/tail/file.pp
+++ b/manifests/plugin/tail/file.pp
@@ -18,6 +18,6 @@ define collectd::plugin::tail::file (
     owner   => $collectd::config_owner,
     group   => $collectd::config_group,
     content => template('collectd/tail-file.conf.erb'),
-    notify  => Service['collectd'],
+    notify  => Service[$collectd::service_name],
   }
 }

--- a/manifests/plugin/write_graphite.pp
+++ b/manifests/plugin/write_graphite.pp
@@ -22,7 +22,7 @@ class collectd::plugin::write_graphite (
         mode           => $collectd::config_mode,
         owner          => $collectd::config_owner,
         group          => $collectd::config_group,
-        notify         => Service['collectd'],
+        notify         => Service[$collectd::service_name],
         ensure_newline => true,
       }
 

--- a/manifests/typesdb.pp
+++ b/manifests/typesdb.pp
@@ -13,6 +13,6 @@ define collectd::typesdb (
     group          => $group,
     mode           => $mode,
     ensure_newline => true,
-    notify         => Service['collectd'],
+    notify         => Service[$collectd::service_name],
   }
 }


### PR DESCRIPTION
The $service_name variable exists but is useless as Service['collectd'] is used in most places.

More or less identical to #738 by @fnoop

Fixes #688 