### PR TITLE
Configuration for NFVPE plugins

### DIFF
--- a/manifests/plugin/connectivity.pp
+++ b/manifests/plugin/connectivity.pp
@@ -1,0 +1,40 @@
+#== Class: collectd::plugin::connectivity
+#
+# Class to manage connectivity plugin for collectd
+#
+# Documentation:
+#   https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_connectivity
+#
+# === Parameters
+#
+# [*ensure*]
+#  Ensure param for collectd::plugin type.
+#  Defaults to 'ensure'
+#
+# [*manage_package*]
+#  Set to true if Puppet should manage plugin package installation.
+#  Defaults to $collectd::manage_package
+#
+# [*interfaces*]
+#  Array of interface(s) to monitor connect to. Empty arrayf means all interfaces
+#  Defaults to []
+#
+class collectd::plugin::connectivity (
+  Enum['present', 'absent'] $ensure = 'present',
+  Boolean $manage_package           = $collectd::manage_package,
+  Array[String[1]] $interfaces      = [],
+) {
+
+  include collectd
+
+  if $manage_package and $facts['os']['family'] == 'RedHat' {
+    package { 'collectd-connectivity':
+      ensure => $ensure,
+    }
+  }
+
+  collectd::plugin { 'connectivity':
+    ensure  => $ensure,
+    content => epp('collectd/plugin/connectivity.conf.epp'),
+  }
+}

--- a/manifests/plugin/procevent.pp
+++ b/manifests/plugin/procevent.pp
@@ -1,0 +1,54 @@
+#== Class: collectd::plugin::procevent
+#
+# Class to manage procevent plugin for collectd
+#
+# Documentation:
+#   https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_procevent
+#
+# === Parameters
+#
+# [*ensure*]
+#  Ensure param for collectd::plugin type.
+#  Defaults to 'ensure'
+#
+# [*manage_package*]
+#  Set to true if Puppet should manage plugin package installation.
+#  Defaults to $collectd::manage_package
+#
+# [*process*]
+#  Enumerate a process name to monitor.  All processes that match this exact
+#  name will be monitored for EXECs and EXITs.
+#  Defaults to undef
+#
+# [*regex_process*]
+#  Enumerate a process pattern to monitor.  All processes that match this
+#  regular expression will be monitored for EXECs and EXITs.
+#  Defaults to undef
+#
+# [*buffer_length*]
+#  Maximum number of rsyslog events that can be stored in plugin's ring buffer.
+#  Once an event has been read, its location becomes available for storing
+#  a new event.
+#  Defaults to undef
+#
+class collectd::plugin::procevent (
+  Enum['present', 'absent'] $ensure            = 'present',
+  Boolean $manage_package                      = $collectd::manage_package,
+  Optional[String[1]] $process                 = undef,
+  Optional[String[1]] $regex_process           = undef,
+  Optional[Integer[1, default]] $buffer_length = undef,
+) {
+
+  include collectd
+
+  if $manage_package and $facts['os']['family'] == 'RedHat' {
+    package { 'collectd-procevent':
+      ensure => $ensure,
+    }
+  }
+
+  collectd::plugin { 'procevent':
+    ensure  => $ensure,
+    content => epp('collectd/plugin/procevent.conf.epp'),
+  }
+}

--- a/manifests/plugin/sysevent.pp
+++ b/manifests/plugin/sysevent.pp
@@ -1,0 +1,64 @@
+#== Class: collectd::plugin::sysevent
+#
+# Class to manage sysevent plugin for collectd
+#
+# Documentation:
+#   https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_sysevent
+#
+# === Parameters
+#
+# [*ensure*]
+#  Ensure param for collectd::plugin type.
+#  Defaults to 'ensure'
+#
+# [*manage_package*]
+#  Set to true if Puppet should manage plugin package installation.
+#  Defaults to $collectd::manage_package
+#
+# [*listen_host*]
+#  Listen on this IP for incoming rsyslog messages.
+#  Defaults to '127.0.0.1'
+#
+# [*listen_port*]
+#  Listen on this port for incoming rsyslog messages.
+#  Defaults to 6666
+#
+# [*regex_filter*]
+#  Enumerate a regex filter to apply to all incoming rsyslog messages.  If a
+#  message matches this filter, it will be published.
+#  Defaults to '.*'
+#
+# [*buffer_size*]
+#  Maximum allowed size for incoming rsyslog messages.  Messages that exceed
+#  this number will be truncated to this size.  Default is 4096 bytes.
+#  Defaults to undef
+#
+# [*buffer_length*]
+#  Maximum number of rsyslog events that can be stored in plugin's ring buffer.
+#  Once an event has been read, its location becomes available for storing
+#  a new event.
+#  Defaults to undef
+#
+class collectd::plugin::sysevent (
+  Enum['present', 'absent'] $ensure            = 'present',
+  Boolean $manage_package                      = $collectd::manage_package,
+  Stdlib::Host $listen_host                    = '127.0.0.1',
+  Stdlib::Port $listen_port                    = 6666,
+  String $regex_filter                         = '/.*/',
+  Optional[Integer[0]] $buffer_size            = undef,
+  Optional[Integer[1, default]] $buffer_length = undef,
+) {
+
+  include collectd
+
+  if $manage_package and $facts['os']['family'] == 'RedHat' {
+    package { 'collectd-sysevent':
+      ensure => $ensure,
+    }
+  }
+
+  collectd::plugin { 'sysevent':
+    ensure  => $ensure,
+    content => epp('collectd/plugin/sysevent.conf.epp'),
+  }
+}

--- a/spec/classes/collectd_plugin_connectivity_spec.rb
+++ b/spec/classes/collectd_plugin_connectivity_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::connectivity', type: :class do
+  on_supported_os(baseline_os_hash).each do |os, facts|
+    context "on #{os} " do
+      let :facts do
+        facts
+      end
+
+      let :pre_condition do
+        'include collectd'
+      end
+
+      options = os_specific_options(facts)
+      context ':ensure => present' do
+        let :params do
+          { ensure: 'present' }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_collectd__plugin('connectivity') }
+        it { is_expected.to contain_file('old_connectivity.load').with_ensure('absent') }
+        it { is_expected.to contain_file('older_connectivity.load').with_ensure('absent') }
+        it 'Will create 10-connectivity.conf' do
+          is_expected.to contain_file('connectivity.load').with(
+            ensure: 'present',
+            path: "#{options[:plugin_conf_dir]}/10-connectivity.conf"
+          )
+        end
+        it { is_expected.to contain_file('connectivity.load').with(content: %r{<Plugin connectivity>}) }
+      end
+
+      context 'overriding default parameters' do
+        let(:params) do
+          { ensure: 'present',
+            interfaces: %w[eth0 eth1] }
+        end
+
+        it { is_expected.to contain_file('connectivity.load').with(content: %r{Interface "eth0"}) }
+        it { is_expected.to contain_file('connectivity.load').with(content: %r{Interface "eth1"}) }
+      end
+
+      context ':ensure => absent' do
+        let :params do
+          { ensure: 'absent' }
+        end
+
+        it 'Will not create 10-connectivity.conf' do
+          is_expected.to contain_file('connectivity.load').with(
+            ensure: 'absent',
+            path: "#{options[:plugin_conf_dir]}/10-connectivity.conf"
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/collectd_plugin_procevent_spec.rb
+++ b/spec/classes/collectd_plugin_procevent_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::procevent', type: :class do
+  on_supported_os(baseline_os_hash).each do |os, facts|
+    context "on #{os} " do
+      let :facts do
+        facts
+      end
+
+      let :pre_condition do
+        'include collectd'
+      end
+
+      options = os_specific_options(facts)
+      context ':ensure => present' do
+        let :params do
+          { ensure: 'present' }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_collectd__plugin('procevent') }
+        it { is_expected.to contain_file('old_procevent.load').with_ensure('absent') }
+        it { is_expected.to contain_file('older_procevent.load').with_ensure('absent') }
+        it 'Will create 10-procevent.conf' do
+          is_expected.to contain_file('procevent.load').with(
+            ensure: 'present',
+            path: "#{options[:plugin_conf_dir]}/10-procevent.conf"
+          )
+        end
+        it { is_expected.to contain_file('procevent.load').with(content: %r{<Plugin procevent>}) }
+      end
+
+      context 'overriding default parameters' do
+        let(:params) do
+          { ensure: 'present',
+            process: 'foo',
+            regex_process: '/bar/',
+            buffer_length: 10 }
+        end
+
+        it { is_expected.to contain_file('procevent.load').with(content: %r{Process "foo"}) }
+        it { is_expected.to contain_file('procevent.load').with(content: %r{RegexProcess "/bar/"}) }
+        it { is_expected.to contain_file('procevent.load').with(content: %r{BufferLength 10}) }
+      end
+
+      context ':ensure => absent' do
+        let :params do
+          { ensure: 'absent' }
+        end
+
+        it 'Will not create 10-procevent.conf' do
+          is_expected.to contain_file('procevent.load').with(
+            ensure: 'absent',
+            path: "#{options[:plugin_conf_dir]}/10-procevent.conf"
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/collectd_plugin_sysevent_spec.rb
+++ b/spec/classes/collectd_plugin_sysevent_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::sysevent', type: :class do
+  on_supported_os(baseline_os_hash).each do |os, facts|
+    context "on #{os} " do
+      let :facts do
+        facts
+      end
+
+      let :pre_condition do
+        'include collectd'
+      end
+
+      options = os_specific_options(facts)
+      context ':ensure => present' do
+        let :params do
+          { ensure: 'present' }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_collectd__plugin('sysevent') }
+        it { is_expected.to contain_file('old_sysevent.load').with_ensure('absent') }
+        it { is_expected.to contain_file('older_sysevent.load').with_ensure('absent') }
+        it 'Will create 10-sysevent.conf' do
+          is_expected.to contain_file('sysevent.load').with(
+            ensure: 'present',
+            path: "#{options[:plugin_conf_dir]}/10-sysevent.conf"
+          )
+        end
+        it { is_expected.to contain_file('sysevent.load').with(content: %r{Listen "127.0.0.1" "6666"}) }
+        it { is_expected.to contain_file('sysevent.load').with(content: %r{RegexFilter "/.*/"}) }
+      end
+
+      context 'overriding default parameters' do
+        let(:params) do
+          { ensure: 'present',
+            listen_host: '1.2.3.4',
+            listen_port: 1234,
+            regex_filter: '/foobar/',
+            buffer_size: 4096,
+            buffer_length: 10 }
+        end
+
+        it { is_expected.to contain_file('sysevent.load').with(content: %r{Listen "1.2.3.4" "1234"}) }
+        it { is_expected.to contain_file('sysevent.load').with(content: %r{RegexFilter "/foobar/"}) }
+        it { is_expected.to contain_file('sysevent.load').with(content: %r{BufferSize 4096}) }
+        it { is_expected.to contain_file('sysevent.load').with(content: %r{BufferLength 10}) }
+      end
+
+      context ':ensure => absent' do
+        let :params do
+          { ensure: 'absent' }
+        end
+
+        it 'Will not create 10-sysevent.conf' do
+          is_expected.to contain_file('sysevent.load').with(
+            ensure: 'absent',
+            path: "#{options[:plugin_conf_dir]}/10-sysevent.conf"
+          )
+        end
+      end
+    end
+  end
+end

--- a/templates/plugin/connectivity.conf.epp
+++ b/templates/plugin/connectivity.conf.epp
@@ -1,0 +1,5 @@
+<Plugin connectivity>
+<% $collectd::plugin::connectivity::interfaces.each |$intf| { -%>
+  Interface "<%= $intf %>"
+<% } -%>
+</Plugin>

--- a/templates/plugin/procevent.conf.epp
+++ b/templates/plugin/procevent.conf.epp
@@ -1,0 +1,11 @@
+<Plugin procevent>
+<% unless $::collectd::plugin::procevent::process  =~ Undef { -%>
+    Process "<%= $::collectd::plugin::procevent::process %>"
+<% } -%>
+<% unless $::collectd::plugin::procevent::regex_process  =~ Undef { -%>
+    RegexProcess "<%= $::collectd::plugin::procevent::regex_process %>"
+<% } -%>
+<% unless $::collectd::plugin::procevent::buffer_length =~ Undef { -%>
+    BufferLength <%= $::collectd::plugin::procevent::buffer_length %>
+<% } -%>
+</Plugin>

--- a/templates/plugin/sysevent.conf.epp
+++ b/templates/plugin/sysevent.conf.epp
@@ -1,0 +1,10 @@
+<Plugin sysevent>
+    Listen "<%= $::collectd::plugin::sysevent::listen_host %>" "<%= $::collectd::plugin::sysevent::listen_port %>"
+    RegexFilter "<%= $::collectd::plugin::sysevent::regex_filter %>"
+<% unless $::collectd::plugin::sysevent::buffer_size =~ Undef { -%>
+    BufferSize <%= $::collectd::plugin::sysevent::buffer_size %>
+<% } -%>
+<% unless $::collectd::plugin::sysevent::buffer_length =~ Undef { -%>
+    BufferLength <%= $::collectd::plugin::sysevent::buffer_length %>
+<% } -%>
+</Plugin>


### PR DESCRIPTION
#### Pull Request (PR) description
This patch adds support for NFVPE plugins, namely: sysevent, procevent and connectivity. 
Those plugins are not merged yet in collectd itself, but once this (hopefully) happens, 
we will have configuration patch ready for merge. 

Collectd patches:
https://github.com/collectd/collectd/pull/2624
https://github.com/collectd/collectd/pull/2623
https://github.com/collectd/collectd/pull/2622

#### This Pull Request (PR) fixes the following issues
n/a