### PR TITLE
collectd::plugin::bind - Add additional data types

### DIFF
--- a/manifests/plugin/bind.pp
+++ b/manifests/plugin/bind.pp
@@ -1,25 +1,23 @@
 # https://collectd.org/wiki/index.php/Plugin:BIND
 class collectd::plugin::bind (
-  $url,
-  $ensure                 = 'present',
-  $manage_package         = undef,
-  Boolean $memorystats    = true,
-  Boolean $opcodes        = true,
-  Boolean $parsetime      = false,
-  Boolean $qtypes         = true,
-  Boolean $resolverstats  = false,
-  Boolean $serverstats    = true,
-  Boolean $zonemaintstats = true,
-  Array $views            = [],
-  $interval               = undef,
+  Stdlib::Httpurl $url,
+  Enum['present', 'absent'] $ensure = 'present',
+  Boolean $manage_package           = $collectd::manage_package,
+  Boolean $memorystats              = true,
+  Boolean $opcodes                  = true,
+  Boolean $parsetime                = false,
+  Boolean $qtypes                   = true,
+  Boolean $resolverstats            = false,
+  Boolean $serverstats              = true,
+  Boolean $zonemaintstats           = true,
+  Array $views                      = [],
+  Optional[Integer[1]] $interval    = undef,
 ) {
 
   include ::collectd
 
-  $_manage_package = pick($manage_package, $::collectd::manage_package)
-
   if $facts['os']['family'] == 'RedHat' {
-    if $_manage_package {
+    if $manage_package {
       package { 'collectd-bind':
         ensure => $ensure,
       }


### PR DESCRIPTION
- $manage_package must now be a Boolean and defaults to the value of $collectd::manage_package