### PR TITLE
Require puppet-epel over stahnma-epel

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,7 +3,7 @@ fixtures:
     apt: https://github.com/puppetlabs/puppetlabs-apt.git
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
     concat: https://github.com/puppetlabs/puppetlabs-concat.git
-    epel: https://github.com/stahnma/puppet-module-epel.git
+    epel: https://github.com/voxpupuli/puppet-epel.git
     yumrepo_core:
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
       puppet_version: ">= 6.0.0"

--- a/metadata.json
+++ b/metadata.json
@@ -84,8 +84,8 @@
       "version_requirement": ">= 4.25.0 < 7.0.0"
     },
     {
-      "name": "stahnma-epel",
-      "version_requirement": ">= 1.2.2 < 2.0.0"
+      "name": "puppet-epel",
+      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "puppetlabs-python_task_helper",


### PR DESCRIPTION
#### Pull Request (PR) description

stahnma-epel has now migrated to VoxPupuli
name space.

Also in particular the `puppet-epel` version is requirment to
work with CentOS 8.
