### PR TITLE
drop legacy precise code

### DIFF
--- a/manifests/plugin/curl_json.pp
+++ b/manifests/plugin/curl_json.pp
@@ -25,11 +25,7 @@ define collectd::plugin::curl_json (
 
   if $_manage_package {
     if $facts['os']['family'] == 'Debian' {
-      $libyajl_package = $facts['os']['distro']['codename'] ? {
-        'precise' => 'libyajl1',
-        default   => 'libyajl2'
-      }
-      ensure_packages($libyajl_package)
+      ensure_packages('libyajl2')
     }
 
     if $facts['os']['family'] == 'RedHat' {

--- a/spec/defines/collectd_plugin_curl_json_spec.rb
+++ b/spec/defines/collectd_plugin_curl_json_spec.rb
@@ -1,15 +1,7 @@
 require 'spec_helper'
 
-# Facter 2 doesn't include the os.distro fact so override the facter version we tell facterdb to use.
-facterdb_facterversion = case Puppet.version
-                         when %r{^4}
-                           '3.6.7'
-                         else
-                           '3.8.0'
-                         end
-
 describe 'collectd::plugin::curl_json', type: :define do
-  on_supported_os(facterversion: facterdb_facterversion).each do |os, facts|
+  on_supported_os.each do |os, facts|
     context "on #{os} " do
       options = os_specific_options(facts)
       let :facts do


### PR DESCRIPTION
We don't support Ubuntu Precise (12.04) anymore, so we can remove the
legacy code.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
