### PR TITLE
Add backwards compatibility in transition to Stdlib::Host

### DIFF
--- a/manifests/plugin/amqp1.pp
+++ b/manifests/plugin/amqp1.pp
@@ -104,7 +104,7 @@ class collectd::plugin::amqp1 (
   Boolean $manage_package            = $collectd::manage_package,
   String $transport                  = 'metrics',
   Stdlib::Host $host                 = 'localhost',
-  Stdlib::Port $port                 = 5672,
+  Variant[Stdlib::Port,String] $port = 5672,
   String $user                       = 'guest',
   String $password                   = 'guest',
   String $address                    = 'collectd',

--- a/manifests/plugin/mongodb.pp
+++ b/manifests/plugin/mongodb.pp
@@ -3,12 +3,12 @@
 class collectd::plugin::mongodb (
   String $db_user,
   String $db_pass,
-  Enum['absent','present'] $ensure          = 'present',
-  Optional[Variant[String,Float]] $interval = undef,
-  Stdlib::Host $db_host                     = '127.0.0.1',
-  Optional[Stdlib::Port] $db_port           = undef,
-  Optional[Array] $configured_dbs           = undef,
-  $collectd_dir                             = '/usr/lib/collectd',
+  Enum['absent','present'] $ensure                = 'present',
+  Optional[Variant[String,Float]] $interval       = undef,
+  Stdlib::Host $db_host                           = '127.0.0.1',
+  Optional[Variant[Stdlib::Port,String]] $db_port = undef,
+  Optional[Array] $configured_dbs                 = undef,
+  $collectd_dir                                   = '/usr/lib/collectd',
 ) {
 
   include collectd

--- a/manifests/plugin/mysql/database.pp
+++ b/manifests/plugin/mysql/database.pp
@@ -5,7 +5,7 @@ define collectd::plugin::mysql::database (
   String $host                         = 'UNSET',
   String $username                     = 'UNSET',
   String $password                     = 'UNSET',
-  Stdlib::Port $port                   = 3306,
+  Variant[Stdlib::Port,String] $port   = 3306,
   Boolean $masterstats                 = false,
   Boolean $slavestats                  = false,
   Optional[String] $socket             = undef,

--- a/manifests/plugin/write_prometheus.pp
+++ b/manifests/plugin/write_prometheus.pp
@@ -1,5 +1,5 @@
 class collectd::plugin::write_prometheus (
-  Stdlib::Port $port = 9103,
+  Variant[Stdlib::Port,String] $port = 9103,
   $ensure = 'present',
 ) {
 

--- a/manifests/plugin/zookeeper.pp
+++ b/manifests/plugin/zookeeper.pp
@@ -1,8 +1,8 @@
 class collectd::plugin::zookeeper (
-  Enum['present', 'absent'] $ensure           = 'present',
-  Optional[Integer]         $interval         = undef,
-  Stdlib::Host              $zookeeper_host   = 'localhost',
-  Stdlib::Port              $zookeeper_port   = 2181,
+  Enum['present', 'absent']    $ensure         = 'present',
+  Optional[Integer]            $interval       = undef,
+  Stdlib::Host                 $zookeeper_host = 'localhost',
+  Variant[Stdlib::Port,String] $zookeeper_port = 2181,
 ) {
 
   include collectd


### PR DESCRIPTION
Patch [1] changed all `port` parameters to use `Stdlib::Port`. When
moving from String type to the new type, this patch is backwards
incompatible leading to type errors when applying manifest. This patch
is using Variant type to make this change backwards compatible and ease
transition to new versions of puppet-collectd.

[1] https://github.com/voxpupuli/puppet-collectd/commit/d7b79c502bd10587d7498ddc1d19484eabfd7380

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
