### PR TITLE
Fix wrong closure of Host parameter for curljson template

### DIFF
--- a/templates/curl_json.conf.erb
+++ b/templates/curl_json.conf.erb
@@ -9,7 +9,7 @@ LoadPlugin "curl_json"
 <%- end -%>
 <% if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.6']) >= 0) -%>
 <%- if @host -%>
-    Host "<%= @host %>">
+    Host "<%= @host %>"
 <%- end -%>
 <%- end -%>
     Instance "<%= @instance %>"


### PR DESCRIPTION
Configuration file right now is being created with a wrong format since for the Host parameter there is an extra ">"