### PR TITLE
Fixes #662 accept numbers into configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1474,7 +1474,9 @@ collectd::plugin::python::module {'my-module':
   modulepath    => '/var/share/collectd',
   script_source => 'puppet:///modules/myorg/my-module.py',
   config        => [
-    {'Key' => "value"}
+    {'Key'   => "value",
+     'Value' => 3.4,
+    }
   ]
 }
 ```

--- a/spec/classes/collectd_plugin_python_spec.rb
+++ b/spec/classes/collectd_plugin_python_spec.rb
@@ -84,6 +84,9 @@ describe 'collectd::plugin::python', type: :class do
                 },
                 'foo' => {
                   'config' => [{ 'Verbose' => true, 'Bar' => '"bar"' }]
+                },
+                'alpha' => {
+                  'config' => [{ 'Beta' => 4.2, 'Gamma' => 'b', 'Delta' => ['a', 4, 5] }]
                 }
               }
             }
@@ -139,6 +142,18 @@ describe 'collectd::plugin::python', type: :class do
             )
             is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo').with(content: %r{Verbose true})
             is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo').with(content: %r{Bar "bar"})
+          end
+
+          it 'includes alpha module configuration' do
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_alpha').with(
+              content: %r{<Module "alpha">},
+              target: "#{options[:plugin_conf_dir]}/python-config.conf"
+            )
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_alpha').with(content: %r{Beta 4.2})
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_alpha').with(content: %r{Delta "a"})
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_alpha').with(content: %r{Delta 4})
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_alpha').with(content: %r{Delta 5})
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_alpha').with(content: %r{Gamma "b"})
           end
         end
 

--- a/templates/plugin/python/module.conf.erb
+++ b/templates/plugin/python/module.conf.erb
@@ -7,14 +7,16 @@
   <%- configuration.sort.each do |key,value| -%>
   <%- if value.is_a?(Array) -%>
   <%- value.each do |v| -%>
-    <%= key %> <% if !!v == v %><%= v %><% else %>"<%= Shellwords.split(v).join('" "') %>"<% end %>
+    <%= key %> <% if !!v == v %><%= v %><% elsif v.is_a?(Numeric) %><%= v.to_s %><% else %>"<%= Shellwords.split(v).join('" "') %>"<% end %>
   <%- end -%>
+  <%  elsif value.is_a?(Numeric) -%>
+    <%= key %> <%= value.to_s %>
   <%- elsif value.is_a?(Hash) -%>
   <%- value.sort.each do |k,v| -%>
-    <%= key %> <%= k %> <% if !!v == v %><%= v %><% else %>"<%= Shellwords.split(v).join('" "') %>"<% end %>
+    <%= key %> <%= k %> <% if !!v == v %><%= v %><% elsif v.is_a?(Numeric) %><%= v.to_s %><% else %>"<%= Shellwords.split(v).join('" "') %>"<% end %>
   <%- end -%>
   <%- else -%>
-    <%= key %> <% if !!value == value %><%= value %><% else %>"<%= Shellwords.split(value).join('" "') %>"<% end %>
+    <%= key %> <% if !!value == value %><%= value %><% elsif value.is_a?(Numeric) %><%= value.to_s %><% else %>"<%= Shellwords.split(value).join('" "') %>"<% end %>
   <%- end -%>
   <%- end -%>
   </Module>


### PR DESCRIPTION
#### Pull Request (PR) description

With a configuration of

```puppet
collectd::python::python{'foo':
  modules => { 'foo' => { config => [{'value' => 4}]
                        }
             }
}
```

Puppet fails with `undefined method scan for 4:Fixnum`.

Integers and floats are now accepted and displayed as numbers.

#### This Pull Request (PR) fixes the following issues
Fixes #662
