### PR TITLE
plugin/java: handle OpenJDK as well

### DIFF
--- a/manifests/plugin/java.pp
+++ b/manifests/plugin/java.pp
@@ -36,6 +36,7 @@ class collectd::plugin::java (
       # Reload SO files so libjvm.so can be found
       exec { '/sbin/ldconfig':
         unless  => '/sbin/ldconfig -p |grep libjvm.so >/dev/null 2>&1',
+        require => [Exec['Link libjvm.so on OpenJDK'], Exec['Link libjvm.so on Oracle']]
       }
     }
   }

--- a/manifests/plugin/java.pp
+++ b/manifests/plugin/java.pp
@@ -22,14 +22,14 @@ class collectd::plugin::java (
       exec { 'Link libjvm.so on OpenJDK':
         command => "/usr/bin/ln -s /usr/lib64/libjvm.so ${java_home}/jre/lib/server/libjvm.so",
         creates => '/usr/lib64/libjvm.so',
-        onlyif  => "test -e ${java_home}/jre/lib/server/libjvm.so",
+        onlyif  => "/usr/bin/test -e ${java_home}/jre/lib/server/libjvm.so",
         notify  => Exec['/sbin/ldconfig'],
       }
 
       exec { 'Link libjvm.so on Oracle':
         command => "/usr/bin/ln -s /usr/lib64/libjvm.so ${java_home}/jre/lib/amd64/server/libjvm.so",
         creates => '/usr/lib64/libjvm.so',
-        onlyif  => "test -e ${java_home}/jre/lib/amd64/server/libjvm.so",
+        onlyif  => "/usr/bin/test -e ${java_home}/jre/lib/amd64/server/libjvm.so",
         notify  => Exec['/sbin/ldconfig'],
       }
 

--- a/manifests/plugin/java.pp
+++ b/manifests/plugin/java.pp
@@ -20,14 +20,14 @@ class collectd::plugin::java (
     }
     if $java_home {
       exec { 'Link libjvm.so on OpenJDK':
-        command => "/usr/bin/ln -s /usr/lib64/libjvm.so ${java_home}/jre/lib/server/libjvm.so",
+        command => "/usr/bin/ln -s ${java_home}/jre/lib/server/libjvm.so /usr/lib64/libjvm.so",
         creates => '/usr/lib64/libjvm.so',
         onlyif  => "/usr/bin/test -e ${java_home}/jre/lib/server/libjvm.so",
         notify  => Exec['/sbin/ldconfig'],
       }
 
       exec { 'Link libjvm.so on Oracle':
-        command => "/usr/bin/ln -s /usr/lib64/libjvm.so ${java_home}/jre/lib/amd64/server/libjvm.so",
+        command => "/usr/bin/ln -s ${java_home}/jre/lib/amd64/server/libjvm.so /usr/lib64/libjvm.so",
         creates => '/usr/lib64/libjvm.so',
         onlyif  => "/usr/bin/test -e ${java_home}/jre/lib/amd64/server/libjvm.so",
         notify  => Exec['/sbin/ldconfig'],

--- a/manifests/plugin/java.pp
+++ b/manifests/plugin/java.pp
@@ -36,7 +36,7 @@ class collectd::plugin::java (
       # Reload SO files so libjvm.so can be found
       exec { '/sbin/ldconfig':
         unless  => '/sbin/ldconfig -p |grep libjvm.so >/dev/null 2>&1',
-        require => [Exec['Link libjvm.so on OpenJDK'], Exec['Link libjvm.so on Oracle']]
+        require => [Exec['Link libjvm.so on OpenJDK'], Exec['Link libjvm.so on Oracle']],
       }
     }
   }

--- a/manifests/plugin/java.pp
+++ b/manifests/plugin/java.pp
@@ -23,14 +23,14 @@ class collectd::plugin::java (
       exec { "/usr/bin/ln -s /usr/lib64/libjvm.so ${java_home}/jre/lib/server/libjvm.so":
         creates => '/usr/lib64/libjvm.so',
         onlyif  => "test -e ${java_home}/jre/lib/server/libjvm.so",
-        notify  => Exec['/sbin/ldconfig']
+        notify  => Exec['/sbin/ldconfig'],
       }
 
       # Oracle based Java distribution
       exec { "/usr/bin/ln -s /usr/lib64/libjvm.so ${java_home}/jre/lib/amd64/server/libjvm.so":
         creates => '/usr/lib64/libjvm.so',
         onlyif  => "test -e ${java_home}/jre/lib/amd64/server/libjvm.so",
-        notify  => Exec['/sbin/ldconfig']
+        notify  => Exec['/sbin/ldconfig'],
       }
 
       # Reload SO files so libjvm.so can be found

--- a/manifests/plugin/java.pp
+++ b/manifests/plugin/java.pp
@@ -19,15 +19,15 @@ class collectd::plugin::java (
       }
     }
     if $java_home {
-      # OpenJDK based Java distribution
-      exec { "/usr/bin/ln -s /usr/lib64/libjvm.so ${java_home}/jre/lib/server/libjvm.so":
+      exec { 'Link libjvm.so on OpenJDK':
+        command => "/usr/bin/ln -s /usr/lib64/libjvm.so ${java_home}/jre/lib/server/libjvm.so",
         creates => '/usr/lib64/libjvm.so',
         onlyif  => "test -e ${java_home}/jre/lib/server/libjvm.so",
         notify  => Exec['/sbin/ldconfig'],
       }
 
-      # Oracle based Java distribution
-      exec { "/usr/bin/ln -s /usr/lib64/libjvm.so ${java_home}/jre/lib/amd64/server/libjvm.so":
+      exec { 'Link libjvm.so on Oracle':
+        command => "/usr/bin/ln -s /usr/lib64/libjvm.so ${java_home}/jre/lib/amd64/server/libjvm.so",
         creates => '/usr/lib64/libjvm.so',
         onlyif  => "test -e ${java_home}/jre/lib/amd64/server/libjvm.so",
         notify  => Exec['/sbin/ldconfig'],

--- a/manifests/plugin/java.pp
+++ b/manifests/plugin/java.pp
@@ -19,13 +19,23 @@ class collectd::plugin::java (
       }
     }
     if $java_home {
-      file { '/usr/lib64/libjvm.so':
-        ensure => 'link',
-        target => "${java_home}/jre/lib/amd64/server/libjvm.so",
+      # OpenJDK based Java distribution
+      exec { "/usr/bin/ln -s /usr/lib64/libjvm.so ${java_home}/jre/lib/server/libjvm.so":
+        creates => '/usr/lib64/libjvm.so',
+        onlyif  => "test -e ${java_home}/jre/lib/server/libjvm.so",
+        notify  => Exec['/sbin/ldconfig']
       }
+
+      # Oracle based Java distribution
+      exec { "/usr/bin/ln -s /usr/lib64/libjvm.so ${java_home}/jre/lib/amd64/server/libjvm.so":
+        creates => '/usr/lib64/libjvm.so',
+        onlyif  => "test -e ${java_home}/jre/lib/amd64/server/libjvm.so",
+        notify  => Exec['/sbin/ldconfig']
+      }
+
       # Reload SO files so libjvm.so can be found
-      -> exec { '/sbin/ldconfig':
-        unless => '/sbin/ldconfig -p |grep libjvm.so >/dev/null 2>&1',
+      exec { '/sbin/ldconfig':
+        unless  => '/sbin/ldconfig -p |grep libjvm.so >/dev/null 2>&1',
       }
     }
   }

--- a/spec/classes/collectd_plugin_java_spec.rb
+++ b/spec/classes/collectd_plugin_java_spec.rb
@@ -119,8 +119,8 @@ describe 'collectd::plugin::java', type: :class do
       when 'RedHat'
         context 'java_home option is empty' do
           it 'will not contain libjvm' do
-            is_expected.not_to contain_exec('Link libjvm.so on OpenJDK').with_onlyif('test -e /bla/jre/lib/server/libjvm.so')
-            is_expected.not_to contain_exec('Link libjvm.so on Oracle').with_onlyif('test -e /bla/jre/lib/amd64/server/libjvm.so')
+            is_expected.not_to contain_exec('Link libjvm.so on OpenJDK').with_onlyif('/usr/bin/test -e /bla/jre/lib/server/libjvm.so')
+            is_expected.not_to contain_exec('Link libjvm.so on Oracle').with_onlyif('/usr/bin/test -e /bla/jre/lib/amd64/server/libjvm.so')
             is_expected.not_to contain_exec('/sbin/ldconfig')
           end
         end
@@ -133,8 +133,8 @@ describe 'collectd::plugin::java', type: :class do
           end
 
           it 'will contain libjvm' do
-            is_expected.to contain_exec('Link libjvm.so on OpenJDK').with_onlyif('test -e /bla/jre/lib/server/libjvm.so')
-            is_expected.to contain_exec('Link libjvm.so on Oracle').with_onlyif('test -e /bla/jre/lib/amd64/server/libjvm.so')
+            is_expected.to contain_exec('Link libjvm.so on OpenJDK').with_onlyif('/usr/bin/test -e /bla/jre/lib/server/libjvm.so')
+            is_expected.to contain_exec('Link libjvm.so on Oracle').with_onlyif('/usr/bin/test -e /bla/jre/lib/amd64/server/libjvm.so')
             is_expected.to contain_exec('/sbin/ldconfig')
           end
         end

--- a/spec/classes/collectd_plugin_java_spec.rb
+++ b/spec/classes/collectd_plugin_java_spec.rb
@@ -119,7 +119,8 @@ describe 'collectd::plugin::java', type: :class do
       when 'RedHat'
         context 'java_home option is empty' do
           it 'will not contain libjvm' do
-            is_expected.not_to contain_file('/usr/lib64/libjvm.so')
+            is_expected.not_to contain_exec('Link libjvm.so on OpenJDK').with_onlyif('test -e /bla/jre/lib/server/libjvm.so')
+            is_expected.not_to contain_exec('Link libjvm.so on Oracle').with_onlyif('test -e /bla/jre/lib/server/amd64/libjvm.so')
             is_expected.not_to contain_exec('/sbin/ldconfig')
           end
         end
@@ -132,7 +133,8 @@ describe 'collectd::plugin::java', type: :class do
           end
 
           it 'will contain libjvm' do
-            is_expected.to contain_file('/usr/lib64/libjvm.so')
+            is_expected.to contain_exec('Link libjvm.so on OpenJDK').with_onlyif('test -e /bla/jre/lib/server/libjvm.so')
+            is_expected.to contain_exec('Link libjvm.so on Oracle').with_onlyif('test -e /bla/jre/lib/server/amd64/libjvm.so')
             is_expected.to contain_exec('/sbin/ldconfig')
           end
         end

--- a/spec/classes/collectd_plugin_java_spec.rb
+++ b/spec/classes/collectd_plugin_java_spec.rb
@@ -120,7 +120,7 @@ describe 'collectd::plugin::java', type: :class do
         context 'java_home option is empty' do
           it 'will not contain libjvm' do
             is_expected.not_to contain_exec('Link libjvm.so on OpenJDK').with_onlyif('test -e /bla/jre/lib/server/libjvm.so')
-            is_expected.not_to contain_exec('Link libjvm.so on Oracle').with_onlyif('test -e /bla/jre/lib/server/amd64/libjvm.so')
+            is_expected.not_to contain_exec('Link libjvm.so on Oracle').with_onlyif('test -e /bla/jre/lib/amd64/server/libjvm.so')
             is_expected.not_to contain_exec('/sbin/ldconfig')
           end
         end
@@ -134,7 +134,7 @@ describe 'collectd::plugin::java', type: :class do
 
           it 'will contain libjvm' do
             is_expected.to contain_exec('Link libjvm.so on OpenJDK').with_onlyif('test -e /bla/jre/lib/server/libjvm.so')
-            is_expected.to contain_exec('Link libjvm.so on Oracle').with_onlyif('test -e /bla/jre/lib/server/amd64/libjvm.so')
+            is_expected.to contain_exec('Link libjvm.so on Oracle').with_onlyif('test -e /bla/jre/lib/amd64/server/libjvm.so')
             is_expected.to contain_exec('/sbin/ldconfig')
           end
         end


### PR DESCRIPTION
`collectd-java` requires:
* `libjvm.so()(64bit)`
* `libjvm.so(SUNWprivate_1.1)(64bit)`

On CentOS/RHEL 6.x/7.x these are provided by OpenJDK. OpenJDK stores the
JVM files in a bit of a different location: `amd64` has been removed
from the path. Thus, ATM the link does not get created properly on such
systems.

Fix this problem by adding two `exec` resources which both will try to
create the needed libjvm symbolic link. They are both smart and check if
that file exists before trying to execute. An assumption is added to the
code that both of the files cannot exist at the same time.
