### PR TITLE
Add ReconnectInterval option to the write_graphite plugin (defaults to zero, introduced in version 5.6)

### DIFF
--- a/manifests/plugin/write_graphite/carbon.pp
+++ b/manifests/plugin/write_graphite/carbon.pp
@@ -12,6 +12,7 @@ define collectd::plugin::write_graphite::carbon (
   $protocol                  = 'tcp',
   Boolean $separateinstances = false,
   Boolean $logsenderrors     = true,
+  $reconnectinterval         = 0,
 ) {
 
   include collectd

--- a/manifests/plugin/write_graphite/carbon.pp
+++ b/manifests/plugin/write_graphite/carbon.pp
@@ -12,7 +12,7 @@ define collectd::plugin::write_graphite::carbon (
   $protocol                  = 'tcp',
   Boolean $separateinstances = false,
   Boolean $logsenderrors     = true,
-  $reconnectinterval         = 0,
+  Integer $reconnectinterval = 0,
 ) {
 
   include collectd

--- a/templates/plugin/write_graphite/carbon.conf.erb
+++ b/templates/plugin/write_graphite/carbon.conf.erb
@@ -17,7 +17,10 @@
   LogSendErrors <%= @logsenderrors %>
   Protocol "<%= @protocol %>"
 <%- end -%>
-<%- if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.3']) >= 0) -%>
+<%- if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.6']) >= 0) -%>
+  ReconnectInterval <%= @reconnectinterval %>
+<%- end -%>
+stores<%- if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.3']) >= 0) -%>
 </Node>
 <%- else -%>
 </Carbon>

--- a/templates/plugin/write_graphite/carbon.conf.erb
+++ b/templates/plugin/write_graphite/carbon.conf.erb
@@ -20,7 +20,7 @@
 <%- if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.6']) >= 0) -%>
   ReconnectInterval <%= @reconnectinterval %>
 <%- end -%>
-stores<%- if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.3']) >= 0) -%>
+<%- if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.3']) >= 0) -%>
 </Node>
 <%- else -%>
 </Carbon>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Version 5.6 has introduced the ReconnectInterval option to the write_graphite plugin (https://collectd.org/wiki/index.php/Version_5.6).

ReconnectInterval Seconds
When set to non-zero, forces the connection to the Graphite backend to be closed and re-opend periodically. This behavior is desirable in environments where the connection to the Graphite backend is done through load balancers, for example. When set to zero, the default, the connetion is kept open for as long as possible.
(https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_write_graphite)


#### This Pull Request (PR) fixes the following issues

New feature
