### PR TITLE
Remove array sorting in python module template (#586)

### DIFF
--- a/templates/plugin/python/module.conf.erb
+++ b/templates/plugin/python/module.conf.erb
@@ -6,7 +6,7 @@
   <Module "<%= @module %>">
   <%- configuration.sort.each do |key,value| -%>
   <%- if value.is_a?(Array) -%>
-  <%- value.sort.each do |v| -%>
+  <%- value.each do |v| -%>
     <%= key %> <% if !!v == v %><%= v %><% else %>"<%= Shellwords.split(v).join('" "') %>"<% end %>
   <%- end -%>
   <%- elsif value.is_a?(Hash) -%>


### PR DESCRIPTION
#### Pull Request (PR) description

    This PR removes array sorting in python module template
    We need to keep the array order provided by the config parameter of the collectd::plugin::python::module function parameter instead of an alphabetic order.
    Please see #586 for details.

#### This Pull Request (PR) fixes the following issues

    Fixes #586 
