### PR TITLE
Remove redundant white space from python templates

### DIFF
--- a/templates/plugin/python/module.conf_config.epp
+++ b/templates/plugin/python/module.conf_config.epp
@@ -9,7 +9,7 @@
     <%- if ($value =~ Numeric or $value =~ Boolean) { -%>
     <%= $key %> <%= $value %>
     <%- } elsif $value =~ Array { %>
-      <%# Render arrays as key "Value 1" "Value2" 22 false #%>
+      <%#- Render arrays as key "Value 1" "Value2" 22 false -%>
     <%= $key -%> 
       <%- $value.each |$v| { -%>
         <%- if ($v =~ Boolean or $v =~ Numeric) { -%>

--- a/templates/plugin/python/module.conf_config.epp
+++ b/templates/plugin/python/module.conf_config.epp
@@ -8,7 +8,7 @@
   <%- $configuration.each |$key,$value| { -%>
     <%- if ($value =~ Numeric or $value =~ Boolean) { -%>
     <%= $key %> <%= $value %>
-    <%- } elsif $value =~ Array { %>
+    <%- } elsif $value =~ Array { -%>
       <%#- Render arrays as key "Value 1" "Value2" 22 false -%>
     <%= $key -%> 
       <%- $value.each |$v| { -%>


### PR DESCRIPTION
#### Pull Request (PR) description
Simplified the epp template contained:

```erb
    <%# a comment #%>
```

* In puppet 5 this renders as a new line. The prefix of spaces is eaten and a new line is created.
* In puppet 6 this renders as a string of spaces and new line.

The puppet 6 behaviour is better so I expect a bug was fixed sometime.

In reality there should be no spaces in here so change to

```erb
    <%#- a comment -%>
```

which renders as nothing and gives us zero catalogue change between 5 and 6 :-)

Extra commit also to remove a redundant blank line from `python-config.conf`
