### PR TITLE
Add address field to memcached plugin

### DIFF
--- a/examples/plugins/memcached.pp
+++ b/examples/plugins/memcached.pp
@@ -1,10 +1,11 @@
 include ::collectd
 
 class { '::collectd::plugin::memcached':
-  instances => {
-    'default' => {
-      'host' => '192.168.122.1',
-      'port' => '11211',
+    instances => {
+        'default' => {
+            'host'    => 'localhost',
+            'address' => '127.0.0.1',
+            'port'    => '11211',
     },
   },
 }

--- a/manifests/plugin/memcached.pp
+++ b/manifests/plugin/memcached.pp
@@ -1,7 +1,13 @@
 # https://collectd.org/wiki/index.php/Plugin:memcached
 class collectd::plugin::memcached (
   $ensure         = 'present',
-  Hash $instances = {'default' => {'host' => '127.0.0.1', 'port' => 11211 } },
+  Hash $instances = {
+    'default' => {
+        'host'    => 'localhost',
+        'address' => '127.0.0.1',
+        'port'    => 11211,
+    },
+  },
   $interval       = undef,
 ) {
 

--- a/spec/classes/collectd_plugin_memcached_spec.rb
+++ b/spec/classes/collectd_plugin_memcached_spec.rb
@@ -9,12 +9,19 @@ describe 'collectd::plugin::memcached', type: :class do
 
       options = os_specific_options(facts)
 
-      context ':ensure => present, default host and port' do
+      context ':ensure => present, default host, address, and port' do
         it "Will create #{options[:plugin_conf_dir]}/memcached.conf" do
+          content = <<EOS
+  <Instance "default">
+    Host "localhost"
+    Address "127.0.0.1"
+    Port 11211
+  </Instance>
+EOS
           is_expected.to contain_file('memcached.load').with(
             ensure: 'present',
             path: "#{options[:plugin_conf_dir]}/10-memcached.conf",
-            content: %r{Host "127.0.0.1"\n.+Port 11211}
+            content: %r{#{content}}
           )
         end
       end
@@ -24,12 +31,17 @@ describe 'collectd::plugin::memcached', type: :class do
           {
             'instances' => {
               'sessions1' => {
-                'host' => '127.0.0.1',
+                'host' => 'localhost',
+                'address' => '127.0.0.1',
                 'port' => '11211'
               },
               'cache1' => {
-                'host' => '127.0.0.1',
+                'host' => 'localhost',
                 'port' => '11212'
+              },
+              'cache3' => {
+                'address' => '127.0.0.1',
+                'port' => '11213'
               }
             }
           }
@@ -38,12 +50,17 @@ describe 'collectd::plugin::memcached', type: :class do
         it "Will create #{options[:plugin_conf_dir]}/memcached.conf" do
           content = <<EOS
   <Instance "sessions1">
-    Host "127.0.0.1"
+    Host "localhost"
+    Address "127.0.0.1"
     Port 11211
   </Instance>
   <Instance "cache1">
-    Host "127.0.0.1"
+    Host "localhost"
     Port 11212
+  </Instance>
+  <Instance "cache3">
+    Address "127.0.0.1"
+    Port 11213
   </Instance>
 EOS
           is_expected.to contain_file('memcached.load').with(

--- a/templates/plugin/memcached.conf.erb
+++ b/templates/plugin/memcached.conf.erb
@@ -1,9 +1,16 @@
 <Plugin memcached>
 <% @instances.each do |name,values| -%>
   <Instance "<%= name %>">
-<% if values['host'] and values['port'] -%>
+<% if values['host'] or values['address'] or values['port'] -%>
+<%- if values['host'] -%>
     Host "<%= values['host'] %>"
+<%- end -%>
+<%- if values['address'] -%>
+    Address "<%= values['address'] %>"
+<%- end -%>
+<%- if values['port'] -%>
     Port <%= values['port'] %>
+<%- end -%>
 <% elsif values['socket'] -%>
     Socket "<%= values['socket'] %>"
 <% end -%>


### PR DESCRIPTION
As addition to the host field, there is also the address setting,
which is helpful sometimes.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This also adds the address field to the memcached plugin.


