### PR TITLE
Ignore more installed versions of python during tests

### DIFF
--- a/spec/unit/python_dir_spec.rb
+++ b/spec/unit/python_dir_spec.rb
@@ -42,7 +42,9 @@ describe 'python_dir', type: :fact do
 
   it 'is empty string if python not installed' do
     Facter::Util::Resolution.stubs(:which).with('python').returns(nil)
+    Facter::Util::Resolution.stubs(:which).with('python2').returns(nil)
     Facter::Util::Resolution.stubs(:which).with('python3').returns(nil)
+    File.stubs(:exist?).with('/usr/libexec/platform-python').returns(nil)
     expect(Facter.fact(:python_dir).value).to eq('')
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
The unit tests for python_dir fact were giving a false failure

```
1) python_dir is empty string if python not installed
   Failure/Error: expect(Facter.fact(:python_dir).value).to eq('')
     expected: ""
          got: "/usr/lib/python2.7/site-packages"
     (compared using ==)
```

If they were executed on a system where `/usr/libexec/platform-python`
was present - not the case (presumably) for Travis CI.
