### PR TITLE
Add ipc plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ documentation for each plugin for configurable attributes.
 * `intel_rdt` (see [collectd::plugin::intel_rdt](#class-collectdpluginintel_rdt) below)
 * `interface` (see [collectd::plugin::interface](#class-collectdplugininterface)
   below)
+* `ipc` (see [collectd::plugin::ipc](#class-collectdpluginipc) below)
 * `ipmi` (see [collectd::plugin::ipmi](#class-collectdpluginipmi) below)
 * `iptables` (see [collectd::plugin::iptables](#class-collectdpluginiptables) below)
 * `iscdhcp` (see [collectd::plugin::iscdhcp](#class-collectdpluginiscdhcp) below)
@@ -915,6 +916,13 @@ class { 'collectd::plugin::interface':
 class { 'collectd::plugin::irq':
   irqs           => ['7', '23'],
   ignoreselected => true,
+}
+```
+
+#### Class: `collectd::plugin::ipc`
+
+```puppet
+class { 'collectd::plugin::ipc':
 }
 ```
 

--- a/manifests/plugin/ipc.pp
+++ b/manifests/plugin/ipc.pp
@@ -1,0 +1,23 @@
+#== Class: collectd::plugin::ipc
+#
+# Class to manage ipc write plugin for collectd
+#
+# Documentation:
+#   https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_ipc
+#
+# === Parameters
+#
+# [*ensure*]
+#  Ensure param for collectd::plugin type.
+#  Defaults to 'ensure'
+#
+class collectd::plugin::ipc (
+  Enum['present', 'absent'] $ensure   = 'present',
+) {
+
+  include collectd
+
+  collectd::plugin { 'ipc':
+    ensure   => $ensure,
+  }
+}


### PR DESCRIPTION
Add ipc plugin

Collectd plugin ipc have been added in Collectd 5.5.

This change adds its support to puppet-collectd