### PR TITLE
doc: tell rake rubocop is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1934,6 +1934,7 @@ gem install bundler
 bundle install
 bundle exec rake lint
 bundle exec rake validate
+bundle exec rake rubocop
 bundle exec rake spec SPEC_OPTS='--format documentation'
 ```
 


### PR DESCRIPTION
doc: tell rake rubocop is needed

"rake rubocop" is missing comparing of what ran on travis-ci.

Adds it, so contributor will not missing syntax issue with old puppet
version.