### PR TITLE
Allow the getval task to work with customized hostnames

### DIFF
--- a/tasks/getval.json
+++ b/tasks/getval.json
@@ -3,6 +3,10 @@
     "input_method": "stdin",
     "files": ["python_task_helper/files/task_helper.py"],
     "parameters": {
+      "hostname": {
+        "description": "Hostname of metric, as configured with Hostname in collectd",
+        "type": "Optional[String[1]]"
+      },
       "metric": {
         "description": "Name of metric, e.g. load/load-relative",
         "type": "String[1]"


### PR DESCRIPTION
#### Pull Request (PR) description

The default hostname used by collectd is system dependent as retuned by
gethostname(3) (On FreeBSD it's the FQDN, while on Linux it's the
non-FQDN).  The python method socket.gethostname() always return a
non-FQDN, and the user has the ability to tune the hostname as he wish
in the collectd configuration (hostname parameter).

This change allow to use a customized hostname by using an optional
argument "hostname".  When not provided, the non-FQDN and the FQDN are
tried in turn to fetch the requested metric value.

#### This Pull Request (PR) fixes the following issues
n/a