### PR TITLE
puppet-lint: fix strict_indent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ end
 
 group :test do
   gem 'voxpupuli-test', '>= 1.0.0',  :require => false
+  gem 'puppet-lint-strict_indent-check', :require => false
   gem 'coveralls',                   :require => false
   gem 'simplecov-console',           :require => false
 end

--- a/examples/plugins/memcached.pp
+++ b/examples/plugins/memcached.pp
@@ -1,11 +1,11 @@
 include collectd
 
 class { 'collectd::plugin::memcached':
-    instances => {
-        'default' => {
-            'host'    => 'localhost',
-            'address' => '127.0.0.1',
-            'port'    => '11211',
+  instances => {
+    'default' => {
+      'host'    => 'localhost',
+      'address' => '127.0.0.1',
+      'port'    => '11211',
     },
   },
 }

--- a/examples/plugins/processes.pp
+++ b/examples/plugins/processes.pp
@@ -3,7 +3,7 @@ include collectd
 class { 'collectd::plugin::processes':
   processes       => [ 'process1', 'process2' ],
   process_matches => [
-    { name  => 'process-all',
-      regex => 'process[0-9]' },
+    { name => 'process-all',
+    regex  => 'process[0-9]' },
   ],
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,8 +12,7 @@ class collectd::install {
     }
   }
 
-  if $collectd::utils and  ( $facts['os']['family'] == 'Debian' or
-    ( $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'8') >= 0 )) {
+  if $collectd::utils and  ( $facts['os']['family'] == 'Debian' or ( $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'8') >= 0 )) {
     package{'collectd-utils':
       ensure => $collectd::package_ensure,
     }

--- a/manifests/plugin/disk.pp
+++ b/manifests/plugin/disk.pp
@@ -17,9 +17,9 @@ class collectd::plugin::disk (
       $_manage_package = $manage_package
     } else {
       if versioncmp($collectd::collectd_version_real, '5.5') >= 0
-        and versioncmp($facts['os']['release']['major'],'8') >= 0 {
+      and versioncmp($facts['os']['release']['major'],'8') >= 0 {
         $_manage_package = true
-    } else {
+      } else {
         $_manage_package = false
       }
     }

--- a/manifests/plugin/logparser.pp
+++ b/manifests/plugin/logparser.pp
@@ -2,74 +2,74 @@
 class collectd::plugin::logparser (
   $ensure         = 'present',
   Array[Hash[String[1],Collectd::LOGPARSER::Logfile]] $logfile = [{
-    '/var/log/syslog' => {
-      'firstfullread' => false,
-      'message' => [
-        'pcie_errors' => {
-          'defaulttype' => 'pcie_error',
-          'defaultseverity' => 'warning',
-          'match' => [{
-            'aer error' => {
-              'regex' => 'AER:.*error received',
-              'submatchidx' => -1,
-            },
-            'incident time' => {
-              'regex' => '(... .. ..:..:..) .* pcieport.*AER',
-              'submatchidx' => 1,
-              'ismandatory' => false,
-            },
-            'root port' => {
-              'regex' =>'pcieport (.*): AER:',
-              'submatchidx' => 1,
-              'ismandatory' => true,
-            },
-            'device' => {
-              'plugininstance' => true,
-              'regex' => ' ([0-9a-fA-F:\\.]*): PCIe Bus Error',
-              'submatchidx' => 1,
-              'ismandatory' => false,
-            },
-            'severity_mandatory' => {
-              'regex' => 'severity=',
-              'submatchidx' => -1,
-            },
-            'nonfatal' => {
-              'regex' => 'severity=.*\\([nN]on-[fF]atal',
-              'typeinstance' => 'non_fatal',
-              'ismandatory' => false,
-            },
-            'fatal' => {
-              'regex' => 'severity=.*\\([fF]atal',
-              'severity' => 'failure',
-              'typeinstance' => 'fatal',
-              'ismandatory' => false,
-            },
-            'corrected' => {
-              'regex' => 'severity=Corrected',
-              'typeinstance' => 'correctable',
-              'ismandatory' => false,
-            },
-            'error type' => {
-              'regex' => 'type=(.*),',
-              'submatchidx' => 1,
-              'ismandatory' => false,
-            },
-            'id' => {
-              'regex' => ', id=(.*)',
-              'submatchidx' => 1,
-            },
-          }],
-        },
-      ],
-    }
+      '/var/log/syslog' => {
+        'firstfullread' => false,
+        'message' => [
+          'pcie_errors' => {
+            'defaulttype' => 'pcie_error',
+            'defaultseverity' => 'warning',
+            'match' => [{
+                'aer error' => {
+                  'regex' => 'AER:.*error received',
+                  'submatchidx' => -1,
+                },
+                'incident time' => {
+                  'regex' => '(... .. ..:..:..) .* pcieport.*AER',
+                  'submatchidx' => 1,
+                  'ismandatory' => false,
+                },
+                'root port' => {
+                  'regex' =>'pcieport (.*): AER:',
+                  'submatchidx' => 1,
+                  'ismandatory' => true,
+                },
+                'device' => {
+                  'plugininstance' => true,
+                  'regex' => ' ([0-9a-fA-F:\\.]*): PCIe Bus Error',
+                  'submatchidx' => 1,
+                  'ismandatory' => false,
+                },
+                'severity_mandatory' => {
+                  'regex' => 'severity=',
+                  'submatchidx' => -1,
+                },
+                'nonfatal' => {
+                  'regex' => 'severity=.*\\([nN]on-[fF]atal',
+                  'typeinstance' => 'non_fatal',
+                  'ismandatory' => false,
+                },
+                'fatal' => {
+                  'regex' => 'severity=.*\\([fF]atal',
+                  'severity' => 'failure',
+                  'typeinstance' => 'fatal',
+                  'ismandatory' => false,
+                },
+                'corrected' => {
+                  'regex' => 'severity=Corrected',
+                  'typeinstance' => 'correctable',
+                  'ismandatory' => false,
+                },
+                'error type' => {
+                  'regex' => 'type=(.*),',
+                  'submatchidx' => 1,
+                  'ismandatory' => false,
+                },
+                'id' => {
+                  'regex' => ', id=(.*)',
+                  'submatchidx' => 1,
+                },
+            }],
+          },
+        ],
+      }
   }]
 ){
-include collectd
+  include collectd
 
   collectd::plugin { 'logparser':
     ensure  => $ensure,
     content => epp('collectd/plugin/logparser.conf.epp', {
-      'logfile' => $logfile,
+        'logfile' => $logfile,
     }),
     order   => '06',
   }

--- a/manifests/plugin/mcelog.pp
+++ b/manifests/plugin/mcelog.pp
@@ -14,8 +14,8 @@ class collectd::plugin::mcelog (
   collectd::plugin { 'mcelog':
     ensure  => $ensure,
     content => epp('collectd/plugin/mcelog.conf.epp', {
-      'mceloglogfile' => $mceloglogfile,
-      'memory'        => $memory
+        'mceloglogfile' => $mceloglogfile,
+        'memory'        => $memory
     }),
   }
 }

--- a/manifests/plugin/memcached.pp
+++ b/manifests/plugin/memcached.pp
@@ -3,9 +3,9 @@ class collectd::plugin::memcached (
   $ensure         = 'present',
   Hash $instances = {
     'default' => {
-        'host'    => 'localhost',
-        'address' => '127.0.0.1',
-        'port'    => 11211,
+      'host'    => 'localhost',
+      'address' => '127.0.0.1',
+      'port'    => 11211,
     },
   },
   $interval       = undef,

--- a/manifests/plugin/nut.pp
+++ b/manifests/plugin/nut.pp
@@ -11,8 +11,8 @@ class collectd::plugin::nut (
     ensure   => $ensure,
   }
   $upss.each |String $ups| {
-      collectd::plugin::nut::ups { $upss:
-        ensure => $ensure,
-      }
+    collectd::plugin::nut::ups { $upss:
+      ensure => $ensure,
+    }
   }
 }

--- a/manifests/plugin/perl/plugin.pp
+++ b/manifests/plugin/perl/plugin.pp
@@ -71,8 +71,7 @@ define collectd::plugin::perl::plugin (
       }
     }
     default: {
-      fail("Unsupported provider: ${provider}. Use 'package', 'cpan',
-      'file' or false.")
+      fail("Unsupported provider: ${provider}. Use 'package', 'cpan', 'file' or false.")
     }
   }
 }

--- a/manifests/plugin/powerdns/recursor.pp
+++ b/manifests/plugin/powerdns/recursor.pp
@@ -10,9 +10,9 @@ define collectd::plugin::powerdns::recursor (
   concat::fragment{ "collectd_plugin_powerdns_conf_recursor_${name}":
     order   => '51',
     content => epp('collectd/plugin/powerdns/recursor.conf.epp', {
-      'name'    => $name,
-      'socket'  => $socket,
-      'collect' => $collect,
+        'name'    => $name,
+        'socket'  => $socket,
+        'collect' => $collect,
     }),
     target  => "${collectd::plugin_conf_dir}/powerdns-config.conf",
   }

--- a/manifests/plugin/powerdns/server.pp
+++ b/manifests/plugin/powerdns/server.pp
@@ -10,9 +10,9 @@ define collectd::plugin::powerdns::server (
   concat::fragment{ "collectd_plugin_powerdns_conf_server_${name}":
     order   => '50',
     content => epp('collectd/plugin/powerdns/server.conf.epp', {
-      'name'    => $name,
-      'socket'  => $socket,
-      'collect' => $collect,
+        'name'    => $name,
+        'socket'  => $socket,
+        'collect' => $collect,
     }),
     target  => "${collectd::plugin_conf_dir}/powerdns-config.conf",
   }

--- a/manifests/plugin/processes/process.pp
+++ b/manifests/plugin/processes/process.pp
@@ -12,10 +12,10 @@ define collectd::plugin::processes::process (
   concat::fragment{ "collectd_plugin_processes_conf_process_${process}":
     order   => '50',
     content => epp('collectd/plugin/processes/process.conf.epp', {
-      'process'                 => $process,
-      'collect_context_switch'  => $collect_context_switch,
-      'collect_file_descriptor' => $collect_file_descriptor,
-      'collect_memory_maps'     => $collect_memory_maps,
+        'process'                 => $process,
+        'collect_context_switch'  => $collect_context_switch,
+        'collect_file_descriptor' => $collect_file_descriptor,
+        'collect_memory_maps'     => $collect_memory_maps,
     }),
     target  => "${collectd::plugin_conf_dir}/processes_config.conf",
   }

--- a/manifests/plugin/processes/processmatch.pp
+++ b/manifests/plugin/processes/processmatch.pp
@@ -13,11 +13,11 @@ define collectd::plugin::processes::processmatch (
   concat::fragment{ "collectd_plugin_processes_conf_processmatch_${matchname}":
     order   => '51',
     content => epp('collectd/plugin/processes/processmatch.conf.epp', {
-      'matchname'               => $matchname,
-      'regex'                   => $regex,
-      'collect_context_switch'  => $collect_context_switch,
-      'collect_file_descriptor' => $collect_file_descriptor,
-      'collect_memory_maps'     => $collect_memory_maps,
+        'matchname'               => $matchname,
+        'regex'                   => $regex,
+        'collect_context_switch'  => $collect_context_switch,
+        'collect_file_descriptor' => $collect_file_descriptor,
+        'collect_memory_maps'     => $collect_memory_maps,
     }),
     target  => "${collectd::plugin_conf_dir}/processes_config.conf",
   }

--- a/manifests/plugin/python.pp
+++ b/manifests/plugin/python.pp
@@ -33,7 +33,7 @@ class collectd::plugin::python (
   }
 
   if $facts['os']['name'] == 'Amazon' or
-      ($facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'8') >= 0) {
+  ($facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'8') >= 0) {
     if $_manage_package {
       package { 'collectd-python':
         ensure => $ensure_real,

--- a/manifests/plugin/smart.pp
+++ b/manifests/plugin/smart.pp
@@ -16,7 +16,7 @@ class collectd::plugin::smart (
     } else {
       if versioncmp($collectd::collectd_version_real, '5.5') >= 0 {
         $_manage_package = true
-    } else {
+      } else {
         $_manage_package = false
       }
     }

--- a/manifests/plugin/snmp_agent.pp
+++ b/manifests/plugin/snmp_agent.pp
@@ -45,8 +45,8 @@ class collectd::plugin::snmp_agent(
   collectd::plugin { 'snmp_agent':
     ensure  => $ensure,
     content => epp('collectd/plugin/snmp_agent.conf.epp', {
-      'data'  => $data,
-      'table' => $table
+        'data'  => $data,
+        'table' => $table
     }),
   }
 }

--- a/manifests/type.pp
+++ b/manifests/type.pp
@@ -9,18 +9,18 @@ define collectd::type (
   # BC compatible .... ending
 
   Array[Struct[{
-    min     => Variant[Numeric, Enum['U']],
-    max     => Variant[Numeric, Enum['U']],
-    ds_type => Enum['ABSOLUTE', 'COUNTER', 'DERIVE', 'GAUGE'],
-    ds_name => String,
+        min     => Variant[Numeric, Enum['U']],
+        max     => Variant[Numeric, Enum['U']],
+        ds_type => Enum['ABSOLUTE', 'COUNTER', 'DERIVE', 'GAUGE'],
+        ds_name => String,
   }]]                                                         $types = [],
 ) {
   if empty($types) {
     $_types = [{
-      min     => $min,
-      max     => $max,
-      ds_type => $ds_type,
-      ds_name => $ds_name,
+        min     => $min,
+        max     => $max,
+        ds_type => $ds_type,
+        ds_name => $ds_name,
     }]
   } else {
     $_types = $types


### PR DESCRIPTION
this check comes from a new plugin:
https://github.com/relud/puppet-lint-strict_indent-check

if this works fine I would like to add it as new dependency to
voxpupuli-test.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
