### PR TITLE
Add CentOS 8 support

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -4,6 +4,7 @@
     - set: ubuntu1604-64
     - set: ubuntu1804-64
     - set: centos7-64
+    - set: centos8-64
     - set: debian8-64
   secure: "FAK3Izs5bSZyblGvcFnGWm0exZV5+v9pbwfRDD2oihWxX3U3pArGW+3XcwcJfLQgrUYBsOTmHC8yPjlgTBYeIt/5pvg9X+3jwNgeto6kozpI/nvAq4NtcHhzxRejuPELhFYeXZ3hEw0w+v/ZRo2cNLwI0LLpiWEDvCMZN1CJ2RY="
 spec/spec_helper.rb:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,14 @@ matrix:
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos8-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos8-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
     env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian8-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
   - rvm: 2.5.3

--- a/README.md
+++ b/README.md
@@ -1622,6 +1622,8 @@ You will need to add this to [collectd::config::typesdb](https://github.com/voxp
 via hiera or in a manifest. Failure to set the types.db.custom content will
 result in *no* metrics from the rabbitmq plugin.
 
+The rabbitmq plugin has not been ported to python3 and will fail on CentOS 8 [#75](https://github.com/nytimes/collectd-rabbitmq/issues/75)
+
 set typesdb to include the collectd-rabbitmq types.db.custom
 
 ```yaml

--- a/lib/facter/python_dir.rb
+++ b/lib/facter/python_dir.rb
@@ -16,6 +16,8 @@ Facter.add(:python_dir) do
       else
         Facter::Util::Resolution.exec('python3 -c "import site; print(site.getsitepackages()[0])"')
       end
+    elsif File.exist?('/usr/libexec/platform-python')
+      Facter::Util::Resolution.exec('/usr/libexec/platform-python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"')
     else
       ''
     end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,7 +71,10 @@ class collectd::params {
       $config_file        = '/etc/collectd.conf'
       $config_group       = 'root'
       $java_dir           = '/usr/share/collectd/java'
-      $default_python_dir = '/usr/lib/python2.7/site-packages'
+      $default_python_dir = $facts['os']['release']['major'] ? {
+        '7'     => '/usr/lib/python2.7/site-packages',
+        default => '/usr/lib/python3.6/site-packages',
+      }
       $manage_repo        = true
       $package_configs    = {
         ovs_events => 'ovs-events.conf',

--- a/manifests/plugin/cuda.pp
+++ b/manifests/plugin/cuda.pp
@@ -12,28 +12,45 @@
 # @param provider_proxy Optional[String] Proxy for provider. Default: undef
 class collectd::plugin::cuda (
   Optional[String] $ensure           = 'present',
-  Optional[Boolean] $manage_package   = undef,
+  Optional[Boolean] $manage_package  = undef,
   Optional[String] $package_name     = 'collectd-cuda',
-  Optional[String] $package_provider = 'pip',
+  Optional[String] $package_provider = undef,
   Optional[String] $provider_proxy   = undef,
 ) {
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)
+  if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8' {
+    $_python_pip_package = 'python3-pip'
+    if $package_provider =~ Undef {
+      $_package_provider = 'pip3'
+    }
+    else {
+      $_package_provider = $package_provider
+    }
+  } else {
+    $_python_pip_package = 'python-pip'
+    if $package_provider =~ Undef {
+      $_package_provider = 'pip'
+    }
+    else {
+      $_package_provider = $package_provider
+    }
+  }
 
   if ($_manage_package) {
-    if (!defined(Package['python-pip'])) {
-      package { 'python-pip': ensure => 'present', }
+    if (!defined(Package[$_python_pip_package])) {
+      package { $_python_pip_package: ensure => 'present', }
 
       Package[$package_name] {
-        require => Package['python-pip'],
+        require => Package[$_python_pip_package],
       }
 
       if $facts['os']['family'] == 'RedHat' {
         # Epel is installed in install.pp if manage_repo is true
         # python-pip doesn't exist in base for RedHat. Need epel installed first
         if (defined(Class['::epel'])) {
-          Package['python-pip'] {
+          Package[$_python_pip_package] {
             require => Class['::epel'],
           }
         }
@@ -49,7 +66,7 @@ class collectd::plugin::cuda (
 
   package { $package_name:
     ensure          => $ensure,
-    provider        => $package_provider,
+    provider        => $_package_provider,
     install_options => $install_options,
   }
 

--- a/manifests/plugin/python.pp
+++ b/manifests/plugin/python.pp
@@ -32,10 +32,16 @@ class collectd::plugin::python (
     $ensure_real = 'absent'
   }
 
-  if $facts['os']['name'] == 'Fedora' or $facts['os']['name'] == 'Amazon' {
+  if $facts['os']['name'] == 'Amazon' or
+      ($facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'8') >= 0) {
     if $_manage_package {
       package { 'collectd-python':
         ensure => $ensure_real,
+      }
+      if (defined(Class['::epel'])) {
+        Package['collectd-python'] {
+          require => Class['::epel'],
+        }
       }
     }
   }

--- a/manifests/plugin/rabbitmq.pp
+++ b/manifests/plugin/rabbitmq.pp
@@ -61,6 +61,10 @@ class collectd::plugin::rabbitmq (
 ) {
   include collectd
 
+  if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'8') >= 0 {
+    fail('https://pypi.org/project/collectd-rabbitmq/ does not support Python 3')
+  }
+
   case $facts['os']['family'] {
     'RedHat': {
       $_custom_types_db = '/usr/share/collectd-rabbitmq/types.db.custom'

--- a/metadata.json
+++ b/metadata.json
@@ -3,19 +3,22 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {

--- a/spec/acceptance/class_plugin_python_spec.rb
+++ b/spec/acceptance/class_plugin_python_spec.rb
@@ -7,6 +7,8 @@ describe 'collectd::plugin::python class' do
       pp = <<-EOS
       class{'collectd::plugin::python':
       }
+      # Enable one write plugin to make logs quieter
+      class { 'collectd::plugin::csv':}
       EOS
       # Run 3 times since the collectd_version
       # fact is impossible until collectd is
@@ -22,39 +24,48 @@ describe 'collectd::plugin::python class' do
     end
   end
 
-  context 'trivial module' do
+  context 'trivial pip module connect-time' do
     it 'works idempotently with no errors' do
       pp = <<-EOS
-      if $facts['os']['family'] == 'Debian' {
+      if $facts['os']['family'] == 'Debian' or ( $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8' )  {
         # for collectdctl command
         package{'collectd-utils':
-	  ensure => present,
+       	  ensure => present,
         }
       }
-      package{'python-pip':
+      if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8'  {
+        $_python_pip_package = 'python3-pip'
+        $_pip_provider = 'pip3'
+      } else {
+        $_python_pip_package = 'python-pip'
+        $_pip_provider = 'pip'
+      }
+      package{$_python_pip_package:
         ensure => present,
       }
       package{['collectd-connect-time']:
-	ensure   => 'present',
-        provider => 'pip',
-	require  => Package['python-pip'],
-	before   => Service['collectd'],
+	      ensure   => 'present',
+        provider => $_pip_provider,
+	      require  => Package[$_python_pip_package],
+	      before   => Service['collectd'],
       }
       class{'collectd::plugin::python':
-	logtraces   => true,
-	interactive => false,
+	      logtraces   => true,
+	      interactive => false,
         modules     => {
            'collectd_connect_time' => {
-	     config => [{'target' => 'google.de'}],
-	   },
-	},
+	            config => [{'target' => 'google.de'}],
+	          },
+	      },
       }
       class{'collectd::plugin::unixsock':
-        socketfile => '/var/run/collectd-sock',
+        socketfile  => '/var/run/collectd-sock',
+        socketgroup => 'root',
       }
       EOS
 
-      # Run it twice and test for idempotency
+      # Run it twice or thrice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
       shell('sleep 10')
@@ -75,39 +86,57 @@ describe 'collectd::plugin::python class' do
       if $facts['os']['family'] == 'Debian' {
         # for collectdctl command
         package{['collectd-utils','python-dbus']:
-	  ensure => present,
+	        ensure => present,
         }
       }
-      package{['git','python-pip']:
-        ensure => present,
-	before => Package['collectd-systemd'],
+      if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8'  {
+        $_python_pip_package = 'python3-pip'
+        $_pip_provider = 'pip3'
+      } else {
+        $_python_pip_package = 'python-pip'
+        $_pip_provider = 'pip'
       }
+
+      package{['git',$_python_pip_package]:
+        ensure => present,
+	      before => Package['collectd-systemd'],
+      }
+      # Dependency on dbus for collectd-systemd installed with pip.
+      # https://github.com/mbachry/collectd-systemd/issues/11
+      if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8'  {
+        package{'python3-dbus':
+          ensure => present,
+        }
+      }
+
       package{'collectd-systemd':
-	ensure   => 'present',
-        provider => 'pip',
-	source   => 'git+https://github.com/mbachry/collectd-systemd.git',
-	before   => Service['collectd'],
+	      ensure   => 'present',
+        provider => $_pip_provider,
+	      source   => 'git+https://github.com/mbachry/collectd-systemd.git',
+	      before   => Service['collectd'],
       }
       class{'collectd':
         typesdb => ['/usr/share/collectd/types.db'],
       }
       class{'collectd::plugin::python':
-	logtraces   => true,
-	interactive => false,
+	      logtraces   => true,
+	      interactive => false,
         modules     => {
            'instanceA' => {
-	     module => 'collectd_systemd',
-	     config => [{'Service' => 'collectd'}],
-	   },
+	             module => 'collectd_systemd',
+	             config => [{'Service' => 'collectd'}],
+	          },
            'instanceB' => {
 	     module => 'collectd_systemd',
 	     config => [{'Service' => 'sshd'}],
-	   },
-	},
+	     },
+	    },
       }
       class{'collectd::plugin::unixsock':
         socketfile => '/var/run/collectd-sock',
+        socketgroup => 'root',
       }
+      class { 'collectd::plugin::csv':}
       EOS
 
       # Run it twice and test for idempotency

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -6,6 +6,8 @@ describe 'collectd class' do
     it 'works idempotently with no errors' do
       pp = <<-EOS
       class { 'collectd': }
+      # Enable one write plugin to make logs quieter
+      class { 'collectd::plugin::csv':}
       EOS
 
       # Run it twice and test for idempotency
@@ -29,7 +31,11 @@ describe 'collectd class' do
 
       class { '::collectd::plugin::memory': }
 
-      class { '::collectd::plugin::rabbitmq': }
+      # rabbitmq plugin not ported to Python3
+      unless $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8' {
+        class { '::collectd::plugin::rabbitmq': }
+      }
+      class { 'collectd::plugin::csv':}
       EOS
 
       # Run it twice and test for idempotency
@@ -44,7 +50,7 @@ describe 'collectd class' do
       end
     end
 
-    if fact('osfamily') == 'RedHat'
+    if fact('osfamily') == 'RedHat' && fact('os.release.major') == '7'
       describe file('/etc/collectd.d/10-rabbitmq.conf') do
         it { is_expected.to be_file }
         it { is_expected.to contain 'TypesDB "/usr/share/collectd-rabbitmq/types.db.custom"' }

--- a/spec/acceptance/curl_json_spec.rb
+++ b/spec/acceptance/curl_json_spec.rb
@@ -17,6 +17,9 @@ describe 'curl_json defined type' do
             },
           }
       }
+      # Adding one write plugin removes a lot
+      # of confusing/misleading warnings in collectd logs
+      class { 'collectd::plugin::csv':}
       EOS
 
       # Run it twice and test for idempotency

--- a/spec/classes/collectd_plugin_rabbitmq_spec.rb
+++ b/spec/classes/collectd_plugin_rabbitmq_spec.rb
@@ -23,36 +23,41 @@ describe 'collectd::plugin::rabbitmq', type: :class do
             }
           end
 
-          it 'import collectd_rabbitmq.collectd_plugin in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_header').with_content(%r{Import "collectd_rabbitmq.collectd_plugin"})
-          end
+          case [facts[:os]['family'], facts[:os]['release']['major']]
+          when %w[RedHat 8]
+            it { is_expected.to raise_error(%r{does not support Python 3}) }
+          else
+            it 'import collectd_rabbitmq.collectd_plugin in python-config' do
+              is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_header').with_content(%r{Import "collectd_rabbitmq.collectd_plugin"})
+            end
 
-          it 'Load collectd_rabbitmq in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Module "collectd_rabbitmq.collectd_plugin"})
-          end
+            it 'Load collectd_rabbitmq in python-config' do
+              is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Module "collectd_rabbitmq.collectd_plugin"})
+            end
 
-          it 'default to Username guest in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Username "guest"})
-          end
+            it 'default to Username guest in python-config' do
+              is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Username "guest"})
+            end
 
-          it 'default to Password guest in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Password "guest"})
-          end
+            it 'default to Password guest in python-config' do
+              is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Password "guest"})
+            end
 
-          it 'default to Port 15672 in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Port "15672"})
-          end
+            it 'default to Port 15672 in python-config' do
+              is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Port "15672"})
+            end
 
-          it 'default to Scheme http in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Scheme "http"})
-          end
+            it 'default to Scheme http in python-config' do
+              is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Scheme "http"})
+            end
 
-          it 'Host should be set to $::fqdn python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Host "testhost.example.com"})
-          end
+            it 'Host should be set to $::fqdn python-config' do
+              is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Host "testhost.example.com"})
+            end
 
-          it 'Realm set to "RabbitMQ Management"' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Realm "RabbitMQ Management"})
+            it 'Realm set to "RabbitMQ Management"' do
+              is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Realm "RabbitMQ Management"})
+            end
           end
         end
 
@@ -61,8 +66,13 @@ describe 'collectd::plugin::rabbitmq', type: :class do
             { custom_types_db: '/var/custom/types.db' }
           end
 
-          it 'override custom TypesDB' do
-            is_expected.to contain_file('rabbitmq.load').with_content(%r{TypesDB "/var/custom/types.db"})
+          case [facts[:os]['family'], facts[:os]['release']['major']]
+          when %w[RedHat 8]
+            it { is_expected.to raise_error(%r{does not support Python 3}) }
+          else
+            it 'override custom TypesDB' do
+              is_expected.to contain_file('rabbitmq.load').with_content(%r{TypesDB "/var/custom/types.db"})
+            end
           end
         end
 
@@ -71,8 +81,13 @@ describe 'collectd::plugin::rabbitmq', type: :class do
             { config: { 'Username' => 'foo' } }
           end
 
-          it 'override Username to foo in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Username "foo"})
+          case [facts[:os]['family'], facts[:os]['release']['major']]
+          when %w[RedHat 8]
+            it { is_expected.to raise_error(%r{does not support Python 3}) }
+          else
+            it 'override Username to foo in python-config' do
+              is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Username "foo"})
+            end
           end
         end
 
@@ -81,8 +96,13 @@ describe 'collectd::plugin::rabbitmq', type: :class do
             { config: { 'Password' => 'foo' } }
           end
 
-          it 'override Username to foo in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Password "foo"})
+          case [facts[:os]['family'], facts[:os]['release']['major']]
+          when %w[RedHat 8]
+            it { is_expected.to raise_error(%r{does not support Python 3}) }
+          else
+            it 'override Username to foo in python-config' do
+              is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Password "foo"})
+            end
           end
         end
 
@@ -91,8 +111,13 @@ describe 'collectd::plugin::rabbitmq', type: :class do
             { config: { 'Scheme' => 'https' } }
           end
 
-          it 'override Username to foo in python-config' do
-            is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Scheme "https"})
+          case [facts[:os]['family'], facts[:os]['release']['major']]
+          when %w[RedHat 8]
+            it { is_expected.to raise_error(%r{does not support Python 3}) }
+          else
+            it 'override Username to foo in python-config' do
+              is_expected.to contain_concat_fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with_content(%r{Scheme "https"})
+            end
           end
         end
       end
@@ -102,8 +127,13 @@ describe 'collectd::plugin::rabbitmq', type: :class do
           { ensure: 'absent' }
         end
 
-        it 'Will remove python-config' do
-          is_expected.not_to contain_concat__fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with(ensure: 'present')
+        case [facts[:os]['family'], facts[:os]['release']['major']]
+        when %w[RedHat 8]
+          it { is_expected.to raise_error(%r{does not support Python 3}) }
+        else
+          it 'Will remove python-config' do
+            is_expected.not_to contain_concat__fragment('collectd_plugin_python_conf_collectd_rabbitmq.collectd_plugin_config').with(ensure: 'present')
+          end
         end
       end
 
@@ -124,11 +154,16 @@ describe 'collectd::plugin::rabbitmq', type: :class do
                       }
                     end
 
-                    it do
-                      is_expected.to contain_package(packagename).with(
-                        'ensure' => ensure_value,
-                        'provider' => provider
-                      )
+                    case [facts[:os]['family'], facts[:os]['release']['major']]
+                    when %w[RedHat 8]
+                      it { is_expected.to raise_error(%r{does not support Python 3}) }
+                    else
+                      it do
+                        is_expected.to contain_package(packagename).with(
+                          'ensure' => ensure_value,
+                          'provider' => provider
+                        )
+                      end
                     end
                   end # packagename
                 end # ensure set

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -13,10 +13,5 @@ RSpec.configure do |c|
   c.before :suite do
     install_module
     install_module_dependencies
-
-    hosts.each do |host|
-      # python is pre-requisite to the python_path fact.
-      host.install_package('python')
-    end
   end
 end

--- a/spec/spec_helper_methods.rb
+++ b/spec/spec_helper_methods.rb
@@ -24,11 +24,11 @@ def all_supported_os_hash
       },
       {
         'operatingsystem' => 'CentOS',
-        'operatingsystemrelease' => ['7']
+        'operatingsystemrelease' => %w[7 8]
       },
       {
         'operatingsystem' => 'Ubuntu',
-        'operatingsystemrelease' => ['16.04', '18.04']
+        'operatingsystemrelease' => %w[16.04 18.04]
       },
       {
         'operatingsystem' => 'FreeBSD',
@@ -46,7 +46,7 @@ def baseline_os_hash
     supported_os: [
       {
         'operatingsystem' => 'CentOS',
-        'operatingsystemrelease' => ['7']
+        'operatingsystemrelease' => %w[7 8]
       }
     ]
   }


### PR DESCRIPTION
#### Pull Request (PR) description

Add CentOS 8 support

The main differences for CentOS 8 are:
* There is now a new collectd-utils package containing collectdctl
* collectd-python is now a seperate sub package
* python is python3.
* pip command is now pip3
* The rabbitmq plugin no longer works due to lack of python3 support

The `python_dir` fact will fall back to `/usr/libexec/platform-python`
if `python3` does not exist on the path. This is the python
that collectd uses and  significantly all that collectd-python requires.

Note that setting `collectd::ci_package_repo` true will currently
result in yum being configured with a non existant repo since
https://pkg.ci.collectd.org/rpm/ does not exist
for 8.  [request](https://github.com/collectd/collectd-ci/issues/35)
