### PR TITLE
Accept to use python3 if python is not on the path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1453,8 +1453,8 @@ class { 'collectd::plugin::protocols':
 
 #### Class: `collectd::plugin::python`
 The plugin uses a fact `python_dir` to find the python load path for modules.
-python must be installed as a pre-requisite for the this fact to give a
-non-default value.
+python or python3 must be installed as a pre-requisite for the this
+fact to give a non-default value.
 
 * `modulepaths` is an array of paths where will be Collectd looking for Python
   modules, Puppet will ensure that each of specified directories exists and it

--- a/lib/facter/python_dir.rb
+++ b/lib/facter/python_dir.rb
@@ -10,6 +10,12 @@ Facter.add(:python_dir) do
       else
         Facter::Util::Resolution.exec('python -c "import site; print(site.getsitepackages()[0])"')
       end
+    elsif Facter::Util::Resolution.which('python3')
+      if Facter.value(:osfamily) == 'RedHat'
+        Facter::Util::Resolution.exec('python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"')
+      else
+        Facter::Util::Resolution.exec('python3 -c "import site; print(site.getsitepackages()[0])"')
+      end
     else
       ''
     end

--- a/spec/unit/python_dir_spec.rb
+++ b/spec/unit/python_dir_spec.rb
@@ -26,10 +26,23 @@ describe 'python_dir', type: :fact do
         expect(Facter.value(:python_dir)).to eq('/usr/lib/python2.7/site-packages')
       end
     end
+
+    context 'RedHat versioned python' do
+      before do
+        Facter.fact(:osfamily).stubs(:value).returns('RedHat')
+        Facter::Util::Resolution.stubs(:which).with('python').returns(false)
+        Facter::Util::Resolution.stubs(:which).with('python3').returns(true)
+        Facter::Util::Resolution.stubs(:exec).with('python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"').returns('/usr/lib/python3.6/site-packages')
+      end
+      it do
+        expect(Facter.value(:python_dir)).to eq('/usr/lib/python3.6/site-packages')
+      end
+    end
   end
 
   it 'is empty string if python not installed' do
     Facter::Util::Resolution.stubs(:which).with('python').returns(nil)
+    Facter::Util::Resolution.stubs(:which).with('python3').returns(nil)
     expect(Facter.fact(:python_dir).value).to eq('')
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
RHEL8 in particular has no python command by design
attempt to use python3 if there is no python command.

https://developers.redhat.com/blog/2018/11/14/python-in-rhel-8/

#### This Pull Request (PR) fixes the following issues

