### PR TITLE
collectd::plugin::network - Add data types

### DIFF
--- a/manifests/plugin/network.pp
+++ b/manifests/plugin/network.pp
@@ -1,13 +1,13 @@
 # https://collectd.org/wiki/index.php/Plugin:Network
 class collectd::plugin::network (
-  $ensure                                    = 'present',
+  Enum['present', 'absent'] $ensure          = 'present',
   Optional[Pattern[/[0-9]+/]] $timetolive    = undef,
   Optional[Pattern[/[0-9]+/]] $maxpacketsize = undef,
-  $forward                                   = undef,
-  $interval                                  = undef,
-  $reportstats                               = undef,
-  $listeners                                 = { },
-  $servers                                   = { },
+  Optional[Boolean] $forward                 = undef,
+  Optional[Integer[1]] $interval             = undef,
+  Optional[Boolean] $reportstats             = undef,
+  Hash $listeners                            = {},
+  Hash $servers                              = {},
 ) {
 
   include ::collectd

--- a/manifests/plugin/network/listener.pp
+++ b/manifests/plugin/network/listener.pp
@@ -1,10 +1,10 @@
 #
 define collectd::plugin::network::listener (
-  $ensure        = 'present',
-  $authfile      = undef,
-  $port          = undef,
-  $securitylevel = undef,
-  $interface     = undef,
+  Enum['present', 'absent'] $ensure                         = 'present',
+  Optional[Stdlib::Absolutepath] $authfile                  = undef,
+  Optional[Integer] $port                                   = undef,
+  Optional[Collectd::Network::SecurityLevel] $securitylevel = undef,
+  Optional[String] $interface                               = undef,
 ) {
 
   include ::collectd

--- a/manifests/plugin/network/server.pp
+++ b/manifests/plugin/network/server.pp
@@ -1,13 +1,13 @@
 #
 define collectd::plugin::network::server (
-  $ensure          = 'present',
-  $username        = undef,
-  $password        = undef,
-  $port            = undef,
-  $securitylevel   = undef,
-  $interface       = undef,
-  $forward         = undef,
-  $resolveinterval = undef,
+  Enum['present', 'absent'] $ensure                         = 'present',
+  Optional[String] $username                                = undef,
+  Optional[String] $password                                = undef,
+  Optional[Integer] $port                                   = undef,
+  Optional[Collectd::Network::SecurityLevel] $securitylevel = undef,
+  Optional[String] $interface                               = undef,
+  Optional[Boolean] $forward                                = undef,
+  Optional[Integer[1]] $resolveinterval                     = undef,
 ) {
 
   include ::collectd

--- a/spec/defines/collectd_plugin_network_listener_spec.rb
+++ b/spec/defines/collectd_plugin_network_listener_spec.rb
@@ -12,7 +12,7 @@ describe 'collectd::plugin::network::listener', type: :define do
         let(:title) { 'mylistener' }
         let :params do
           {
-            port: '1234'
+            port: 1234
           }
         end
 

--- a/spec/defines/collectd_plugin_network_server_spec.rb
+++ b/spec/defines/collectd_plugin_network_server_spec.rb
@@ -12,7 +12,7 @@ describe 'collectd::plugin::network::server', type: :define do
         let(:title) { 'node1' }
         let :params do
           {
-            port: '1234',
+            port: 1234,
             interface: 'eth0',
             securitylevel: 'Encrypt',
             username: 'foo',

--- a/types/network/securitylevel.pp
+++ b/types/network/securitylevel.pp
@@ -1,0 +1,2 @@
+#
+type Collectd::Network::SecurityLevel = Enum['Encrypt', 'Sign', 'None']


### PR DESCRIPTION
- $port is now required to be an Integer type, not String