### PR TITLE
Apt update before installation of collectd

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -2,7 +2,7 @@ class collectd::repo::debian {
 
   contain apt
   if $collectd::manage_package {
-    Exec['apt_update'] -> Package[$collectd::package_name]
+    Class['apt::update'] -> Package[$collectd::package_name]
   }
 
   if $collectd::ci_package_repo {

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,6 +1,9 @@
 class collectd::repo::debian {
 
   contain apt
+  if $collectd::manage_package {
+    Exec['apt_update'] -> Package[$collectd::package_name]
+  }
 
   if $collectd::ci_package_repo {
 

--- a/spec/classes/collectd_init_spec.rb
+++ b/spec/classes/collectd_init_spec.rb
@@ -192,6 +192,32 @@ describe 'collectd', type: :class do
             end
           end
 
+          context 'and manage_package is true' do
+            let(:params) do
+              {
+                manage_repo: true,
+                manage_package: true
+              }
+            end
+
+            if facts[:osfamily] == 'Debian'
+              it { is_expected.to contain_package(options[:package]).that_requires('Class[Apt::Update]') }
+            end
+          end
+
+          context 'and manage_package is false' do
+            let(:params) do
+              {
+                manage_repo: true,
+                manage_package: false
+              }
+            end
+
+            if facts[:osfamily] == 'Debian'
+              it { is_expected.not_to contain_class('Class[Apt::Update]').that_comes_before('Package[collectd]') }
+            end
+          end
+
           context 'and ci_package_repo set to a version' do
             context 'and package_keyserver is default' do
               let(:params) do


### PR DESCRIPTION
Hi

It seems to me that there is not any dependency between Exec['apt_update'] and Package['collectd'].
Specifically, this is what I get in `noop` mode: `apt-update` is run after the installation of the `collectd` package.

```
Notice: Compiled catalog for 067d02440e1f in environment production in 0.48 seconds
Notice: /Stage[main]/Apt/Apt::Setting[conf-update-stamp]/File[/etc/apt/apt.conf.d/15update-stamp]/ensure: current_value absent, should be file (noop)
Notice: Apt::Setting[conf-update-stamp]: Would have triggered 'refresh' from 1 events
Notice: /Stage[main]/Apt/File[preferences]/ensure: current_value absent, should be file (noop)
Notice: Class[Apt]: Would have triggered 'refresh' from 2 events
Notice: Class[Collectd::Repo::Debian]: Would have triggered 'refresh' from 1 events
Notice: /Stage[main]/Collectd::Install/Package[collectd]/ensure: current_value purged, should be present (noop)
Notice: /Stage[main]/Collectd::Install/Package[collectd-core]/ensure: current_value purged, should be present (noop)
Notice: Class[Collectd::Install]: Would have triggered 'refresh' from 2 events
Notice: Class[Apt::Update]: Would have triggered 'refresh' from 2 events
Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Would have triggered 'refresh' from 1 events
Notice: Class[Apt::Update]: Would have triggered 'refresh' from 1 events
Notice: /Stage[main]/Collectd::Config/File[collectd.d]/ensure: current_value absent, should be directory (noop)
```
You can reproduce it by viewing the compiled catalog.

Indeed, the class `Apt::Update` is contained inside `Stage[main]` and not inside the class `Collectd::Repo::Debian` as you might expect.