### PR TITLE
Use different file name for processes plugin config

### DIFF
--- a/manifests/plugin/processes.pp
+++ b/manifests/plugin/processes.pp
@@ -18,7 +18,9 @@ class collectd::plugin::processes (
     interval => $interval,
   }
 
-  concat { "${collectd::plugin_conf_dir}/processes-config.conf":
+  $config_file = "${collectd::plugin_conf_dir}/processes-plugin-config.conf"
+
+  concat { $config_file:
     ensure         => $ensure,
     mode           => $collectd::config_mode,
     owner          => $collectd::config_owner,
@@ -29,13 +31,13 @@ class collectd::plugin::processes (
   concat::fragment { 'collectd_plugin_processes_conf_header':
     order   => '00',
     content => epp('collectd/plugin/processes-header.conf.epp'),
-    target  => "${collectd::plugin_conf_dir}/processes-config.conf",
+    target  => $config_file,
   }
 
   concat::fragment { 'collectd_plugin_processes_conf_footer':
     order   => '99',
     content => '</Plugin>',
-    target  => "${collectd::plugin_conf_dir}/processes-config.conf",
+    target  => $config_file,
   }
 
   $defaults = { 'ensure' => $ensure }

--- a/manifests/plugin/processes/process.pp
+++ b/manifests/plugin/processes/process.pp
@@ -17,7 +17,7 @@ define collectd::plugin::processes::process (
       'collect_file_descriptor' => $collect_file_descriptor,
       'collect_memory_maps'     => $collect_memory_maps,
     }),
-    target  => "${collectd::plugin_conf_dir}/processes-config.conf",
+    target  => $::collectd::plugin::processes::config_file,
   }
 
 }

--- a/manifests/plugin/processes/processmatch.pp
+++ b/manifests/plugin/processes/processmatch.pp
@@ -19,6 +19,6 @@ define collectd::plugin::processes::processmatch (
       'collect_file_descriptor' => $collect_file_descriptor,
       'collect_memory_maps'     => $collect_memory_maps,
     }),
-    target  => "${collectd::plugin_conf_dir}/processes-config.conf",
+    target  => $::collectd::plugin::processes::config_file,
   }
 }


### PR DESCRIPTION
This change fixes collectd::plugin::processes to work on RHEL-based
systems again after a conflicting change on puppet-collectd v10.0.1.

It uses a different filename for the processes plugin configuration
in a way that it will no longer overwrite a vendor-supplied file that
is being wiped as part of collectd::plugin.

#### Pull Request (PR) description
Updates file name used for collectd::plugin::processes settings.

#### This Pull Request (PR) fixes the following issues
Fixes #851 