### PR TITLE
Fix for Issue #653 - Wrong ci-repo URL for 'master'

### DIFF
--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -8,7 +8,7 @@ class collectd::repo::redhat {
     } else {
       $path_prefix = ''
     }
-      
+
     yumrepo { 'collectd-ci':
       ensure  => present,
       enabled => '1',

--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -2,6 +2,13 @@ class collectd::repo::redhat {
 
   if $::collectd::ci_package_repo {
 
+    # Fix for issue #653
+    if $::collectd::ci_package_repo != 'master' {
+      $path_prefix = 'collectd-'
+    } else {
+      $path_prefix = ''
+    }
+      
     yumrepo { 'collectd-ci':
       ensure  => present,
       enabled => '1',

--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -12,7 +12,7 @@ class collectd::repo::redhat {
     yumrepo { 'collectd-ci':
       ensure  => present,
       enabled => '1',
-      baseurl => "https://pkg.ci.collectd.org/rpm/collectd-${::collectd::ci_package_repo}/epel-${::operatingsystemmajrelease}-${::architecture}",
+      baseurl => "https://pkg.ci.collectd.org/rpm/${path_prefix}${::collectd::ci_package_repo}/epel-${::operatingsystemmajrelease}-${::architecture}",
       gpgkey  => 'https://pkg.ci.collectd.org/pubkey.asc',
     }
 


### PR DESCRIPTION
Many thanks for the puppet-collectd  module. It is magnificent, and I hope that you find this PR worthy. :)

#### Pull Request (PR) description
when the ci_package_repo is set to 'master' an incorrect 'collectd-' was prepended. This patch changes that.

#### This Pull Request (PR) fixes the following issues
Fixes #653 