### PR TITLE
New utils parameter to install collectdctl

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,10 @@
+# @summary installs and configures collectd
+# @example Install collectd utilities
+#  class{'collectd':
+#    utils => true,
+#  }
 #
+# @param utils Install collectd utilities package containing collectdctl, collectd-nagios
 class collectd (
   Boolean $autoloadplugin                              = $collectd::params::autoloadplugin,
   String $collectd_hostname                            = $collectd::params::collectd_hostname,
@@ -36,6 +42,7 @@ class collectd (
   Optional[Integer] $write_queue_limit_high            = $collectd::params::write_queue_limit_high,
   Optional[Integer] $write_queue_limit_low             = $collectd::params::write_queue_limit_low,
   Integer[1] $write_threads                            = $collectd::params::write_threads,
+  Boolean    $utils                                    = $collectd::params::utils,
 ) inherits collectd::params {
 
   $collectd_version_real = pick_default($facts['collectd_version'], $minimum_version)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,4 +1,5 @@
-#
+# @summary installs collectd
+# @api private
 class collectd::install {
 
   assert_private()
@@ -10,4 +11,12 @@ class collectd::install {
       install_options => $collectd::package_install_options,
     }
   }
+
+  if $collectd::utils and  ( $facts['os']['family'] == 'Debian' or
+    ( $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'8') >= 0 )) {
+    package{'collectd-utils':
+      ensure => $collectd::package_ensure,
+    }
+  }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,6 +29,7 @@ class collectd::params {
   $plugin_conf_dir_mode      = '0750'
   $ci_package_repo           = undef
   $package_keyserver         = 'keyserver.ubuntu.com'
+  $utils                     = false
 
   case $facts['kernel'] {
     'OpenBSD': { $has_wordexp = false }

--- a/spec/acceptance/class_plugin_python_spec.rb
+++ b/spec/acceptance/class_plugin_python_spec.rb
@@ -27,12 +27,6 @@ describe 'collectd::plugin::python class' do
   context 'trivial pip module connect-time' do
     it 'works idempotently with no errors' do
       pp = <<-EOS
-      if $facts['os']['family'] == 'Debian' or ( $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8' )  {
-        # for collectdctl command
-        package{'collectd-utils':
-       	  ensure => present,
-        }
-      }
       if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8'  {
         $_python_pip_package = 'python3-pip'
         $_pip_provider = 'pip3'
@@ -48,6 +42,9 @@ describe 'collectd::plugin::python class' do
         provider => $_pip_provider,
 	      require  => Package[$_python_pip_package],
 	      before   => Service['collectd'],
+      }
+      class{'collectd':
+        utils => true,
       }
       class{'collectd::plugin::python':
 	      logtraces   => true,
@@ -84,8 +81,7 @@ describe 'collectd::plugin::python class' do
     it 'works idempotently with no errors' do
       pp = <<-EOS
       if $facts['os']['family'] == 'Debian' {
-        # for collectdctl command
-        package{['collectd-utils','python-dbus']:
+        package{'python-dbus':
 	        ensure => present,
         }
       }
@@ -116,6 +112,7 @@ describe 'collectd::plugin::python class' do
 	      before   => Service['collectd'],
       }
       class{'collectd':
+        utils   => true,
         typesdb => ['/usr/share/collectd/types.db'],
       }
       class{'collectd::plugin::python':

--- a/spec/classes/collectd_init_spec.rb
+++ b/spec/classes/collectd_init_spec.rb
@@ -37,6 +37,23 @@ describe 'collectd', type: :class do
         end
       end
 
+      context 'when utils false' do
+        let(:params) { { utils: false } }
+
+        it { is_expected.not_to contain_package('collectd-utils') }
+      end
+
+      context 'when utils true' do
+        let(:params) { { utils: true } }
+
+        case "#{facts[:os]['family']}-#{facts[:os]['release']['major']}"
+        when %r{^Debian-.+}, 'RedHat-8'
+          it { is_expected.to contain_package('collectd-utils') }
+        else
+          it { is_expected.not_to contain_package('collectd-utils') }
+        end
+      end
+
       context 'when purge_config is enabled' do
         let(:params) { { purge_config: true } }
 


### PR DESCRIPTION
#### Pull Request (PR) description
On some operating systems `collectdctl`, `collectd-nagios`
is contained in a seperate sub package, typically `collectd-utils`

Setting `utils` to `true` will install this sub package if it exists
for an operating system.

Also start some puppet-strings.