### PR TITLE
WIP: Change all `port` parameters to use `Stdlib::Port`

### DIFF
--- a/manifests/plugin/amqp1.pp
+++ b/manifests/plugin/amqp1.pp
@@ -27,7 +27,7 @@
 #  Service name or port number on which the AMQP 1.0 intermediary accepts
 #  connections. This argument must be a string, even if the numeric form
 #  is used.
-#  Defaults to '5672'
+#  Defaults to 5672
 #
 # [*user*]
 #  User part of credentials used to authenticate to the AMQP 1.0 intermediary.
@@ -104,7 +104,7 @@ class collectd::plugin::amqp1 (
   Boolean $manage_package            = $collectd::manage_package,
   String $transport                  = 'metrics',
   Stdlib::Host $host                 = 'localhost',
-  String $port                       = '5672',
+  Stdlib::Port $port                 = 5672,
   String $user                       = 'guest',
   String $password                   = 'guest',
   String $address                    = 'collectd',

--- a/manifests/plugin/dns.pp
+++ b/manifests/plugin/dns.pp
@@ -1,13 +1,13 @@
 # Class: collectd::plugin::dns
 #
 class collectd::plugin::dns (
-  Enum['present','absent'] $ensure                   = 'present',
-  Optional[Stdlib::Compat::Ip_address] $ignoresource = undef,
-  String $interface                                  = 'any',
-  Optional[String] $interval                         = undef,
-  $manage_package                                    = undef,
-  $package_name                                      = 'collectd-dns',
-  Variant[String,Boolean] $selectnumericquerytypes   = true,
+  Enum['present','absent'] $ensure                 = 'present',
+  Optional[Stdlib::IP::Address] $ignoresource      = undef,
+  String $interface                                = 'any',
+  Optional[String] $interval                       = undef,
+  $manage_package                                  = undef,
+  $package_name                                    = 'collectd-dns',
+  Variant[String,Boolean] $selectnumericquerytypes = true,
 ) {
 
   include ::collectd

--- a/manifests/plugin/hddtemp.pp
+++ b/manifests/plugin/hddtemp.pp
@@ -1,7 +1,7 @@
 # https://collectd.org/wiki/index.php/Plugin:HDDTemp
 class collectd::plugin::hddtemp (
-  $host         = '127.0.0.1',
-  Integer $port = 7634,
+  Stdlib::Host $host = '127.0.0.1',
+  Stdlib::Port $port = 7634,
   $ensure       = 'present',
   $interval     = undef,
 ) {

--- a/manifests/plugin/mongodb.pp
+++ b/manifests/plugin/mongodb.pp
@@ -5,8 +5,8 @@ class collectd::plugin::mongodb (
   String $db_pass,
   Enum['absent','present'] $ensure          = 'present',
   Optional[Variant[String,Float]] $interval = undef,
-  Stdlib::Compat::Ip_address $db_host       = '127.0.0.1',
-  Optional[String] $db_port                 = undef,
+  Stdlib::Host $db_host                     = '127.0.0.1',
+  Optional[Stdlib::Port] $db_port           = undef,
   Optional[Array] $configured_dbs           = undef,
   $collectd_dir                             = '/usr/lib/collectd',
 ) {
@@ -14,7 +14,7 @@ class collectd::plugin::mongodb (
   include ::collectd
 
   if $configured_dbs {
-    assert_type(String, $db_port)
+    assert_type(Stdlib::Port, $db_port)
   }
 
   collectd::plugin { 'mongodb':

--- a/manifests/plugin/mysql/database.pp
+++ b/manifests/plugin/mysql/database.pp
@@ -5,7 +5,7 @@ define collectd::plugin::mysql::database (
   String $host                         = 'UNSET',
   String $username                     = 'UNSET',
   String $password                     = 'UNSET',
-  String $port                         = '3306',
+  Stdlib::Port $port                   = 3306,
   Boolean $masterstats                 = false,
   Boolean $slavestats                  = false,
   Optional[String] $socket             = undef,

--- a/manifests/plugin/network/listener.pp
+++ b/manifests/plugin/network/listener.pp
@@ -2,7 +2,7 @@
 define collectd::plugin::network::listener (
   Enum['present', 'absent'] $ensure                         = 'present',
   Optional[Stdlib::Absolutepath] $authfile                  = undef,
-  Optional[Integer] $port                                   = undef,
+  Optional[Stdlib::Port] $port                              = undef,
   Optional[Collectd::Network::SecurityLevel] $securitylevel = undef,
   Optional[String] $interface                               = undef,
 ) {

--- a/manifests/plugin/network/server.pp
+++ b/manifests/plugin/network/server.pp
@@ -3,7 +3,7 @@ define collectd::plugin::network::server (
   Enum['present', 'absent'] $ensure                         = 'present',
   Optional[String] $username                                = undef,
   Optional[String] $password                                = undef,
-  Optional[Integer] $port                                   = undef,
+  Optional[Stdlib::Port] $port                              = undef,
   Optional[Collectd::Network::SecurityLevel] $securitylevel = undef,
   Optional[String] $interface                               = undef,
   Optional[Boolean] $forward                                = undef,

--- a/manifests/plugin/ntpd.pp
+++ b/manifests/plugin/ntpd.pp
@@ -1,8 +1,8 @@
 # https://collectd.org/wiki/index.php/Plugin:NTPd
 class collectd::plugin::ntpd (
   $ensure           = 'present',
-  $host             = 'localhost',
-  $port             = 123,
+  Stdlib::Host $host = 'localhost',
+  Stdlib::Port $port = 123,
   $reverselookups   = false,
   $includeunitid    = false,
   $interval         = undef,

--- a/manifests/plugin/ovs_events.pp
+++ b/manifests/plugin/ovs_events.pp
@@ -36,7 +36,7 @@
 #  Defaults to 'collectd-ovs_stats'
 #
 # [*port*]
-#  TCP-port to connect to. Either a service name or a port number may be given.
+#  TCP-port to connect to.
 #
 # [*socket*]
 #  The UNIX domain socket path of OVS DB server JSON-RPC interface used
@@ -50,7 +50,7 @@ class collectd::plugin::ovs_events (
   Boolean $manage_package              = true,
   Optional[Boolean] $send_notification = undef,
   String $package_name                 = 'collectd-ovs-events',
-  Optional[Integer] $port              = undef,
+  Optional[Stdlib::Port] $port         = undef,
   Optional[String] $socket             = undef,
 ) {
 

--- a/manifests/plugin/ovs_stats.pp
+++ b/manifests/plugin/ovs_stats.pp
@@ -27,7 +27,7 @@
 #  Defaults to 'collectd-ovs_stats'
 #
 # [*port*]
-#  TCP-port to connect to. Either a service name or a port number may be given.
+#  TCP-port to connect to.
 #
 # [*socket*]
 #  The UNIX domain socket path of OVS DB server JSON-RPC interface used
@@ -39,7 +39,7 @@ class collectd::plugin::ovs_stats (
   String $ensure            = 'present',
   Boolean $manage_package   = true,
   String $package_name      = 'collectd-ovs-stats',
-  Optional[Integer] $port   = undef,
+  Optional[Stdlib::Port] $port = undef,
   Optional[String] $socket  = undef,
 ) {
 

--- a/manifests/plugin/postgresql/database.pp
+++ b/manifests/plugin/postgresql/database.pp
@@ -2,9 +2,9 @@
 # useful if you have multiple instances of different version of pg
 define collectd::plugin::postgresql::database (
   $ensure       = 'present',
-  $host         = undef,
+  Optional[Stdlib::Host] $host = undef,
   $databasename = $name,
-  $port         = undef,
+  Optional[Stdlib::Port] $port = undef,
   $user         = undef,
   $password     = undef,
   $sslmode      = undef,

--- a/manifests/plugin/statsd.pp
+++ b/manifests/plugin/statsd.pp
@@ -1,8 +1,8 @@
 # https://collectd.org/wiki/index.php/Plugin:StatsD
 class collectd::plugin::statsd (
   $ensure                = 'present',
-  $host                  = undef,
-  $port                  = undef,
+  Optional[Stdlib::Host] $host = undef,
+  Optional[Stdlib::Port] $port = undef,
   $deletecounters        = undef,
   $deletetimers          = undef,
   $deletegauges          = undef,

--- a/manifests/plugin/tcpconns.pp
+++ b/manifests/plugin/tcpconns.pp
@@ -1,7 +1,7 @@
 # https://collectd.org/wiki/index.php/Plugin:TCPConns
 class collectd::plugin::tcpconns (
-  Optional[Array] $localports        = undef,
-  Optional[Array] $remoteports       = undef,
+  Optional[Array[Stdlib::Port]] $localports  = undef,
+  Optional[Array[Stdlib::Port]] $remoteports = undef,
   $listening                         = undef,
   $interval                          = undef,
   Optional[Boolean] $allportssummary = undef,

--- a/manifests/plugin/write_graphite/carbon.pp
+++ b/manifests/plugin/write_graphite/carbon.pp
@@ -1,8 +1,8 @@
 # a single graphite backend
 define collectd::plugin::write_graphite::carbon (
   $ensure                    = 'present',
-  $graphitehost              = 'localhost',
-  $graphiteport              = 2003,
+  Stdlib::Host $graphitehost = 'localhost',
+  Stdlib::Port $graphiteport = 2003,
   Boolean $storerates        = true,
   $graphiteprefix            = 'collectd.',
   $graphitepostfix           = undef,

--- a/manifests/plugin/write_kafka.pp
+++ b/manifests/plugin/write_kafka.pp
@@ -2,7 +2,7 @@ class collectd::plugin::write_kafka (
   $ensure                    = 'present',
   $kafka_host                = undef,
   Array[String] $kafka_hosts = ['localhost:9092'],
-  $kafka_port                = 9092,
+  Stdlib::Port $kafka_port   = 9092,
   Hash $topics               = {},
 ) {
 

--- a/manifests/plugin/write_prometheus.pp
+++ b/manifests/plugin/write_prometheus.pp
@@ -1,6 +1,6 @@
 class collectd::plugin::write_prometheus (
-  String $port = '9103',
-  $ensure      = 'present',
+  Stdlib::Port $port = 9103,
+  $ensure = 'present',
 ) {
 
   include ::collectd

--- a/manifests/plugin/write_sensu.pp
+++ b/manifests/plugin/write_sensu.pp
@@ -2,8 +2,8 @@
 class collectd::plugin::write_sensu (
   $ensure           = 'present',
   $manage_package   = undef,
-  $sensu_host       = 'localhost',
-  $sensu_port       = 3030,
+  Stdlib::Host $sensu_host = 'localhost',
+  Stdlib::Port $sensu_port = 3030,
   Boolean $store_rates      = false,
   Boolean $always_append_ds = false,
   $metrics          = false,

--- a/manifests/plugin/write_tsdb.pp
+++ b/manifests/plugin/write_tsdb.pp
@@ -2,8 +2,8 @@
 class collectd::plugin::write_tsdb (
   $ensure                   = present,
   Boolean $globals          = false,
-  $host                     = 'localhost',
-  $port                     = 4242,
+  Stdlib::Host $host        = 'localhost',
+  Stdlib::Port $port        = 4242,
   Array $host_tags          = [],
   Boolean $store_rates      = false,
   Boolean $always_append_ds = false,

--- a/manifests/plugin/zookeeper.pp
+++ b/manifests/plugin/zookeeper.pp
@@ -1,8 +1,8 @@
 class collectd::plugin::zookeeper (
   Enum['present', 'absent'] $ensure           = 'present',
   Optional[Integer]         $interval         = undef,
-  String                    $zookeeper_host   = 'localhost',
-  String                    $zookeeper_port   = '2181',
+  Stdlib::Host              $zookeeper_host   = 'localhost',
+  Stdlib::Port              $zookeeper_port   = 2181,
 ) {
 
   include ::collectd

--- a/spec/classes/collectd_plugin_amqp1_spec.rb
+++ b/spec/classes/collectd_plugin_amqp1_spec.rb
@@ -40,7 +40,7 @@ describe 'collectd::plugin::amqp1', type: :class do
           { ensure: 'present',
             transport: 'transport',
             host: 'host',
-            port: 'port',
+            port: 666,
             user: 'user',
             password: 'password',
             address: 'address',
@@ -63,7 +63,7 @@ describe 'collectd::plugin::amqp1', type: :class do
 
         it { is_expected.to contain_file('amqp1.load').with(content: %r{<Transport "transport">}) }
         it { is_expected.to contain_file('amqp1.load').with(content: %r{Host "host"}) }
-        it { is_expected.to contain_file('amqp1.load').with(content: %r{Port "port"}) }
+        it { is_expected.to contain_file('amqp1.load').with(content: %r{Port "666"}) }
         it { is_expected.to contain_file('amqp1.load').with(content: %r{User "user"}) }
         it { is_expected.to contain_file('amqp1.load').with(content: %r{Password "password"}) }
         it { is_expected.to contain_file('amqp1.load').with(content: %r{Address "address"}) }

--- a/spec/classes/collectd_plugin_mysql_database_spec.rb
+++ b/spec/classes/collectd_plugin_mysql_database_spec.rb
@@ -21,7 +21,7 @@ describe 'collectd::plugin::mysql::database', type: :define do
           {
             'aliasname' => 'fancyname',
             'host' => 'database.serv.er',
-            'port' => '8010',
+            'port' => 8010,
             'username' => 'db_user',
             'password' => 'secret',
             'sslkey' => '/path/to/key.pem',

--- a/spec/classes/collectd_plugin_postgresql_spec.rb
+++ b/spec/classes/collectd_plugin_postgresql_spec.rb
@@ -79,7 +79,7 @@ describe 'collectd::plugin::postgresql', type: :class do
                 'host'     => 'localhost',
                 'user'     => 'postgres',
                 'password' => 'postgres',
-                'port'     => '5432',
+                'port'     => 5432,
                 'sslmode'  => 'disable',
                 'query'    => %w[disk_io log_delay]
               },
@@ -88,7 +88,7 @@ describe 'collectd::plugin::postgresql', type: :class do
                 'host'     => 'localhost',
                 'user'     => 'postgres',
                 'password' => 'postgres',
-                'port'     => '5433',
+                'port'     => 5433,
                 'sslmode'  => 'disable',
                 'query'    => %w[disk_io log_delay]
 

--- a/spec/classes/collectd_plugin_write_kafka_spec.rb
+++ b/spec/classes/collectd_plugin_write_kafka_spec.rb
@@ -10,7 +10,7 @@ describe 'collectd::plugin::write_kafka', type: :class do
       options = os_specific_options(facts)
       context ':ensure => present and :kafka_host => \'myhost\'' do
         let :params do
-          { kafka_host: 'myhost', kafka_port: '9092', topics: { 'my-topic' => { 'format' => 'JSON' } } }
+          { kafka_host: 'myhost', kafka_port: 9092, topics: { 'my-topic' => { 'format' => 'JSON' } } }
         end
 
         it "Will create #{options[:plugin_conf_dir]}/10-write_kafka.conf" do

--- a/spec/classes/collectd_plugin_write_prometheus_spec.rb
+++ b/spec/classes/collectd_plugin_write_prometheus_spec.rb
@@ -8,9 +8,9 @@ describe 'collectd::plugin::write_prometheus', type: :class do
       end
 
       options = os_specific_options(facts)
-      context ':ensure => present and :port => "9103"' do
+      context ':ensure => present and :port => 9103' do
         let :params do
-          { port: '9103' }
+          { port: 9103 }
         end
 
         it "Will create #{options[:plugin_conf_dir]}/10-write_prometheus.conf" do

--- a/spec/classes/collectd_plugin_zookeeper_spec.rb
+++ b/spec/classes/collectd_plugin_zookeeper_spec.rb
@@ -11,7 +11,7 @@ describe 'collectd::plugin::zookeeper', type: :class do
 
       context ":ensure => present and :zookeeper_host => 'myhost'" do
         let :params do
-          { zookeeper_host: 'myhost', zookeeper_port: '2181' }
+          { zookeeper_host: 'myhost', zookeeper_port: 2181 }
         end
 
         it "Will create #{options[:plugin_conf_dir]}/10-zookeeper.load" do

--- a/types/redis/node.pp
+++ b/types/redis/node.pp
@@ -1,2 +1,2 @@
 #
-type Collectd::Redis::Node = Struct[{Optional['host'] => String[1], Optional['port'] => Variant[Integer[0, 65535], String[1]], Optional['password'] => String[1], Optional['timeout'] => Integer[0], Optional['queries'] => Hash[String[1], Hash[String[1], String[1]]]}]
+type Collectd::Redis::Node = Struct[{Optional['host'] => String[1], Optional['port'] => Variant[Stdlib::Port, String[1]], Optional['password'] => String[1], Optional['timeout'] => Integer[0], Optional['queries'] => Hash[String[1], Hash[String[1], String[1]]]}]


### PR DESCRIPTION
Instead of having a mix of strings and integers, all port parameters
should be using `Stdlib::Port`.

I've also changed some `String`s to `Stdlib::Host`, but none of these
should be breaking changes.