### PR TITLE
Modularize python plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1428,6 +1428,8 @@ non-default value.
   collectd with the name of the exception and the message (default: `false`)
 * `conf_name` name of the file that will contain the python module configuration
   (default: `python-config.conf`)
+* `python_conf_dir` name of directory inside which individual python plugins will write
+  their configuration to. (default: `python.d`)
 
  See [collectd-python documentation](https://collectd.org/documentation/manpages/collectd-python.5.shtml)
  for more details.

--- a/manifests/plugin/python.pp
+++ b/manifests/plugin/python.pp
@@ -14,6 +14,7 @@ class collectd::plugin::python (
   Hash $modules        = {},
   $order               = '10',
   $conf_name           = 'python-config.conf',
+  $python_conf_dir     = 'python.d',
 ) {
 
   include ::collectd
@@ -52,6 +53,14 @@ class collectd::plugin::python (
     default  => 'directory',
   }
 
+  file{"${collectd::plugin_conf_dir}/${python_conf_dir}":
+    ensure  => directory,
+    mode    => $collectd::plugin_conf_dir_mode,
+    owner   => $collectd::config_owner,
+    group   => $collectd::config_group,
+    require => Package[$collectd::package_name],
+  }
+
   ensure_resource('file', $module_dirs,
     {
       'ensure'  => $ensure_modulepath,
@@ -85,7 +94,7 @@ class collectd::plugin::python (
 
   concat::fragment { 'collectd_plugin_python_conf_footer':
     order   => '99',
-    content => '</Plugin>',
+    content => "</Plugin>\nInclude \"${collectd::plugin_conf_dir}/${python_conf_dir}/*.conf\"",
     target  => $python_conf,
   }
 

--- a/manifests/plugin/python/module.pp
+++ b/manifests/plugin/python/module.pp
@@ -33,10 +33,25 @@ define collectd::plugin::python::module (
       notify  => Service[$collectd::service_name],
     }
   }
-
-  concat::fragment{ "collectd_plugin_python_conf_${module}":
-    order   => '50', # somewhere between header and footer
-    target  => $collectd::plugin::python::python_conf,
-    content => template('collectd/plugin/python/module.conf.erb'),
+  $_python_module_conf = "${collectd::plugin_conf_dir}/${collectd::plugin::python::python_conf_dir}/${module}.conf"
+  concat{$_python_module_conf:
+    ensure         => $ensure,
+    mode           => $collectd::config_mode,
+    owner          => $collectd::config_owner,
+    group          => $collectd::config_group,
+    notify         => Service[$collectd::service_name],
+    ensure_newline => true,
   }
+
+  concat::fragment{ "collectd_plugin_python_conf_${module}_header":
+    order   => '00', # header
+    target  => $_python_module_conf,
+    content => template('collectd/plugin/python/module_header.conf.erb'),
+  }
+  concat::fragment{ "collectd_plugin_python_conf_${module}_footer":
+    order   => '99', #  footer
+    target  => $_python_module_conf,
+    content => "   </Module>\n</Plugin>",
+  }
+
 }

--- a/spec/classes/collectd_plugin_cuda_spec.rb
+++ b/spec/classes/collectd_plugin_cuda_spec.rb
@@ -9,8 +9,8 @@ describe 'collectd::plugin::cuda', type: :class do
 
       context 'package ensure' do
         context ':ensure => present' do
-          it 'import collectd_cuda.collectd_plugin in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_cuda.collectd_plugin').with_content(%r{Import "collectd_cuda.collectd_plugin"})
+          it 'import collectd_cuda.collectd_plugin in cuda.conf' do
+            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_cuda.collectd_plugin_header').with_content(%r{Import "collectd_cuda.collectd_plugin"})
           end
         end
       end

--- a/spec/classes/collectd_plugin_iscdhcp_spec.rb
+++ b/spec/classes/collectd_plugin_iscdhcp_spec.rb
@@ -9,8 +9,8 @@ describe 'collectd::plugin::cuda', type: :class do
 
       context 'package ensure' do
         context ':ensure => present' do
-          it 'import collectd_cuda.collectd_plugin in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_cuda.collectd_plugin').with_content(%r{Import "collectd_cuda.collectd_plugin"})
+          it 'import collectd_cuda.collectd_plugin in cuda.conf' do
+            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_cuda.collectd_plugin_header').with_content(%r{Import "collectd_cuda.collectd_plugin"})
           end
         end
       end

--- a/spec/classes/collectd_plugin_python_spec.rb
+++ b/spec/classes/collectd_plugin_python_spec.rb
@@ -89,31 +89,35 @@ describe 'collectd::plugin::python', type: :class do
             }
           end
 
+          it "Will create #{options[:plugin_conf_dir]}/python.d/elasticsearch.conf" do
+            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/python.d/elasticsearch.conf")
+          end
+
           it 'imports elasticsearch module' do
-            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_elasticsearch').with(
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_elasticsearch_header').with(
               content: %r{Import "elasticsearch"},
-              target: "#{options[:plugin_conf_dir]}/python-config.conf"
+              target: "#{options[:plugin_conf_dir]}/python.d/elasticsearch.conf"
             )
           end
 
           it 'includes elasticsearch module configuration' do
-            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_elasticsearch').with(
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_elasticsearch_header').with(
               content: %r{<Module "elasticsearch">},
-              target: "#{options[:plugin_conf_dir]}/python-config.conf"
+              target: "#{options[:plugin_conf_dir]}/python.d/elasticsearch.conf"
             )
           end
 
           it 'includes elasticsearch Cluster name' do
-            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_elasticsearch').with(
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_elasticsearch_header').with(
               content: %r{Cluster "ES-clust"},
-              target: "#{options[:plugin_conf_dir]}/python-config.conf"
+              target: "#{options[:plugin_conf_dir]}/python.d/elasticsearch.conf"
             )
           end
 
           it 'includes second elasticsearch Cluster name' do
-            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_elasticsearch').with(
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_elasticsearch_header').with(
               content: %r{Cluster "Another-ES-clust"},
-              target: "#{options[:plugin_conf_dir]}/python-config.conf"
+              target: "#{options[:plugin_conf_dir]}/python.d/elasticsearch.conf"
             )
           end
 
@@ -125,20 +129,24 @@ describe 'collectd::plugin::python', type: :class do
           end
 
           # test foo module
+          it "Will create #{options[:plugin_conf_dir]}/python.d/foo.conf" do
+            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/python.d/foo.conf")
+          end
+
           it 'imports foo module' do
-            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo').with(
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo_header').with(
               content: %r{Import "foo"},
-              target: "#{options[:plugin_conf_dir]}/python-config.conf"
+              target: "#{options[:plugin_conf_dir]}/python.d/foo.conf"
             )
           end
 
           it 'includes foo module configuration' do
-            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo').with(
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo_header').with(
               content: %r{<Module "foo">},
-              target: "#{options[:plugin_conf_dir]}/python-config.conf"
+              target: "#{options[:plugin_conf_dir]}/python.d/foo.conf"
             )
-            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo').with(content: %r{Verbose true})
-            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo').with(content: %r{Bar "bar"})
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo_header').with(content: %r{Verbose true})
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo_header').with(content: %r{Bar "bar"})
           end
         end
 
@@ -228,6 +236,11 @@ describe 'collectd::plugin::python', type: :class do
           is_expected.to contain_concat__fragment('collectd_plugin_python_conf_header').with(content: %r{LogTraces true})
           is_expected.to contain_concat__fragment('collectd_plugin_python_conf_header').with(content: %r{Interactive true})
           is_expected.to contain_concat__fragment('collectd_plugin_python_conf_header').with(content: %r{Encoding utf-8})
+        end
+        it 'includes directory of python module configurations' do
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_footer').with(
+            content: %r{Include "/etc/collectd.d/python.d/\*\.conf"}
+          )
         end
       end
 

--- a/spec/classes/collectd_plugin_rabbitmq_spec.rb
+++ b/spec/classes/collectd_plugin_rabbitmq_spec.rb
@@ -24,35 +24,35 @@ describe 'collectd::plugin::rabbitmq', type: :class do
           end
 
           it 'Load collectd_rabbitmq in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(%r{Module "collectd_rabbitmq.collectd_plugin"})
+            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_header').with_content(%r{Module "collectd_rabbitmq.collectd_plugin"})
           end
 
           it 'import collectd_rabbitmq.collectd_plugin in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(%r{Import "collectd_rabbitmq.collectd_plugin"})
+            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_header').with_content(%r{Import "collectd_rabbitmq.collectd_plugin"})
           end
 
           it 'default to Username guest in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(%r{Username "guest"})
+            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_header').with_content(%r{Username "guest"})
           end
 
           it 'default to Password guest in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(%r{Password "guest"})
+            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_header').with_content(%r{Password "guest"})
           end
 
           it 'default to Port 15672 in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(%r{Port "15672"})
+            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_header').with_content(%r{Port "15672"})
           end
 
           it 'default to Scheme http in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(%r{Scheme "http"})
+            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_header').with_content(%r{Scheme "http"})
           end
 
           it 'Host should be set to $::fqdn python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(%r{Host "testhost.example.com"})
+            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_header').with_content(%r{Host "testhost.example.com"})
           end
 
           it 'Realm set to "RabbitMQ Management"' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(%r{Realm "RabbitMQ Management"})
+            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_header').with_content(%r{Realm "RabbitMQ Management"})
           end
         end
 
@@ -72,7 +72,7 @@ describe 'collectd::plugin::rabbitmq', type: :class do
           end
 
           it 'override Username to foo in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(%r{Username "foo"})
+            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_header').with_content(%r{Username "foo"})
           end
         end
 
@@ -82,7 +82,7 @@ describe 'collectd::plugin::rabbitmq', type: :class do
           end
 
           it 'override Username to foo in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(%r{Password "foo"})
+            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_header').with_content(%r{Password "foo"})
           end
         end
 
@@ -92,7 +92,7 @@ describe 'collectd::plugin::rabbitmq', type: :class do
           end
 
           it 'override Username to foo in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with_content(%r{Scheme "https"})
+            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_header').with_content(%r{Scheme "https"})
           end
         end
       end
@@ -103,7 +103,7 @@ describe 'collectd::plugin::rabbitmq', type: :class do
         end
 
         it 'Will remove python-config' do
-          is_expected.not_to contain_concat__fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin').with(ensure: 'present')
+          is_expected.not_to contain_concat__fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_header').with(ensure: 'present')
         end
       end
 

--- a/spec/defines/collectd_plugin_python_module_spec.rb
+++ b/spec/defines/collectd_plugin_python_module_spec.rb
@@ -18,27 +18,27 @@ describe 'collectd::plugin::python::module', type: :define do
         end
 
         it 'imports spam module' do
-          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_spam').with(
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_spam_header').with(
             content: %r{Import "spam"},
-            target: "#{options[:plugin_conf_dir]}/python-config.conf"
+            target: "#{options[:plugin_conf_dir]}/python.d/spam.conf"
           )
         end
 
         it 'includes spam module configuration' do
-          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_spam').with(
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_spam_header').with(
             content: %r{<Module "spam">},
-            target: "#{options[:plugin_conf_dir]}/python-config.conf"
+            target: "#{options[:plugin_conf_dir]}/python.d/spam.conf"
           )
 
-          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_spam').with(
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_spam_header').with(
             content: %r{spam "wonderful" "lovely"}
           )
         end
 
-        it "Will create #{options[:plugin_conf_dir]}python-config.conf" do
-          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_header').with(
+        it "Will create #{options[:plugin_conf_dir]}/python.d/spam.conf" do
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_spam_header').with(
             content: %r{<Plugin "python">},
-            target: "#{options[:plugin_conf_dir]}/python-config.conf",
+            target: "#{options[:plugin_conf_dir]}/python.d/spam.conf",
             order: '00'
           )
         end
@@ -51,9 +51,9 @@ describe 'collectd::plugin::python::module', type: :define do
         end
 
         it "Will create #{options[:plugin_conf_dir]}/python-config.conf" do
-          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_footer').with(
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_spam_footer').with(
             content: %r{</Plugin>},
-            target: "#{options[:plugin_conf_dir]}/python-config.conf",
+            target: "#{options[:plugin_conf_dir]}/python.d/spam.conf",
             order: '99'
           )
         end
@@ -69,18 +69,18 @@ describe 'collectd::plugin::python::module', type: :define do
         end
 
         it 'imports foo module' do
-          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo').with(
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo_header').with(
             content: %r{Import "foo"},
-            target: "#{options[:plugin_conf_dir]}/python-config.conf"
+            target: "#{options[:plugin_conf_dir]}/python.d/foo.conf"
           )
         end
 
         it 'includes foo module configuration' do
-          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo').with(
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo_header').with(
             content: %r{<Module "foo">},
-            target: "#{options[:plugin_conf_dir]}/python-config.conf"
+            target: "#{options[:plugin_conf_dir]}/python.d/foo.conf"
           )
-          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo').with(content: %r{bar "baz"})
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo_header').with(content: %r{bar "baz"})
         end
 
         it 'created collectd plugin file on Debian default path' do
@@ -100,11 +100,11 @@ describe 'collectd::plugin::python::module', type: :define do
         end
 
         it 'includes foo module configuration' do
-          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo').with(content: %r{k1 "v1"})
-          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo').with(content: %r{k2 "v21"})
-          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo').with(content: %r{k2 "v22"})
-          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo').with(content: %r{k3 k31 "v31"})
-          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo').with(content: %r{k3 k32 "v32"})
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo_header').with(content: %r{k1 "v1"})
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo_header').with(content: %r{k2 "v21"})
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo_header').with(content: %r{k2 "v22"})
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo_header').with(content: %r{k3 k31 "v31"})
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo_header').with(content: %r{k3 k32 "v32"})
         end
       end
     end

--- a/templates/plugin/python/module_header.conf.erb
+++ b/templates/plugin/python/module_header.conf.erb
@@ -1,3 +1,4 @@
+<Plugin "python">
   <%- require 'shellwords' -%>
   Import "<%= @_module_import %>"
 
@@ -17,5 +18,4 @@
     <%= key %> <% if !!value == value %><%= value %><% else %>"<%= Shellwords.split(value).join('" "') %>"<% end %>
   <%- end -%>
   <%- end -%>
-  </Module>
   <%- end -%>


### PR DESCRIPTION
#### Pull Request (PR) description

Previously a `python-config.conf`

```ApacheConf
<Plugin "python">
  ModulePath "/usr/lib/python2.7/site-packages"
  ModulePath "/usr/libexec/sensors"
  LogTraces true
  Interactive false
  Import "moduleA"

  <Module "moduleA">
    Value "60"
    Value "100"
  </Module>

  Import "moduleB"

  <Module "moduleB">
    Value "120"
  </Module>

</Plugin>
```

This patch rewrites the configuration to

```ApacheConf
<Plugin "python">
  ModulePath "/usr/lib/python2.7/site-packages"
  ModulePath "/usr/libexec/sensors"
  LogTraces true
  Interactive false
</Plugin>
Include /etc/collectd.d/python.d/*.conf
```
And creates two files in the directory, one per python module, e.g. `/etc/collect.d/python.d/moduleA.conf` with

```ApacheConf
<Module Python>
  Import "moduleA"
  <Module "moduleA">
    Value "60"
    Value "100"
  </Module>
</Module Python>
```

As far as I can ascertain these multiple `Module Python` blocks are all loaded together so no
actual difference.

In addition these per python module files are maintained as a concat so it easy to inject configuration
arbitary values into the Module Configration with a defined type.

My use case was this. Create a defined type to configure indidual bits of  array of parameters to a defined type.
One instance defining `60` the other `100`

