### PR TITLE
collectd::plugin::amqp - Use data types

### DIFF
--- a/manifests/plugin/amqp.pp
+++ b/manifests/plugin/amqp.pp
@@ -1,30 +1,28 @@
 # https://collectd.org/wiki/index.php/Plugin:AMQP
 class collectd::plugin::amqp (
-  $ensure                            = 'present',
-  $manage_package                    = undef,
-  $amqphost                          = 'localhost',
-  $amqpport                          = 5672,
-  $amqpvhost                         = 'graphite',
-  $amqpuser                          = 'graphite',
-  $amqppass                          = 'graphite',
-  $amqpformat                        = 'Graphite',
-  $amqpstorerates                    = false,
-  $amqpexchange                      = 'metrics',
+  Enum['present', 'absent'] $ensure  = 'present',
+  Boolean $manage_package            = $collectd::manage_package,
+  Stdlib::Host $amqphost             = 'localhost',
+  Stdlib::Port $amqpport             = 5672,
+  String $amqpvhost                  = 'graphite',
+  String $amqpuser                   = 'graphite',
+  String $amqppass                   = 'graphite',
+  Collectd::Amqp::Format $amqpformat = 'Graphite',
+  Boolean $amqpstorerates            = false,
+  String $amqpexchange               = 'metrics',
   Boolean $amqppersistent            = true,
-  $amqproutingkey                    = 'collectd',
-  $graphiteprefix                    = 'collectd.',
-  $escapecharacter                   = '_',
-  $interval                          = undef,
+  String $amqproutingkey             = 'collectd',
+  String $graphiteprefix             = 'collectd.',
+  String[1] $escapecharacter         = '_',
+  Optional[Integer[1]] $interval     = undef,
   Boolean $graphiteseparateinstances = false,
   Boolean $graphitealwaysappendds    = false,
 ) {
 
-  include ::collectd
-
-  $_manage_package = pick($manage_package, $::collectd::manage_package)
+  include collectd
 
   if $facts['os']['family'] == 'RedHat' {
-    if $_manage_package {
+    if $manage_package {
       package { 'collectd-amqp':
         ensure => $ensure,
       }

--- a/spec/classes/collectd_plugin_amqp_spec.rb
+++ b/spec/classes/collectd_plugin_amqp_spec.rb
@@ -7,6 +7,10 @@ describe 'collectd::plugin::amqp', type: :class do
         facts
       end
 
+      let :pre_condition do
+        'include collectd'
+      end
+
       options = os_specific_options(facts)
       context ':ensure => present' do
         let :params do
@@ -39,7 +43,7 @@ describe 'collectd::plugin::amqp', type: :class do
       context 'overriding default parameters' do
         let(:params) do
           { amqphost: 'myhost',
-            amqpport: '5666',
+            amqpport: 5666,
             amqpvhost: 'amqp',
             amqpuser: 'user',
             amqppass: 'pass',

--- a/types/amqp/format.pp
+++ b/types/amqp/format.pp
@@ -1,0 +1,2 @@
+# https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_amqp
+type Collectd::Amqp::Format = Enum['Command', 'JSON', 'Graphite']


### PR DESCRIPTION
- $manage_package must now be a Boolean and defaults to the value of $collectd::manage_package
- $amqpport cannot be a String