### PR TITLE
Create processes plugin configuration on RedHat

### DIFF
--- a/manifests/plugin/processes.pp
+++ b/manifests/plugin/processes.pp
@@ -21,7 +21,7 @@ class collectd::plugin::processes (
     interval => $interval,
   }
 
-  concat { "${collectd::plugin_conf_dir}/processes-config.conf":
+  concat { "${collectd::plugin_conf_dir}/processes_config.conf":
     ensure         => $ensure,
     mode           => $collectd::config_mode,
     owner          => $collectd::config_owner,
@@ -32,13 +32,13 @@ class collectd::plugin::processes (
   concat::fragment { 'collectd_plugin_processes_conf_header':
     order   => '00',
     content => epp('collectd/plugin/processes-header.conf.epp'),
-    target  => "${collectd::plugin_conf_dir}/processes-config.conf",
+    target  => "${collectd::plugin_conf_dir}/processes_config.conf",
   }
 
   concat::fragment { 'collectd_plugin_processes_conf_footer':
     order   => '99',
     content => '</Plugin>',
-    target  => "${collectd::plugin_conf_dir}/processes-config.conf",
+    target  => "${collectd::plugin_conf_dir}/processes_config.conf",
   }
 
   if $processes {

--- a/manifests/plugin/processes/process.pp
+++ b/manifests/plugin/processes/process.pp
@@ -17,7 +17,7 @@ define collectd::plugin::processes::process (
       'collect_file_descriptor' => $collect_file_descriptor,
       'collect_memory_maps'     => $collect_memory_maps,
     }),
-    target  => "${collectd::plugin_conf_dir}/processes-config.conf",
+    target  => "${collectd::plugin_conf_dir}/processes_config.conf",
   }
 
 }

--- a/manifests/plugin/processes/processmatch.pp
+++ b/manifests/plugin/processes/processmatch.pp
@@ -19,6 +19,6 @@ define collectd::plugin::processes::processmatch (
       'collect_file_descriptor' => $collect_file_descriptor,
       'collect_memory_maps'     => $collect_memory_maps,
     }),
-    target  => "${collectd::plugin_conf_dir}/processes-config.conf",
+    target  => "${collectd::plugin_conf_dir}/processes_config.conf",
   }
 }

--- a/spec/acceptance/define_plugin_processes_process_spec.rb
+++ b/spec/acceptance/define_plugin_processes_process_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper_acceptance'
+
+describe 'collectd::plugin::processes::process' do
+  context 'basic parameters' do
+    # Using puppet_apply as a helper
+    it 'works idempotently with no errors' do
+      pp = <<-EOS
+      class{'collectd':
+        utils        => true,
+        purge        => true,
+        recurse      => true,
+        purge_config => true,
+      }
+
+      collectd::plugin::processes::process{'bar':
+        collect_file_descriptor => true,
+      }
+
+      # Configure one write plugin to keep logs quiet
+      class{'collectd::plugin::csv':}
+      # Create a socket to query
+      class{'collectd::plugin::unixsock':
+        socketfile  => '/var/run/collectd-sock',
+        socketgroup => 'root',
+        deletesocket => true,
+      }
+
+      EOS
+      # Run 3 times since the collectd_version
+      # fact is impossible until collectd is
+      # installed.
+      apply_manifest(pp, catch_failures: false)
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+      # Wait to get some data
+      shell('sleep 10')
+    end
+
+    describe service('collectd') do
+      it { is_expected.to be_running }
+    end
+
+    describe command('collectdctl -s /var/run/collectd-sock listval') do
+      its(:exit_status) { is_expected.to eq 0 }
+      its(:stdout) { is_expected.to match %r{processes-bar/ps_count} }
+    end
+  end
+end

--- a/spec/acceptance/define_plugin_processes_processmatch_spec.rb
+++ b/spec/acceptance/define_plugin_processes_processmatch_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper_acceptance'
+
+describe 'collectd::plugin::processes::processmatchs' do
+  context 'basic parameters' do
+    # Using puppet_apply as a helper
+    it 'works idempotently with no errors' do
+      pp = <<-EOS
+      class{'collectd':
+        utils        => true,
+        purge        => true,
+        recurse      => true,
+        purge_config => true,
+
+      }
+
+      # Configure one write plugin to keep logs quiet
+      collectd::plugin::processes::processmatch{'foo':
+        collect_file_descriptor => true,
+        regex                   => 'foo .*$',
+      }
+
+      class{'collectd::plugin::csv':}
+      # Create a socket to query
+      class{'collectd::plugin::unixsock':
+        socketfile   => '/var/run/collectd-sock',
+        socketgroup  => 'root',
+        deletesocket => true,
+      }
+
+      EOS
+      # Run 3 times since the collectd_version
+      # fact is impossible until collectd is
+      # installed.
+      apply_manifest(pp, catch_failures: false)
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+      # Wait to get some data
+      shell('sleep 10')
+    end
+
+    describe service('collectd') do
+      it { is_expected.to be_running }
+    end
+
+    describe command('collectdctl -s /var/run/collectd-sock listval') do
+      its(:exit_status) { is_expected.to eq 0 }
+      its(:stdout) { is_expected.to match %r{processes-foo/ps_count} }
+    end
+  end
+end

--- a/spec/classes/collectd_plugin_processes_spec.rb
+++ b/spec/classes/collectd_plugin_processes_spec.rb
@@ -18,19 +18,19 @@ describe 'collectd::plugin::processes', type: :class do
             )
           end
 
-          it "Will create #{options[:plugin_conf_dir]}/processes-config.conf" do
-            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/processes-config.conf").that_requires('File[collectd.d]')
+          it "Will create #{options[:plugin_conf_dir]}/processes_config.conf" do
+            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/processes_config.conf").that_requires('File[collectd.d]')
             is_expected.to contain_concat__fragment('collectd_plugin_processes_conf_header').with(
               content: "<Plugin processes>\n",
-              target: "#{options[:plugin_conf_dir]}/processes-config.conf",
+              target: "#{options[:plugin_conf_dir]}/processes_config.conf",
               order: '00'
             )
           end
 
-          it "Will create #{options[:plugin_conf_dir]}/processes-config.conf" do
+          it "Will create #{options[:plugin_conf_dir]}/processes_config.conf" do
             is_expected.to contain_concat__fragment('collectd_plugin_processes_conf_footer').with(
               content: %r{</Plugin>},
-              target: "#{options[:plugin_conf_dir]}/processes-config.conf",
+              target: "#{options[:plugin_conf_dir]}/processes_config.conf",
               order: '99'
             )
           end
@@ -66,15 +66,15 @@ describe 'collectd::plugin::processes', type: :class do
             }
           end
 
-          it "Will create #{options[:plugin_conf_dir]}/processes-config.conf" do
-            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/processes-config.conf").that_requires('File[collectd.d]')
+          it "Will create #{options[:plugin_conf_dir]}/processes_config.conf" do
+            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/processes_config.conf").that_requires('File[collectd.d]')
             is_expected.to contain_concat__fragment('collectd_plugin_processes_conf_header').with(
               content: "<Plugin processes>
   CollectContextSwitch true
   CollectFileDescriptor false
   CollectMemoryMaps true
 ",
-              target: "#{options[:plugin_conf_dir]}/processes-config.conf",
+              target: "#{options[:plugin_conf_dir]}/processes_config.conf",
               order: '00'
             )
             is_expected.to contain_concat__fragment('collectd_plugin_processes_conf_process_httpd').with(
@@ -84,14 +84,14 @@ describe 'collectd::plugin::processes', type: :class do
     CollectMemoryMaps false
   </Process>
 ",
-              target: "#{options[:plugin_conf_dir]}/processes-config.conf",
+              target: "#{options[:plugin_conf_dir]}/processes_config.conf",
               order: '50'
             )
             is_expected.to contain_concat__fragment('collectd_plugin_processes_conf_process_mysql').with(
               content: "  <Process \"mysql\">
   </Process>
 ",
-              target: "#{options[:plugin_conf_dir]}/processes-config.conf",
+              target: "#{options[:plugin_conf_dir]}/processes_config.conf",
               order: '50'
             )
 
@@ -102,14 +102,14 @@ describe 'collectd::plugin::processes', type: :class do
     CollectMemoryMaps false
   </ProcessMatch>
 ",
-              target: "#{options[:plugin_conf_dir]}/processes-config.conf",
+              target: "#{options[:plugin_conf_dir]}/processes_config.conf",
               order: '51'
             )
             is_expected.to contain_concat__fragment('collectd_plugin_processes_conf_processmatch_dove').with(
               content: "  <ProcessMatch \"dove\" \"dove.*\">
   </ProcessMatch>
 ",
-              target: "#{options[:plugin_conf_dir]}/processes-config.conf",
+              target: "#{options[:plugin_conf_dir]}/processes_config.conf",
               order: '51'
             )
           end
@@ -122,19 +122,19 @@ describe 'collectd::plugin::processes', type: :class do
             }
           end
 
-          it "Will create #{options[:plugin_conf_dir]}/processes-config.conf" do
+          it "Will create #{options[:plugin_conf_dir]}/processes_config.conf" do
             is_expected.to contain_concat__fragment('collectd_plugin_processes_conf_process_process1').with(
               content: "  <Process \"process1\">
   </Process>
 ",
-              target: "#{options[:plugin_conf_dir]}/processes-config.conf",
+              target: "#{options[:plugin_conf_dir]}/processes_config.conf",
               order: '50'
             )
             is_expected.to contain_concat__fragment('collectd_plugin_processes_conf_process_process2').with(
               content: "  <Process \"process2\">
   </Process>
 ",
-              target: "#{options[:plugin_conf_dir]}/processes-config.conf",
+              target: "#{options[:plugin_conf_dir]}/processes_config.conf",
               order: '50'
             )
           end
@@ -145,6 +145,10 @@ describe 'collectd::plugin::processes', type: :class do
           context 'on osfamily => RedHat' do
             it 'Will delete packaging config file' do
               is_expected.to contain_file('package_processes.load').with_ensure('absent')
+              is_expected.to contain_file('package_processes.load').with_path('/etc/collectd.d/processes-config.conf')
+            end
+            it 'Will not clash with package file' do
+              is_expected.not_to contain_concat('/etc/collectd.d/processes-config.conf')
             end
           end
         end


### PR DESCRIPTION
#### Pull Request (PR) description

There was a name clash between:
* Puppet created configuration file.
* Package provided configuration file.

Since a864d0d58815d58c944277417dcf52df2d3c7572 the collectd module on RedHat
purges the package provided file file `/etc/collectd.d/processes-config.conf`

The module was also creating this file with a concat and result was no
file on system.

To avoid the clash puppet now creates the file `processes_config.conf`. Note
the `-` vs `_`.

There is probably a cleaner fix to move all of the processes plugin configuration
into the per module file `/etc/collect.d/10-processses.conf` as that would
be more consistant with other simpler modules. This would be a change
for every module however with `collectd::plugin` itself changing.

#### This Pull Request (PR) fixes the following issues
Fixes #926 

