### PR TITLE
Validate bind view parameters

### DIFF
--- a/manifests/plugin/bind.pp
+++ b/manifests/plugin/bind.pp
@@ -10,7 +10,7 @@ class collectd::plugin::bind (
   Boolean $resolverstats            = false,
   Boolean $serverstats              = true,
   Boolean $zonemaintstats           = true,
-  Array $views                      = [],
+  Array[Collectd::Bind::View] $views = [],
   Optional[Integer[1]] $interval    = undef,
 ) {
 

--- a/manifests/plugin/bind.pp
+++ b/manifests/plugin/bind.pp
@@ -1,17 +1,17 @@
 # https://collectd.org/wiki/index.php/Plugin:BIND
 class collectd::plugin::bind (
   Stdlib::Httpurl $url,
-  Enum['present', 'absent'] $ensure = 'present',
-  Boolean $manage_package           = $collectd::manage_package,
-  Boolean $memorystats              = true,
-  Boolean $opcodes                  = true,
-  Boolean $parsetime                = false,
-  Boolean $qtypes                   = true,
-  Boolean $resolverstats            = false,
-  Boolean $serverstats              = true,
-  Boolean $zonemaintstats           = true,
+  Enum['present', 'absent'] $ensure  = 'present',
+  Boolean $manage_package            = $collectd::manage_package,
+  Boolean $memorystats               = true,
+  Boolean $opcodes                   = true,
+  Boolean $parsetime                 = false,
+  Boolean $qtypes                    = true,
+  Boolean $resolverstats             = false,
+  Boolean $serverstats               = true,
+  Boolean $zonemaintstats            = true,
   Array[Collectd::Bind::View] $views = [],
-  Optional[Integer[1]] $interval    = undef,
+  Optional[Integer[1]] $interval     = undef,
 ) {
 
   include ::collectd

--- a/spec/classes/collectd_plugin_bind_spec.rb
+++ b/spec/classes/collectd_plugin_bind_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::bind', type: :class do
+  on_supported_os(baseline_os_hash).each do |os, facts|
+    context "on #{os} " do
+      let :facts do
+        facts
+      end
+
+      let :pre_condition do
+        'include collectd'
+      end
+
+      options = os_specific_options(facts)
+      context ':ensure => present' do
+        let :params do
+          {
+            ensure: 'present',
+            url: 'http://localhost:8053/',
+            views: views
+          }
+        end
+
+        let :views do
+          :undef
+        end
+
+        it { is_expected.to contain_collectd__plugin('bind') }
+        it { is_expected.to contain_file('old_bind.load').with_ensure('absent') }
+        it { is_expected.to contain_file('older_bind.load').with_ensure('absent') }
+        it 'Will create 10-bind.conf' do
+          is_expected.to contain_file('bind.load').with(
+            ensure: 'present',
+            path: "#{options[:plugin_conf_dir]}/10-bind.conf"
+          )
+        end
+        it { is_expected.to contain_file('bind.load').with(content: %r{<Plugin bind>}) }
+        it { is_expected.to contain_file('bind.load').with(content: %r{URL "http://localhost:8053/"}) }
+        it { is_expected.to contain_file('bind.load').with(content: %r{ParseTime false}) }
+        it { is_expected.to contain_file('bind.load').with(content: %r{OpCodes true}) }
+        it { is_expected.to contain_file('bind.load').with(content: %r{QTypes true}) }
+        it { is_expected.to contain_file('bind.load').with(content: %r{ServerStats true}) }
+        it { is_expected.to contain_file('bind.load').with(content: %r{ZoneMaintStats true}) }
+        it { is_expected.to contain_file('bind.load').with(content: %r{ResolverStats false}) }
+        it { is_expected.to contain_file('bind.load').with(content: %r{MemoryStats true}) }
+        it { is_expected.to contain_file('bind.load').with(content: %r{</Plugin>}) }
+
+        context 'when given a view' do
+          let :views do
+            [
+              {
+                name: 'internal',
+                qtypes: true,
+                resolverstats: true,
+                cacherrsets: true
+              },
+              {
+                name: 'external',
+                qtypes: true,
+                resolverstats: true,
+                cacherrsets: true,
+                zones: ['example.com/IN']
+              }
+            ]
+          end
+
+          it { is_expected.to contain_file('bind.load').with(content: %r{  <View "internal">\n    QTypes true\n    ResolverStats true\n    CacheRRSets true\n  </View>\n  <View "external">\n    QTypes true\n    ResolverStats true\n    CacheRRSets true\n    Zone "example\.com/IN"\n  </View>}) }
+        end
+      end
+    end
+  end
+end

--- a/types/bind/view.pp
+++ b/types/bind/view.pp
@@ -1,0 +1,8 @@
+# https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_bind
+type Collectd::Bind::View = Struct[{
+  name          => String,
+  qtypes        => Optional[Boolean],
+  resolverstats => Optional[Boolean],
+  cacherrsets   => Optional[Boolean],
+  zones         => Optional[Array[String]],
+}]


### PR DESCRIPTION
#### Pull Request (PR) description
This tiny Pull-Request add a custom type for validating the values passed to `$collectd::plugin::bind::views`.  Without this safety belt, you can end up with a useless (but surprisingly valid!) configuration file:

```
<Plugin bind>
  [...]
  <View "">
  </View>
  <View "">
  </View>
</Plugin>
```

#### This Pull Request (PR) fixes the following issues
n/a