### PR TITLE
Add puppet tasks to call collectdctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -2092,6 +2092,57 @@ collectd::typesdb { $db:
 }
 ```
 
+## Puppet Tasks
+Assuming that the collectdctl command is available on remote nodes puppet tasks exist to
+run collectdctl and collect results from nodes.
+
+### Puppet Task collectd::listval
+```bash
+$ bolt task show collectd::listval
+collectd::listval - Lists all available collectd metrics
+
+USAGE:
+bolt task run --nodes <node-name> collectd::listval
+collectd::listval - Lists all available collectd metrics
+
+USAGE:
+bolt task run --nodes <node-name> collectd::listval
+```
+
+### Puppet Task collectd::getval
+```bash
+$ bolt task show collectd::getval
+
+collectd::getval - Get a particular metric for a host
+
+USAGE:
+bolt task run --nodes <node-name> collectd::getval metric=<value>
+
+PARAMETERS:
+- metric: String[1]
+    Name of metric, e.g. load/load-relative
+
+```
+
+#### Example Task collectd::getval
+
+```bash
+$ bolt -u root task run collectd::getval metric=load/load-relative -n aiadm32.example.org
+```
+
+returns the values of the load metric.
+
+```json
+  {
+    "metric": "load/load-relative",
+    "values": {
+      "shortterm": "1.750000e-01",
+      "longterm": "8.000000e-02",
+      "midterm": "8.500000e-02"
+    }
+  }
+```
+
 ## Limitations
 
 See metadata.json for supported platforms

--- a/README.md
+++ b/README.md
@@ -2094,7 +2094,8 @@ collectd::typesdb { $db:
 
 ## Puppet Tasks
 Assuming that the collectdctl command is available on remote nodes puppet tasks exist to
-run collectdctl and collect results from nodes.
+run collectdctl and collect results from nodes. The tasks rely on `python3` being available
+also.
 
 ### Puppet Task collectd::listval
 ```bash

--- a/metadata.json
+++ b/metadata.json
@@ -101,6 +101,10 @@
     {
       "name": "stahnma-epel",
       "version_requirement": ">= 1.2.2 < 2.0.0"
+    },
+    {
+      "name": "puppetlabs-python_task_helper",
+      "version_requirement": ">= 0.2.0 < 1.0.0"
     }
   ]
 }

--- a/tasks/getval.json
+++ b/tasks/getval.json
@@ -1,0 +1,11 @@
+{
+    "description": "Get a particular metric for a host",
+    "input_method": "stdin",
+    "files": ["python_task_helper/files/task_helper.py"],
+    "parameters": {
+      "metric": {
+        "description": "Name of metric, e.g. load/load-relative",
+        "type": "String[1]"
+      }
+    }
+}

--- a/tasks/getval.py
+++ b/tasks/getval.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, sys
 import subprocess
@@ -12,7 +12,7 @@ HOSTNAME = socket.gethostname()
 class GetVal(TaskHelper):
     def task(self, args):
         fullmetric = HOSTNAME+'/'+args['metric']
-        results = subprocess.check_output(['/usr/bin/collectdctl', 'getval',fullmetric]).rstrip().split('\n')
+        results = subprocess.check_output(['/usr/bin/collectdctl', 'getval',fullmetric]).rstrip().decode().split('\n')
         values = { k:v for k,v in (x.split('=')  for x in results)}
         return {
                   'metric': args['metric'],

--- a/tasks/getval.py
+++ b/tasks/getval.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+import os, sys
+import subprocess
+import socket
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'python_task_helper', 'files'))
+from task_helper import TaskHelper
+
+
+HOSTNAME = socket.gethostname()
+class GetVal(TaskHelper):
+    def task(self, args):
+        fullmetric = HOSTNAME+'/'+args['metric']
+        results = subprocess.check_output(['/usr/bin/collectdctl', 'getval',fullmetric]).rstrip().split('\n')
+        values = { k:v for k,v in (x.split('=')  for x in results)}
+        return {
+                  'metric': args['metric'],
+                  'values': values
+               }
+
+if __name__ == '__main__':
+    GetVal().run()
+

--- a/tasks/listval.json
+++ b/tasks/listval.json
@@ -1,0 +1,5 @@
+{
+    "description": "Lists all available collectd metrics",
+    "input_method": "stdin",
+    "files": ["python_task_helper/files/task_helper.py"]
+}

--- a/tasks/listval.py
+++ b/tasks/listval.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+import os, sys
+import subprocess
+import socket
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'python_task_helper', 'files'))
+from task_helper import TaskHelper
+
+
+HOSTNAME = socket.gethostname()
+class ListVal(TaskHelper):
+    def task(self, args):
+        values = subprocess.check_output(['/usr/bin/collectdctl', 'listval']).rstrip().split('\n')
+        metrics = [v.replace(HOSTNAME+'/', '') for v in values]
+        return {'metrics': metrics}
+
+if __name__ == '__main__':
+    ListVal().run()
+

--- a/tasks/listval.py
+++ b/tasks/listval.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, sys
 import subprocess
@@ -11,7 +11,7 @@ from task_helper import TaskHelper
 HOSTNAME = socket.gethostname()
 class ListVal(TaskHelper):
     def task(self, args):
-        values = subprocess.check_output(['/usr/bin/collectdctl', 'listval']).rstrip().split('\n')
+        values = subprocess.check_output(['/usr/bin/collectdctl', 'listval']).rstrip().decode().split('\n')
         metrics = [v.replace(HOSTNAME+'/', '') for v in values]
         return {'metrics': metrics}
 


### PR DESCRIPTION
#### Pull Request (PR) description

Two puppet tasks

* collectd::listval - lists all collectd metrics on a node
* collectd::getval metric=load/load-relative - shows values
  of a particular metric

For example

```bash
$ bolt -u root task run collectd::getval metric=load/load-relative -n node.example.org
Started on node.example.org...
Finished on node.example.org:
  {
    "metric": "load/load-relative",
    "values": {
      "shortterm": "1.750000e-01",
      "longterm": "8.000000e-02",
      "midterm": "8.500000e-02"
    }
  }
```
