### PR TITLE
Persist the interval in the conf file as a number

### DIFF
--- a/spec/classes/collectd_plugin_postgresql_spec.rb
+++ b/spec/classes/collectd_plugin_postgresql_spec.rb
@@ -34,7 +34,8 @@ describe 'collectd::plugin::postgresql', type: :class do
                 'user'     => 'postgres',
                 'password' => 'postgres',
                 'sslmode'  => 'disable',
-                'query'    => %w[disk_io log_delay]
+                'query'    => %w[disk_io log_delay],
+                'interval' => 60
               }
             },
             queries: {
@@ -61,6 +62,7 @@ describe 'collectd::plugin::postgresql', type: :class do
         it "Will create #{options[:plugin_conf_dir]}/postgresql-config.conf" do
           is_expected.to contain_concat__fragment('collectd_plugin_postgresql_conf_db_postgres').with(content: %r{Host \"localhost\"})
           is_expected.to contain_concat__fragment('collectd_plugin_postgresql_conf_db_postgres').with(content: %r{Query \"disk_io\"})
+          is_expected.to contain_concat__fragment('collectd_plugin_postgresql_conf_db_postgres').with(content: %r{Interval 60})
           is_expected.to contain_concat__fragment('collectd_plugin_postgresql_conf_query_log_delay').with(content: %r{Statement \"SELECT \* FROM log_delay_repli;\"\n})
           is_expected.to contain_concat__fragment('collectd_plugin_postgresql_conf_query_log_delay').with(content: %r{<Result>\n})
           is_expected.to contain_concat__fragment('collectd_plugin_postgresql_conf_query_log_delay').with(content: %r{Param \"database\"})

--- a/templates/plugin/postgresql/database.conf.erb
+++ b/templates/plugin/postgresql/database.conf.erb
@@ -12,7 +12,7 @@
     Password "<%= @password %>"
 <% end -%>
 <% if @interval -%>
-    Interval "<%= @interval %>"
+    Interval <%= @interval %>
 <% end -%>
 <% if @instance -%>
     Instance "<%= @instance %>"


### PR DESCRIPTION
When passing it as a string the plugin will basically ignore the setting and write the following to the log file:

```
  cf_util_get_cdtime:
     The Interval option requires exactly one numeric argument.
```

Without this patch it's not possible to declare different databases with different query interval.