### PR TITLE
Allow to set separate interval for database resource

### DIFF
--- a/manifests/plugin/dbi/database.pp
+++ b/manifests/plugin/dbi/database.pp
@@ -2,12 +2,13 @@
 #
 define collectd::plugin::dbi::database (
   String $driver,
-  String $ensure             = 'present',
-  Optional[String] $host     = undef,
-  String $databasename       = $name,
-  Hash $driveroption         = {},
-  Optional[String] $selectdb = undef,
-  Array $query               = [],
+  String $ensure                        = 'present',
+  Optional[String] $host                = undef,
+  String $databasename                  = $name,
+  Hash $driveroption                    = {},
+  Optional[String] $selectdb            = undef,
+  Array $query                          = [],
+  OptionalInteger[1] $db_query_interval = undef,
 ) {
 
   include collectd

--- a/manifests/plugin/dbi/database.pp
+++ b/manifests/plugin/dbi/database.pp
@@ -2,13 +2,13 @@
 #
 define collectd::plugin::dbi::database (
   String $driver,
-  String $ensure                        = 'present',
-  Optional[String] $host                = undef,
-  String $databasename                  = $name,
-  Hash $driveroption                    = {},
-  Optional[String] $selectdb            = undef,
-  Array $query                          = [],
-  OptionalInteger[1] $db_query_interval = undef,
+  String $ensure                          = 'present',
+  Optional[String] $host                  = undef,
+  String $databasename                    = $name,
+  Hash $driveroption                      = {},
+  Optional[String] $selectdb              = undef,
+  Array $query                            = [],
+  Optional[Integer[1]] $db_query_interval = undef,
 ) {
 
   include collectd

--- a/spec/classes/collectd_plugin_dbi_spec.rb
+++ b/spec/classes/collectd_plugin_dbi_spec.rb
@@ -56,6 +56,7 @@ describe 'collectd::plugin::dbi', type: :class do
         it "Will create #{options[:plugin_conf_dir]}/dbi-config.conf" do
           is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_db_mydatabase').with(content: %r{Driver \"mysql\"\n})
           is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_db_mydatabase').with(content: %r{Host \"localhost\"\n})
+          is_expected.not_to contain_concat__fragment('collectd_plugin_dbi_conf_db_mydatabase').with(content: %r{Interval})
           is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_db_mydatabase').with(content: %r{Query \"disk_io\"\n})
           is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_db_mydatabase').with(content: %r{DriverOption \"host\" \"db\.example\.com\"\n})
           is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_db_mydatabase').with(content: %r{DriverOption \"username\" \"dbuser\"\n})
@@ -67,6 +68,54 @@ describe 'collectd::plugin::dbi', type: :class do
           is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_query_log_delay').with(content: %r{ValuesFrom \"log_delay\"\n})
         end
       end
+
+      context ':ensure => present and create a db with a query and certain interval' do
+        let(:params) do
+          {
+            databases: {
+              'mydatabase' => {
+                'host'              => 'localhost',
+                'driver'            => 'mysql',
+                'db_query_interval' => 60,
+                'driveroption'      => {
+                  'host'     => 'db.example.com',
+                  'username' => 'dbuser',
+                  'password' => 'dbpasswd'
+                },
+                'selectdb'          => 'db',
+                'query'             => %w[disk_io log_delay]
+              }
+            },
+            queries: {
+              'log_delay' => {
+                'statement' => 'SELECT * FROM log_delay_repli;',
+                'results'   => [{
+                  'type'           => 'gauge',
+                  'instanceprefix' => 'log_delay',
+                  'instancesfrom'  => %w[inet_server_port inet_server_host],
+                  'valuesfrom'     => 'log_delay'
+                }]
+              }
+            }
+          }
+        end
+
+        it "Will create #{options[:plugin_conf_dir]}/dbi-config.conf with Interval" do
+          is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_db_mydatabase').with(content: %r{Driver \"mysql\"\n})
+          is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_db_mydatabase').with(content: %r{Host \"localhost\"\n})
+          is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_db_mydatabase').with(content: %r{Interval 60\n})
+          is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_db_mydatabase').with(content: %r{Query \"disk_io\"\n})
+          is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_db_mydatabase').with(content: %r{DriverOption \"host\" \"db\.example\.com\"\n})
+          is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_db_mydatabase').with(content: %r{DriverOption \"username\" \"dbuser\"\n})
+          is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_db_mydatabase').with(content: %r{DriverOption \"password\" \"dbpasswd\"\n})
+
+          is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_query_log_delay').with(content: %r{Statement \"SELECT \* FROM log_delay_repli;\"\n})
+          is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_query_log_delay').with(content: %r{<Result>\n})
+          is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_query_log_delay').with(content: %r{InstancesFrom \"inet_server_port\" \"inet_server_host\"\n})
+          is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_query_log_delay').with(content: %r{ValuesFrom \"log_delay\"\n})
+        end
+      end
+
     end
   end
 end

--- a/spec/classes/collectd_plugin_dbi_spec.rb
+++ b/spec/classes/collectd_plugin_dbi_spec.rb
@@ -115,7 +115,6 @@ describe 'collectd::plugin::dbi', type: :class do
           is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_query_log_delay').with(content: %r{ValuesFrom \"log_delay\"\n})
         end
       end
-
     end
   end
 end

--- a/templates/plugin/dbi/database.conf.erb
+++ b/templates/plugin/dbi/database.conf.erb
@@ -1,5 +1,8 @@
   <Database "<%= @databasename %>">
     Driver "<%= @driver %>"
+<% if @db_query_interval -%>    
+    Interval <%= @db_query_interval %>
+<% end -%>
 <% @driveroption.each do |key, value| -%>
     DriverOption "<%= key %>" "<%= value %>"
 <% end -%>


### PR DESCRIPTION
#### Pull Request (PR) description
By default dpi plugin and each database querying configuration inherits global collectd Interval. While this global interval may be OK for some mail queue checking activities, it is overwhelmingly frequent as for a daily check on a number of email accounts through mysql database. Since collectd [dbi plugin ](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_dbi) support Interval, I would like to have it added into puppet module as well.

P.S. Checked puppet code through` puppet validate` and ruby template syntax/rendering through 
`erb db_query_interval=120 -P -x -T '-' templates/plugin/dbi/database.conf.erb`
Please consider my pull request.