### PR TITLE
Fix unixsock default path

### DIFF
--- a/manifests/plugin/unixsock.pp
+++ b/manifests/plugin/unixsock.pp
@@ -1,6 +1,6 @@
 # https://collectd.org/wiki/index.php/Plugin:UnixSock
 class collectd::plugin::unixsock (
-  Stdlib::Absolutepath $socketfile = '/var/run/collectd-socket',
+  Stdlib::Absolutepath $socketfile = '/var/run/collectd-unixsock',
   $socketgroup                     = 'collectd',
   $socketperms                     = '0770',
   $deletesocket                    = false,

--- a/spec/classes/collectd_plugin_unixsock_spec.rb
+++ b/spec/classes/collectd_plugin_unixsock_spec.rb
@@ -13,7 +13,7 @@ describe 'collectd::plugin::unixsock', type: :class do
           is_expected.to contain_file('unixsock.load').with(
             ensure: 'present',
             path: "#{options[:plugin_conf_dir]}/10-unixsock.conf",
-            content: %r{SocketFile  "/var/run/collectd-socket".+SocketGroup "collectd".+SocketPerms "0770"}m
+            content: %r{SocketFile  "/var/run/collectd-unixsock".+SocketGroup "collectd".+SocketPerms "0770"}m
           )
         end
       end


### PR DESCRIPTION
#### Pull Request (PR) description

The default path for unixsock has been /var/run/collectd-unixsock since
the first version of the plugin, 14 years ago:
https://github.com/collectd/collectd/blob/4bf284162200a304f0ec8d1f5c2dd93339ddc64c/src/unixsock.c#L48

This path is not overridden by the Debian nor CentOS packages as
installed by the module.

Use this path by default so that collectdctl without argument can
connect to the socket, unbreaking the bolt tasks.


#### This Pull Request (PR) fixes the following issues
n/a
