### PR TITLE
Make the threshold plugin configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1801,6 +1801,42 @@ class { '::collectd::plugin::thermal':
 
 ```puppet
 class { 'collectd::plugin::threshold':
+  hosts   => [
+    {
+      name    => 'example.com',
+      plugins => [
+        {
+          name  => 'load',
+          types => [
+            {
+              name        => 'load',
+              data_source => 'shortterm',
+              warning_max => $facts.dig('processors', 'count') * 1.2,
+              failure_max => $facts.dig('processors', 'count') * 1.9,
+            },
+            {
+              name        => 'load',
+              data_source => 'midterm',
+              warning_max => $facts.dig('processors', 'count') * 1.1,
+              failure_max => $facts.dig('processors', 'count') * 1.7,
+            },
+            {
+              name        => 'load',
+              data_source => 'longterm',
+              warning_max => $facts.dig('processors', 'count'),
+              failure_max => $facts.dig('processors', 'count') * 1.5,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  plugins => [
+    # See plugin definition above
+  ],
+  types   => [
+    # See types definition above
+  ],
 }
 ```
 

--- a/functions/indent.pp
+++ b/functions/indent.pp
@@ -1,0 +1,4 @@
+function collectd::indent(String $arg) >> String {
+  $body = regsubst($arg,  "\n(.)", "\n  \\1", 'G')
+  "  ${body}"
+}

--- a/manifests/plugin/threshold.pp
+++ b/manifests/plugin/threshold.pp
@@ -2,9 +2,9 @@
 class collectd::plugin::threshold (
   $ensure   = 'present',
   $interval = undef,
-  Hash[String[1], Collectd::Threshold::Type]   $types   = {},
-  Hash[String[1], Collectd::Threshold::Plugin] $plugins = {},
-  Hash[String[1], Collectd::Threshold::Host]   $hosts   = {},
+  Array[Collectd::Threshold::Type]   $types   = [],
+  Array[Collectd::Threshold::Plugin] $plugins = [],
+  Array[Collectd::Threshold::Host]   $hosts   = [],
 ) {
 
   include ::collectd

--- a/manifests/plugin/threshold.pp
+++ b/manifests/plugin/threshold.pp
@@ -2,12 +2,16 @@
 class collectd::plugin::threshold (
   $ensure   = 'present',
   $interval = undef,
+  Hash[String, Collectd::Threshold::Type]   $types   = {},
+  Hash[String, Collectd::Threshold::Plugin] $plugins = {},
+  Hash[String, Collectd::Threshold::Host]   $hosts   = {},
 ) {
 
   include ::collectd
 
   collectd::plugin { 'threshold':
     ensure   => $ensure,
+    content  => epp('collectd/plugin/threshold.conf.epp'),
     interval => $interval,
   }
 }

--- a/manifests/plugin/threshold.pp
+++ b/manifests/plugin/threshold.pp
@@ -2,9 +2,9 @@
 class collectd::plugin::threshold (
   $ensure   = 'present',
   $interval = undef,
-  Hash[String, Collectd::Threshold::Type]   $types   = {},
-  Hash[String, Collectd::Threshold::Plugin] $plugins = {},
-  Hash[String, Collectd::Threshold::Host]   $hosts   = {},
+  Hash[String[1], Collectd::Threshold::Type]   $types   = {},
+  Hash[String[1], Collectd::Threshold::Plugin] $plugins = {},
+  Hash[String[1], Collectd::Threshold::Host]   $hosts   = {},
 ) {
 
   include ::collectd

--- a/manifests/plugin/threshold.pp
+++ b/manifests/plugin/threshold.pp
@@ -1,10 +1,10 @@
 # http://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_threshold
 class collectd::plugin::threshold (
-  $ensure   = 'present',
-  $interval = undef,
-  Array[Collectd::Threshold::Type]   $types   = [],
-  Array[Collectd::Threshold::Plugin] $plugins = [],
-  Array[Collectd::Threshold::Host]   $hosts   = [],
+  Enum['present', 'absent']          $ensure   = 'present',
+  Optional[Integer]                  $interval = undef,
+  Array[Collectd::Threshold::Type]   $types    = [],
+  Array[Collectd::Threshold::Plugin] $plugins  = [],
+  Array[Collectd::Threshold::Host]   $hosts    = [],
 ) {
 
   include ::collectd

--- a/spec/classes/collectd_plugin_threshold_spec.rb
+++ b/spec/classes/collectd_plugin_threshold_spec.rb
@@ -7,6 +7,58 @@ describe 'collectd::plugin::threshold', type: :class do
         facts
       end
 
+      let :params do
+        {
+          'types' => {
+            'foo' => {
+              'warning_min' =>    0.00,
+              'warning_max' => 1000.00,
+              'failure_min' =>    0.00,
+              'failure_max' => 1200.00,
+              'invert'      => false,
+              'instance'    => 'bar'
+            }
+          },
+          'plugins' => {
+            'interface' => {
+              'instance' => 'eth0',
+              'types'    => {
+                'if_octets' => {
+                  'failure_max' => 10_000_000,
+                  'data_source' => 'rx'
+                }
+              }
+            }
+          },
+          'hosts' => {
+            'hostname' => {
+              'types' => {
+                'cpu' => {
+                  'instance'    => 'idle',
+                  'failure_min' => 10
+                },
+                'load' => {
+                  'data_source' => 'midterm',
+                  'failure_max' => 4,
+                  'hits'        => 3,
+                  'hysteresis'  => 3
+                }
+              },
+              'plugins' => {
+                'memory' => {
+                  'types' => {
+                    'memory' => {
+                      'instance'    => 'cached',
+                      'warning_min' => 100_000_000
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      end
+
       options = os_specific_options(facts)
       context ':ensure => present' do
         context ':ensure => present and default parameters' do
@@ -17,6 +69,32 @@ describe 'collectd::plugin::threshold', type: :class do
               content: %r{LoadPlugin threshold}
             )
           end
+
+          it { is_expected.to contain_file('threshold.load').with(content: %r{<Type "foo">}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{WarningMin 0\.0}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{WarningMax 1000\.0}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{FailureMin 0\.0}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{FailureMax 1200\.0}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{Invert false}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{Instance "bar"}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{<Plugin "interface">}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{Instance "eth0"}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{<Type "if_octets">}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{FailureMax 10000000}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{DataSource "rx"}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{<Host "hostname">}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{<Type "cpu">}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{Instance "idle"}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{FailureMin 10}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{<Plugin "memory">}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{<Type "memory">}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{Instance "cached"}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{WarningMin 100000000}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{<Type "load">}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{DataSource "midterm"}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{FailureMax 4}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{Hits 3}) }
+          it { is_expected.to contain_file('threshold.load').with(content: %r{Hysteresis 3}) }
         end
       end
     end

--- a/spec/classes/collectd_plugin_threshold_spec.rb
+++ b/spec/classes/collectd_plugin_threshold_spec.rb
@@ -9,8 +9,9 @@ describe 'collectd::plugin::threshold', type: :class do
 
       let :params do
         {
-          'types' => {
-            'foo' => {
+          'types' => [
+            {
+              'name'        => 'foo',
               'warning_min' =>    0.00,
               'warning_max' => 1000.00,
               'failure_min' =>    0.00,
@@ -18,44 +19,51 @@ describe 'collectd::plugin::threshold', type: :class do
               'invert'      => false,
               'instance'    => 'bar'
             }
-          },
-          'plugins' => {
-            'interface' => {
+          ],
+          'plugins' => [
+            {
+              'name'     => 'interface',
               'instance' => 'eth0',
-              'types'    => {
-                'if_octets' => {
+              'types'    => [
+                {
+                  'name'        => 'if_octets',
                   'failure_max' => 10_000_000,
                   'data_source' => 'rx'
                 }
-              }
+              ]
             }
-          },
-          'hosts' => {
-            'hostname' => {
-              'types' => {
-                'cpu' => {
+          ],
+          'hosts' => [
+            {
+              'name'  => 'hostname',
+              'types' => [
+                {
+                  'name'        => 'cpu',
                   'instance'    => 'idle',
                   'failure_min' => 10
                 },
-                'load' => {
+                {
+                  'name'        => 'load',
                   'data_source' => 'midterm',
                   'failure_max' => 4,
                   'hits'        => 3,
                   'hysteresis'  => 3
                 }
-              },
-              'plugins' => {
-                'memory' => {
-                  'types' => {
-                    'memory' => {
+              ],
+              'plugins' => [
+                {
+                  'name'  => 'memory',
+                  'types' => [
+                    {
+                      'name'        => 'memory',
                       'instance'    => 'cached',
                       'warning_min' => 100_000_000
                     }
-                  }
+                  ]
                 }
-              }
+              ]
             }
-          }
+          ]
         }
       end
 

--- a/spec/classes/collectd_plugin_threshold_spec.rb
+++ b/spec/classes/collectd_plugin_threshold_spec.rb
@@ -7,7 +7,7 @@ describe 'collectd::plugin::threshold', type: :class do
         facts
       end
 
-      let :params do
+      let :custom_params do
         {
           'types' => [
             {
@@ -76,6 +76,31 @@ describe 'collectd::plugin::threshold', type: :class do
               path: "#{options[:plugin_conf_dir]}/10-threshold.conf",
               content: %r{LoadPlugin threshold}
             )
+          end
+        end
+
+        context ':ensure => present and empty configurations' do
+          let :params do
+            {
+              'hosts' => [
+                {
+                  'name' => 'example.com'
+                }
+              ],
+              'plugins' => [
+                {
+                  'name' => 'interface'
+                }
+              ]
+            }
+          end
+
+          it { is_expected.to compile }
+        end
+
+        context ':ensure => present and custom parameters' do
+          let :params do
+            custom_params
           end
 
           it { is_expected.to contain_file('threshold.load').with(content: %r{<Type "foo">}) }

--- a/templates/plugin/threshold.conf.epp
+++ b/templates/plugin/threshold.conf.epp
@@ -1,11 +1,11 @@
 <Plugin "threshold">
-  <%- $collectd::plugin::threshold::hosts.each |$host| { -%>
+  <%- $collectd::plugin::threshold::hosts.lest || { [] }.each |$host| { -%>
 <%= collectd::indent(epp('collectd/plugin/threshold/host.epp', { host => $host })) -%>
   <%- } -%>
-  <%- $collectd::plugin::threshold::plugins.each |$plugin| { -%>
+  <%- $collectd::plugin::threshold::plugins.lest || { [] }.each |$plugin| { -%>
 <%= collectd::indent(epp('collectd/plugin/threshold/plugin.epp', { plugin => $plugin })) -%>
   <%- } -%>
-  <%- $collectd::plugin::threshold::types.each |$type| { -%>
+  <%- $collectd::plugin::threshold::types.lest || { [] }.each |$type| { -%>
 <%= collectd::indent(epp('collectd/plugin/threshold/type.epp', { type => $type })) -%>
   <%- } -%>
 </Plugin>

--- a/templates/plugin/threshold.conf.epp
+++ b/templates/plugin/threshold.conf.epp
@@ -1,11 +1,11 @@
 <Plugin "threshold">
-  <%- $collectd::plugin::threshold::hosts.each |$name, $values| { -%>
-<%= collectd::indent(epp('collectd/plugin/threshold/host.epp', {name => $name, values => $values })) -%>
+  <%- $collectd::plugin::threshold::hosts.each |$host| { -%>
+<%= collectd::indent(epp('collectd/plugin/threshold/host.epp', { host => $host })) -%>
   <%- } -%>
-  <%- $collectd::plugin::threshold::plugins.each |$name, $values| { -%>
-<%= collectd::indent(epp('collectd/plugin/threshold/plugin.epp', {name => $name, values => $values })) -%>
+  <%- $collectd::plugin::threshold::plugins.each |$plugin| { -%>
+<%= collectd::indent(epp('collectd/plugin/threshold/plugin.epp', { plugin => $plugin })) -%>
   <%- } -%>
-  <%- $collectd::plugin::threshold::types.each |$name, $values| { -%>
-<%= collectd::indent(epp('collectd/plugin/threshold/type.epp', {name => $name, values => $values })) -%>
+  <%- $collectd::plugin::threshold::types.each |$type| { -%>
+<%= collectd::indent(epp('collectd/plugin/threshold/type.epp', { type => $type })) -%>
   <%- } -%>
 </Plugin>

--- a/templates/plugin/threshold.conf.epp
+++ b/templates/plugin/threshold.conf.epp
@@ -1,0 +1,11 @@
+<Plugin "threshold">
+  <%- $collectd::plugin::threshold::hosts.each |$name, $values| { -%>
+<%= collectd::indent(epp('collectd/plugin/threshold/host.epp', {name => $name, values => $values })) -%>
+  <%- } -%>
+  <%- $collectd::plugin::threshold::plugins.each |$name, $values| { -%>
+<%= collectd::indent(epp('collectd/plugin/threshold/plugin.epp', {name => $name, values => $values })) -%>
+  <%- } -%>
+  <%- $collectd::plugin::threshold::types.each |$name, $values| { -%>
+<%= collectd::indent(epp('collectd/plugin/threshold/type.epp', {name => $name, values => $values })) -%>
+  <%- } -%>
+</Plugin>

--- a/templates/plugin/threshold/host.epp
+++ b/templates/plugin/threshold/host.epp
@@ -1,8 +1,8 @@
 <Host "<%= $host['name'] %>">
-  <%- $host['plugins'].each |$plugin| { -%>
+  <%- $host['plugins'].lest || { [] }.each |$plugin| { -%>
 <%= collectd::indent(epp('collectd/plugin/threshold/plugin.epp', { plugin => $plugin })) -%>
   <%- } -%>
-  <%- $host['types'].each |$type| { -%>
+  <%- $host['types'].lest || { [] }.each |$type| { -%>
 <%= collectd::indent(epp('collectd/plugin/threshold/type.epp', { type => $type })) -%>
   <%- } -%>
 </Host>

--- a/templates/plugin/threshold/host.epp
+++ b/templates/plugin/threshold/host.epp
@@ -1,8 +1,8 @@
-<Host "<%= $name %>">
-  <%- $values['plugins'].each |$name, $values| { -%>
-<%= collectd::indent(epp('collectd/plugin/threshold/plugin.epp', {name => $name, values => $values })) -%>
+<Host "<%= $host['name'] %>">
+  <%- $host['plugins'].each |$plugin| { -%>
+<%= collectd::indent(epp('collectd/plugin/threshold/plugin.epp', { plugin => $plugin })) -%>
   <%- } -%>
-  <%- $values['types'].each |$name, $values| { -%>
-<%= collectd::indent(epp('collectd/plugin/threshold/type.epp', {name => $name, values => $values })) -%>
+  <%- $host['types'].each |$type| { -%>
+<%= collectd::indent(epp('collectd/plugin/threshold/type.epp', { type => $type })) -%>
   <%- } -%>
 </Host>

--- a/templates/plugin/threshold/host.epp
+++ b/templates/plugin/threshold/host.epp
@@ -1,0 +1,8 @@
+<Host "<%= $name %>">
+  <%- $values['plugins'].each |$name, $values| { -%>
+<%= collectd::indent(epp('collectd/plugin/threshold/plugin.epp', {name => $name, values => $values })) -%>
+  <%- } -%>
+  <%- $values['types'].each |$name, $values| { -%>
+<%= collectd::indent(epp('collectd/plugin/threshold/type.epp', {name => $name, values => $values })) -%>
+  <%- } -%>
+</Host>

--- a/templates/plugin/threshold/plugin.epp
+++ b/templates/plugin/threshold/plugin.epp
@@ -1,8 +1,8 @@
-<Plugin "<%= $name %>">
-  <%- if $values['instance'] != undef { -%>
-  Instance "<%= $values['instance'] %>"
+<Plugin "<%= $plugin['name'] %>">
+  <%- if $plugin['instance'] != undef { -%>
+  Instance "<%= $plugin['instance'] %>"
   <%- } -%>
-  <%- $values['types'].each |$name, $values| { -%>
-<%= collectd::indent(epp('collectd/plugin/threshold/type.epp', {name => $name, values => $values })) -%>
+  <%- $plugin['types'].each |$type| { -%>
+<%= collectd::indent(epp('collectd/plugin/threshold/type.epp', { type => $type })) -%>
   <%- } -%>
 </Plugin>

--- a/templates/plugin/threshold/plugin.epp
+++ b/templates/plugin/threshold/plugin.epp
@@ -2,7 +2,7 @@
   <%- if $plugin['instance'] != undef { -%>
   Instance "<%= $plugin['instance'] %>"
   <%- } -%>
-  <%- $plugin['types'].each |$type| { -%>
+  <%- $plugin['types'].lest || { [] }.each |$type| { -%>
 <%= collectd::indent(epp('collectd/plugin/threshold/type.epp', { type => $type })) -%>
   <%- } -%>
 </Plugin>

--- a/templates/plugin/threshold/plugin.epp
+++ b/templates/plugin/threshold/plugin.epp
@@ -1,0 +1,8 @@
+<Plugin "<%= $name %>">
+  <%- if $values['instance'] != undef { -%>
+  Instance "<%= $values['instance'] %>"
+  <%- } -%>
+  <%- $values['types'].each |$name, $values| { -%>
+<%= collectd::indent(epp('collectd/plugin/threshold/type.epp', {name => $name, values => $values })) -%>
+  <%- } -%>
+</Plugin>

--- a/templates/plugin/threshold/type.epp
+++ b/templates/plugin/threshold/type.epp
@@ -1,41 +1,41 @@
-<Type "<%= $name %>">
-  <%- if $values['instance'] != undef { -%>
-  Instance "<%= $values['instance'] %>"
+<Type "<%= $type['name'] %>">
+  <%- if $type['instance'] != undef { -%>
+  Instance "<%= $type['instance'] %>"
   <%- } -%>
-  <%- if $values['failure_max'] != undef { -%>
-  FailureMax <%= $values['failure_max'] %>
+  <%- if $type['failure_max'] != undef { -%>
+  FailureMax <%= $type['failure_max'] %>
   <%- } -%>
-  <%- if $values['failure_min'] != undef { -%>
-  FailureMin <%= $values['failure_min'] %>
+  <%- if $type['failure_min'] != undef { -%>
+  FailureMin <%= $type['failure_min'] %>
   <%- } -%>
-  <%- if $values['warning_max'] != undef { -%>
-  WarningMax <%= $values['warning_max'] %>
+  <%- if $type['warning_max'] != undef { -%>
+  WarningMax <%= $type['warning_max'] %>
   <%- } -%>
-  <%- if $values['warning_min'] != undef { -%>
-  WarningMin <%= $values['warning_min'] %>
+  <%- if $type['warning_min'] != undef { -%>
+  WarningMin <%= $type['warning_min'] %>
   <%- } -%>
-  <%- if $values['data_source'] != undef { -%>
-  DataSource "<%= $values['data_source'] %>"
+  <%- if $type['data_source'] != undef { -%>
+  DataSource "<%= $type['data_source'] %>"
   <%- } -%>
-  <%- if $values['invert'] != undef { -%>
-  Invert <%= $values['invert'] %>
+  <%- if $type['invert'] != undef { -%>
+  Invert <%= $type['invert'] %>
   <%- } -%>
-  <%- if $values['persist'] != undef { -%>
-  Persist <%= $values['persist'] %>
+  <%- if $type['persist'] != undef { -%>
+  Persist <%= $type['persist'] %>
   <%- } -%>
-  <%- if $values['persist_ok'] != undef { -%>
-  PersistOK <%= $values['persist_ok'] %>
+  <%- if $type['persist_ok'] != undef { -%>
+  PersistOK <%= $type['persist_ok'] %>
   <%- } -%>
-  <%- if $values['percentage'] != undef { -%>
-  Percentage <%= $values['percentage'] %>
+  <%- if $type['percentage'] != undef { -%>
+  Percentage <%= $type['percentage'] %>
   <%- } -%>
-  <%- if $values['hits'] != undef { -%>
-  Hits <%= $values['hits'] %>
+  <%- if $type['hits'] != undef { -%>
+  Hits <%= $type['hits'] %>
   <%- } -%>
-  <%- if $values['hysteresis'] != undef { -%>
-  Hysteresis <%= $values['hysteresis'] %>
+  <%- if $type['hysteresis'] != undef { -%>
+  Hysteresis <%= $type['hysteresis'] %>
   <%- } -%>
-  <%- if $values['interesting'] != undef { -%>
-  Interesting <%= $values['interesting'] %>
+  <%- if $type['interesting'] != undef { -%>
+  Interesting <%= $type['interesting'] %>
   <%- } -%>
 </Type>

--- a/templates/plugin/threshold/type.epp
+++ b/templates/plugin/threshold/type.epp
@@ -1,0 +1,41 @@
+<Type "<%= $name %>">
+  <%- if $values['instance'] != undef { -%>
+  Instance "<%= $values['instance'] %>"
+  <%- } -%>
+  <%- if $values['failure_max'] != undef { -%>
+  FailureMax <%= $values['failure_max'] %>
+  <%- } -%>
+  <%- if $values['failure_min'] != undef { -%>
+  FailureMin <%= $values['failure_min'] %>
+  <%- } -%>
+  <%- if $values['warning_max'] != undef { -%>
+  WarningMax <%= $values['warning_max'] %>
+  <%- } -%>
+  <%- if $values['warning_min'] != undef { -%>
+  WarningMin <%= $values['warning_min'] %>
+  <%- } -%>
+  <%- if $values['data_source'] != undef { -%>
+  DataSource "<%= $values['data_source'] %>"
+  <%- } -%>
+  <%- if $values['invert'] != undef { -%>
+  Invert <%= $values['invert'] %>
+  <%- } -%>
+  <%- if $values['persist'] != undef { -%>
+  Persist <%= $values['persist'] %>
+  <%- } -%>
+  <%- if $values['persist_ok'] != undef { -%>
+  PersistOK <%= $values['persist_ok'] %>
+  <%- } -%>
+  <%- if $values['percentage'] != undef { -%>
+  Percentage <%= $values['percentage'] %>
+  <%- } -%>
+  <%- if $values['hits'] != undef { -%>
+  Hits <%= $values['hits'] %>
+  <%- } -%>
+  <%- if $values['hysteresis'] != undef { -%>
+  Hysteresis <%= $values['hysteresis'] %>
+  <%- } -%>
+  <%- if $values['interesting'] != undef { -%>
+  Interesting <%= $values['interesting'] %>
+  <%- } -%>
+</Type>

--- a/types/threshold/host.pp
+++ b/types/threshold/host.pp
@@ -1,5 +1,5 @@
 type Collectd::Threshold::Host = Struct[{
   name    => String[1],
-  plugins => Array[Collectd::Threshold::Plugin],
-  types   => Array[Collectd::Threshold::Type],
+  plugins => Optional[Array[Collectd::Threshold::Plugin]],
+  types   => Optional[Array[Collectd::Threshold::Type]],
 }]

--- a/types/threshold/host.pp
+++ b/types/threshold/host.pp
@@ -1,4 +1,5 @@
 type Collectd::Threshold::Host = Struct[{
-  plugins => Hash[String[1], Collectd::Threshold::Plugin],
-  types   => Hash[String[1], Collectd::Threshold::Type],
+  name    => String[1],
+  plugins => Array[Collectd::Threshold::Plugin],
+  types   => Array[Collectd::Threshold::Type],
 }]

--- a/types/threshold/host.pp
+++ b/types/threshold/host.pp
@@ -1,0 +1,4 @@
+type Collectd::Threshold::Host = Struct[{
+  plugins => Hash[String, Collectd::Threshold::Plugin],
+  types   => Hash[String, Collectd::Threshold::Type],
+}]

--- a/types/threshold/host.pp
+++ b/types/threshold/host.pp
@@ -1,4 +1,4 @@
 type Collectd::Threshold::Host = Struct[{
-  plugins => Hash[String, Collectd::Threshold::Plugin],
-  types   => Hash[String, Collectd::Threshold::Type],
+  plugins => Hash[String[1], Collectd::Threshold::Plugin],
+  types   => Hash[String[1], Collectd::Threshold::Type],
 }]

--- a/types/threshold/plugin.pp
+++ b/types/threshold/plugin.pp
@@ -1,5 +1,5 @@
 type Collectd::Threshold::Plugin = Struct[{
   name     => String[1],
   instance => Optional[String[1]],
-  types    => Array[Collectd::Threshold::Type],
+  types    => Optional[Array[Collectd::Threshold::Type]],
 }]

--- a/types/threshold/plugin.pp
+++ b/types/threshold/plugin.pp
@@ -1,4 +1,5 @@
 type Collectd::Threshold::Plugin = Struct[{
+  name     => String[1],
   instance => Optional[String[1]],
-  types    => Hash[String[1], Collectd::Threshold::Type],
+  types    => Array[Collectd::Threshold::Type],
 }]

--- a/types/threshold/plugin.pp
+++ b/types/threshold/plugin.pp
@@ -1,4 +1,4 @@
 type Collectd::Threshold::Plugin = Struct[{
-  instance => Optional[String],
-  types    => Hash[String, Collectd::Threshold::Type],
+  instance => Optional[String[1]],
+  types    => Hash[String[1], Collectd::Threshold::Type],
 }]

--- a/types/threshold/plugin.pp
+++ b/types/threshold/plugin.pp
@@ -1,0 +1,4 @@
+type Collectd::Threshold::Plugin = Struct[{
+  instance => Optional[String],
+  types    => Hash[String, Collectd::Threshold::Type],
+}]

--- a/types/threshold/type.pp
+++ b/types/threshold/type.pp
@@ -1,4 +1,5 @@
 type Collectd::Threshold::Type = Struct[{
+  name        => String[1],
   instance    => Optional[String[1]],
   failure_max => Optional[Numeric],
   warning_max => Optional[Numeric],

--- a/types/threshold/type.pp
+++ b/types/threshold/type.pp
@@ -1,10 +1,10 @@
 type Collectd::Threshold::Type = Struct[{
-  instance    => Optional[String],
+  instance    => Optional[String[1]],
   failure_max => Optional[Numeric],
   warning_max => Optional[Numeric],
   failure_min => Optional[Numeric],
   warning_min => Optional[Numeric],
-  data_source => Optional[String],
+  data_source => Optional[String[1]],
   invert      => Optional[Boolean],
   persist     => Optional[Boolean],
   persist_ok  => Optional[Boolean],

--- a/types/threshold/type.pp
+++ b/types/threshold/type.pp
@@ -1,0 +1,15 @@
+type Collectd::Threshold::Type = Struct[{
+  instance    => Optional[String],
+  failure_max => Optional[Numeric],
+  warning_max => Optional[Numeric],
+  failure_min => Optional[Numeric],
+  warning_min => Optional[Numeric],
+  data_source => Optional[String],
+  invert      => Optional[Boolean],
+  persist     => Optional[Boolean],
+  persist_ok  => Optional[Boolean],
+  percentage  => Optional[Boolean],
+  hits        => Optional[Integer],
+  hysteresis  => Optional[Integer],
+  interesting => Optional[Boolean],
+}]


### PR DESCRIPTION
#### Pull Request (PR) description

Allow to configure the threshold plugin

```puppet
class { 'collectd::plugin::processes':
  process_matches => [
    'carbon-cache',
    'python.+carbon-cache',
  ],
}

class { 'collectd::plugin::threshold':
  plugins => {
    processes => {
      instance => 'carbon-cache',
      types    => {
        data_source => 'processes',
        warning_min => 2,
        failure_min => 1,
      },
    },
  },
}
```

#### This Pull Request (PR) fixes the following issues
Fixes #292
