### PR TITLE
collectd::plugin::apache - Use data types

### DIFF
--- a/manifests/plugin/apache.pp
+++ b/manifests/plugin/apache.pp
@@ -1,18 +1,16 @@
 # https://collectd.org/wiki/index.php/Plugin:Apache
 class collectd::plugin::apache (
-  $ensure                                  = 'present',
-  $manage_package                          = undef,
+  Enum['present', 'absent'] $ensure        = 'present',
+  Boolean $manage_package                  = $collectd::manage_package,
   Hash $instances                          = { 'localhost' => { 'url' => 'http://localhost/mod_status?auto' } },
-  $interval                                = undef,
+  Optional[Integer[1]] $interval           = undef,
   Optional[Array] $package_install_options = $collectd::package_install_options,
 ) {
 
   include ::collectd
 
-  $_manage_package = pick($manage_package, $::collectd::manage_package)
-
   if $facts['os']['family'] == 'RedHat' {
-    if $_manage_package {
+    if $manage_package {
       package { 'collectd-apache':
         ensure          => $ensure,
         install_options => $package_install_options,


### PR DESCRIPTION
- $manage_package must now be a Boolean and defaults to the value of $collectd::manage_package