### PR TITLE
remove reference to collectd::plugin::perl::filename

### DIFF
--- a/manifests/plugin/perl/plugin.pp
+++ b/manifests/plugin/perl/plugin.pp
@@ -30,7 +30,6 @@ define collectd::plugin::perl::plugin (
   }
 
   $conf_dir = $collectd::plugin_conf_dir
-  $base_filename = $collectd::plugin::perl::filename
   $filename = "${conf_dir}/perl/plugin-${order}_${name}.conf"
 
   file { $filename:


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
When using the perl plugin the following issue is raised during catalog compilation, upon inspection this appears to be declared from variable which is not used, so removing it seemed the most logic resolution.

#### This Pull Request (PR) fixes the following issues
`error during compilation: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Unknown variable: 'collectd::plugin::perl::filename'.`
