### PR TITLE
modulesync 3.0.0 / fix several puppet-ling warnings

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,3 @@
+# Vox Pupuli Security Policy
+
+Our vulnerabilities reporting process is at https://voxpupuli.org/security/

--- a/.msync.yml
+++ b/.msync.yml
@@ -1,1 +1,1 @@
-modulesync_config_version: '2.12.0'
+modulesync_config_version: '3.0.0'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -528,6 +528,9 @@ RSpec/RepeatedDescription:
 RSpec/NestedGroups:
   Enabled: False
 
+RSpec/MultipleExpectations:
+  Enabled: false
+
 # this is broken on ruby1.9
 Layout/IndentHeredoc:
   Enabled: False

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 ---
+os: linux
 dist: bionic
 language: ruby
 cache: bundler
@@ -7,7 +8,7 @@ before_install:
   - bundle --version
 script:
   - 'bundle exec rake $CHECK'
-matrix:
+jobs:
   fast_finish: true
   include:
   - rvm: 2.4.4
@@ -92,7 +93,7 @@ notifications:
       - "chat.freenode.org#voxpupuli-notifications"
 deploy:
   provider: puppetforge
-  user: puppet
+  username: puppet
   password:
     secure: "FAK3Izs5bSZyblGvcFnGWm0exZV5+v9pbwfRDD2oihWxX3U3pArGW+3XcwcJfLQgrUYBsOTmHC8yPjlgTBYeIt/5pvg9X+3jwNgeto6kozpI/nvAq4NtcHhzxRejuPELhFYeXZ3hEw0w+v/ZRo2cNLwI0LLpiWEDvCMZN1CJ2RY="
   on:

--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,9 @@ def location_for(place, fake_version = nil)
 end
 
 group :test do
-  gem 'voxpupuli-test', '>= 2.0.0',  :require => false
-  gem 'coveralls',                   :require => false
-  gem 'simplecov-console',           :require => false
+  gem 'voxpupuli-test', '~> 2.0',  :require => false
+  gem 'coveralls',                 :require => false
+  gem 'simplecov-console',         :require => false
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def location_for(place, fake_version = nil)
 end
 
 group :test do
-  gem 'voxpupuli-test', '~> 1.5',    :require => false
+  gem 'voxpupuli-test', '>= 2.0.0',  :require => false
   gem 'coveralls',                   :require => false
   gem 'simplecov-console',           :require => false
 end

--- a/examples/plugins/ceph.pp
+++ b/examples/plugins/ceph.pp
@@ -1,7 +1,5 @@
 include collectd
 
 class { 'collectd::plugin::ceph':
-  osds          => [ 'osd.0', 'osd.1', 'osd.2'],
+  osds          => ['osd.0', 'osd.1', 'osd.2'],
 }
-
-

--- a/examples/plugins/filecount.pp
+++ b/examples/plugins/filecount.pp
@@ -7,11 +7,11 @@ class { 'collectd::plugin::filecount':
   },
 }
 
-collectd::plugin::filecount::directory {'foodir':
+collectd::plugin::filecount::directory { 'foodir':
   path => '/path/to/dir',
 }
 
-collectd::plugin::filecount::directory {'aborted-uploads':
+collectd::plugin::filecount::directory { 'aborted-uploads':
   path          => '/var/spool/foo/upload',
   pattern       => '.part.*',
   mtime         => '5m',

--- a/examples/plugins/memcached.pp
+++ b/examples/plugins/memcached.pp
@@ -1,11 +1,11 @@
 include collectd
 
 class { 'collectd::plugin::memcached':
-    instances => {
-        'default' => {
-            'host'    => 'localhost',
-            'address' => '127.0.0.1',
-            'port'    => '11211',
+  instances => {
+    'default' => {
+      'host'    => 'localhost',
+      'address' => '127.0.0.1',
+      'port'    => '11211',
     },
   },
 }

--- a/examples/plugins/perl.pp
+++ b/examples/plugins/perl.pp
@@ -17,14 +17,14 @@ collectd::plugin::perl::plugin { 'foo':
   order       => 99,
   config      => {
     'foo' => 'bar',
-    'key' => [ 'val1', 'val2' ],
+    'key' => ['val1', 'val2'],
   },
 }
 
 collectd::plugin::perl::plugin { 'bar':
   module          => 'B',
   enable_debugger => 'DProf',
-  include_dir     => ['/tmp', '/tmp/lib' ],
+  include_dir     => ['/tmp', '/tmp/lib'],
 }
 
 #collectd::plugin::perl {
@@ -44,10 +44,10 @@ collectd::plugin::perl::plugin {
       'foo'  => 'bar',
       'more' => {
         'complex' => 'structure',
-        'no'      => [ 'a', 'b' ],
+        'no'      => ['a', 'b'],
         'yes'     => {
           'last' => 'level',
-          'and'  => [ 'array' , 'thing' ],
+          'and'  => ['array' , 'thing'],
         },
       },
     },

--- a/examples/plugins/processes.pp
+++ b/examples/plugins/processes.pp
@@ -3,7 +3,7 @@ include collectd
 class { 'collectd::plugin::processes':
   processes       => [ 'process1', 'process2' ],
   process_matches => [
-    { name  => 'process-all',
-      regex => 'process[0-9]' },
+    { name => 'process-all',
+    regex  => 'process[0-9]' },
   ],
 }

--- a/examples/plugins/processes.pp
+++ b/examples/plugins/processes.pp
@@ -1,7 +1,7 @@
 include collectd
 
 class { 'collectd::plugin::processes':
-  processes       => [ 'process1', 'process2' ],
+  processes       => ['process1', 'process2'],
   process_matches => [
     { name => 'process-all',
     regex  => 'process[0-9]' },

--- a/examples/plugins/snmp.pp
+++ b/examples/plugins/snmp.pp
@@ -1,7 +1,7 @@
 include collectd
 
-class {'collectd::plugin::snmp':
-  data  =>  {
+class { 'collectd::plugin::snmp':
+  data  => {
     amavis_incoming_messages => {
       'type'     => 'counter',
       'table'    => false,
@@ -19,4 +19,3 @@ class {'collectd::plugin::snmp':
     },
   },
 }
-

--- a/examples/purge_config.pp
+++ b/examples/purge_config.pp
@@ -4,7 +4,6 @@ class { 'collectd':
   purge_config => true,
 }
 
-
 collectd::plugin { 'battery': }
 collectd::plugin { 'cpu': }
 collectd::plugin { 'df': }
@@ -18,4 +17,3 @@ collectd::plugin { 'memory': }
 collectd::plugin { 'processes': }
 collectd::plugin { 'swap': }
 collectd::plugin { 'users': }
-

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,5 @@
 # private
 class collectd::config inherits collectd {
-
   assert_private()
 
   $_conf_content = $collectd::purge_config ? {
@@ -42,5 +41,4 @@ class collectd::config inherits collectd {
   }
 
   File['collectd.d'] -> Concat <| tag == 'collectd' |>
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,7 +44,6 @@ class collectd (
   Integer[1] $write_threads                            = $collectd::params::write_threads,
   Boolean    $utils                                    = $collectd::params::utils,
 ) inherits collectd::params {
-
   $collectd_version_real = pick_default($facts['collectd_version'], $minimum_version)
 
   contain collectd::repo

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,8 +12,7 @@ class collectd::install {
     }
   }
 
-  if $collectd::utils and  ( $facts['os']['family'] == 'Debian' or
-    ( $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'8') >= 0 )) {
+  if $collectd::utils and  ( $facts['os']['family'] == 'Debian' or ( $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'8') >= 0 )) {
     package{'collectd-utils':
       ensure => $collectd::package_ensure,
     }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,6 @@
 # @summary installs collectd
 # @api private
 class collectd::install {
-
   assert_private()
 
   if $collectd::manage_package {
@@ -13,9 +12,8 @@ class collectd::install {
   }
 
   if $collectd::utils and  ( $facts['os']['family'] == 'Debian' or ( $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'8') >= 0 )) {
-    package{'collectd-utils':
+    package { 'collectd-utils':
       ensure => $collectd::package_ensure,
     }
   }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,5 @@
 #
 class collectd::params {
-
   $autoloadplugin            = false
   $fqdnlookup                = true
   $collectd_hostname         = $facts['networking']['hostname']
@@ -16,7 +15,7 @@ class collectd::params {
   $read_threads              = 5
   $write_threads             = 5
   $timeout                   = 2
-  $typesdb                   = [ '/usr/share/collectd/types.db' ]
+  $typesdb                   = ['/usr/share/collectd/types.db']
   $write_queue_limit_high    = undef
   $write_queue_limit_low     = undef
   $package_ensure            = 'present'
@@ -38,7 +37,7 @@ class collectd::params {
 
   case $facts['os']['family'] {
     'Debian': {
-      $package_name       = [ 'collectd', 'collectd-core' ]
+      $package_name       = ['collectd', 'collectd-core']
       $package_provider   = 'apt'
       $collectd_dir       = '/etc/collectd'
       $plugin_conf_dir    = "${collectd_dir}/conf.d"

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -8,7 +8,6 @@ define collectd::plugin (
   $plugin   = $name,
   Optional[Integer] $flushinterval = undef,
 ) {
-
   include collectd
 
   $conf_dir = $collectd::plugin_conf_dir

--- a/manifests/plugin/aggregation.pp
+++ b/manifests/plugin/aggregation.pp
@@ -4,7 +4,6 @@ class collectd::plugin::aggregation (
   Optional[Integer[1]] $interval    = undef,
   Hash $aggregators                 = {},
 ) {
-
   include collectd
 
   collectd::plugin { 'aggregation':

--- a/manifests/plugin/aggregation/aggregator.pp
+++ b/manifests/plugin/aggregation/aggregator.pp
@@ -18,7 +18,6 @@ define collectd::plugin::aggregation::aggregator (
   Optional[Boolean] $calculatemaximum     = undef,
   Optional[Boolean] $calculatestddev      = undef,
 ) {
-
   include collectd
   include collectd::plugin::aggregation
 

--- a/manifests/plugin/amqp.pp
+++ b/manifests/plugin/amqp.pp
@@ -18,7 +18,6 @@ class collectd::plugin::amqp (
   Boolean $graphiteseparateinstances = false,
   Boolean $graphitealwaysappendds    = false,
 ) {
-
   include collectd
 
   if $facts['os']['family'] == 'RedHat' {

--- a/manifests/plugin/amqp1.pp
+++ b/manifests/plugin/amqp1.pp
@@ -112,7 +112,6 @@ class collectd::plugin::amqp1 (
   Optional[Integer] $retry_delay     = undef,
   Optional[Integer] $interval        = undef,
 ) {
-
   include collectd
 
   if $facts['os']['family'] == 'RedHat' {

--- a/manifests/plugin/apache.pp
+++ b/manifests/plugin/apache.pp
@@ -6,7 +6,6 @@ class collectd::plugin::apache (
   Optional[Integer[1]] $interval           = undef,
   Optional[Array] $package_install_options = $collectd::package_install_options,
 ) {
-
   include collectd
 
   if $facts['os']['family'] == 'RedHat' {

--- a/manifests/plugin/battery.pp
+++ b/manifests/plugin/battery.pp
@@ -40,7 +40,6 @@ class collectd::plugin::battery (
   Boolean $report_degraded            = false,
   Boolean $query_state_fs             = false,
 ) {
-
   include collectd
 
   collectd::plugin { 'battery':

--- a/manifests/plugin/bind.pp
+++ b/manifests/plugin/bind.pp
@@ -13,7 +13,6 @@ class collectd::plugin::bind (
   Array[Collectd::Bind::View] $views = [],
   Optional[Integer[1]] $interval     = undef,
 ) {
-
   include collectd
 
   if $facts['os']['family'] == 'RedHat' {

--- a/manifests/plugin/ceph.pp
+++ b/manifests/plugin/ceph.pp
@@ -41,7 +41,6 @@ class collectd::plugin::ceph (
   Boolean $manage_package            = $collectd::manage_package,
   String $package_name               = 'collectd-ceph'
 ) {
-
   include collectd
 
   if $manage_package {

--- a/manifests/plugin/cgroups.pp
+++ b/manifests/plugin/cgroups.pp
@@ -5,7 +5,6 @@ class collectd::plugin::cgroups (
   Boolean $ignore_selected          = false,
   Optional[Integer[1]] $interval    = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'cgroups':

--- a/manifests/plugin/chain.pp
+++ b/manifests/plugin/chain.pp
@@ -5,7 +5,6 @@ class collectd::plugin::chain (
   Collectd::Filter::Target $defaulttarget = 'write',
   Array $rules                            = []
 ) {
-
   include collectd
 
   $conf_dir = $collectd::plugin_conf_dir

--- a/manifests/plugin/connectivity.pp
+++ b/manifests/plugin/connectivity.pp
@@ -24,7 +24,6 @@ class collectd::plugin::connectivity (
   Boolean $manage_package           = $collectd::manage_package,
   Array[String[1]] $interfaces      = [],
 ) {
-
   include collectd
 
   if $manage_package and $facts['os']['family'] == 'RedHat' {

--- a/manifests/plugin/conntrack.pp
+++ b/manifests/plugin/conntrack.pp
@@ -2,7 +2,6 @@
 class collectd::plugin::conntrack (
   Enum['present', 'absent'] $ensure = 'present',
 ) {
-
   include collectd
 
   collectd::plugin { 'conntrack':

--- a/manifests/plugin/contextswitch.pp
+++ b/manifests/plugin/contextswitch.pp
@@ -3,7 +3,6 @@ class collectd::plugin::contextswitch (
   Enum['present', 'absent'] $ensure   = 'present',
   Optional[Integer[1]] $interval      = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'contextswitch':

--- a/manifests/plugin/cpu.pp
+++ b/manifests/plugin/cpu.pp
@@ -9,7 +9,6 @@ class collectd::plugin::cpu (
   Boolean $subtractgueststate       = true,
   Optional[Integer[1]] $interval    = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'cpu':

--- a/manifests/plugin/cpufreq.pp
+++ b/manifests/plugin/cpufreq.pp
@@ -2,7 +2,6 @@
 class collectd::plugin::cpufreq (
   Enum['present', 'absent'] $ensure = 'present',
 ) {
-
   include collectd
 
   collectd::plugin { 'cpufreq':

--- a/manifests/plugin/csv.pp
+++ b/manifests/plugin/csv.pp
@@ -5,7 +5,6 @@ class collectd::plugin::csv (
   $interval   = undef,
   $storerates = false
 ) {
-
   include collectd
 
   collectd::plugin { 'csv':

--- a/manifests/plugin/cuda.pp
+++ b/manifests/plugin/cuda.pp
@@ -59,7 +59,7 @@ class collectd::plugin::cuda (
   }
 
   if ($_manage_package) and ($provider_proxy) {
-    $install_options = [{'--proxy' => $provider_proxy}]
+    $install_options = [{ '--proxy' => $provider_proxy }]
   } else {
     $install_options = undef
   }

--- a/manifests/plugin/curl.pp
+++ b/manifests/plugin/curl.pp
@@ -3,9 +3,8 @@ class collectd::plugin::curl (
   $ensure         = 'present',
   $manage_package = undef,
   $interval       = undef,
-  $pages          = { },
+  $pages          = {},
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/curl/page.pp
+++ b/manifests/plugin/curl/page.pp
@@ -13,7 +13,6 @@ define collectd::plugin::curl::page (
   Optional[Array[Hash]] $matches         = undef,
   String $plugininstance                 = $name, # You can have multiple <Page> with the same name.
 ) {
-
   include collectd
   include collectd::plugin::curl
 

--- a/manifests/plugin/curl_json.pp
+++ b/manifests/plugin/curl_json.pp
@@ -18,7 +18,6 @@ define collectd::plugin::curl_json (
   $order          = '10',
   $manage_package = undef,
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/dbi.pp
+++ b/manifests/plugin/dbi.pp
@@ -1,13 +1,12 @@
 # https://collectd.org/wiki/index.php/Plugin:DBI
 class collectd::plugin::dbi (
   $ensure         = 'present',
-  $databases      = { },
-  $queries        = { },
+  $databases      = {},
+  $queries        = {},
   $packages       = undef,
   $interval       = undef,
   $manage_package = undef,
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/dbi/database.pp
+++ b/manifests/plugin/dbi/database.pp
@@ -10,11 +10,10 @@ define collectd::plugin::dbi::database (
   Array $query                            = [],
   Optional[Integer[1]] $db_query_interval = undef,
 ) {
-
   include collectd
   include collectd::plugin::dbi
 
-  concat::fragment{ "collectd_plugin_dbi_conf_db_${title}":
+  concat::fragment { "collectd_plugin_dbi_conf_db_${title}":
     order   => '50',
     target  => "${collectd::plugin_conf_dir}/dbi-config.conf",
     content => template('collectd/plugin/dbi/database.conf.erb'),

--- a/manifests/plugin/dbi/query.pp
+++ b/manifests/plugin/dbi/query.pp
@@ -9,7 +9,7 @@ define collectd::plugin::dbi::query (
   include collectd
   include collectd::plugin::dbi
 
-  concat::fragment{ "collectd_plugin_dbi_conf_query_${title}":
+  concat::fragment { "collectd_plugin_dbi_conf_query_${title}":
     order   => '30',
     target  => "${collectd::plugin_conf_dir}/dbi-config.conf",
     content => template('collectd/plugin/dbi/query.conf.erb'),

--- a/manifests/plugin/dcpmm.pp
+++ b/manifests/plugin/dcpmm.pp
@@ -17,7 +17,6 @@ class collectd::plugin::dcpmm (
   Boolean                   $enable_dispatch_all  = false,
 
 ) {
-
   include collectd
 
   if $collect_health and $collect_perf_metrics {

--- a/manifests/plugin/df.pp
+++ b/manifests/plugin/df.pp
@@ -12,7 +12,6 @@ class collectd::plugin::df (
   Boolean $valuesabsolute   = true,
   Boolean $valuespercentage = false,
 ) {
-
   include collectd
 
   collectd::plugin { 'df':

--- a/manifests/plugin/disk.pp
+++ b/manifests/plugin/disk.pp
@@ -9,7 +9,6 @@ class collectd::plugin::disk (
   $udevnameattr           = undef,
   Optional[Array[String]] $package_install_options = undef
 ) {
-
   include collectd
 
   if $facts['os']['family'] == 'RedHat' {

--- a/manifests/plugin/disk.pp
+++ b/manifests/plugin/disk.pp
@@ -17,9 +17,9 @@ class collectd::plugin::disk (
       $_manage_package = $manage_package
     } else {
       if versioncmp($collectd::collectd_version_real, '5.5') >= 0
-        and versioncmp($facts['os']['release']['major'],'8') >= 0 {
+      and versioncmp($facts['os']['release']['major'],'8') >= 0 {
         $_manage_package = true
-    } else {
+      } else {
         $_manage_package = false
       }
     }

--- a/manifests/plugin/dns.pp
+++ b/manifests/plugin/dns.pp
@@ -9,7 +9,6 @@ class collectd::plugin::dns (
   $package_name                                    = 'collectd-dns',
   Variant[String,Boolean] $selectnumericquerytypes = true,
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/dpdk_telemetry.pp
+++ b/manifests/plugin/dpdk_telemetry.pp
@@ -18,7 +18,6 @@ class collectd::plugin::dpdk_telemetry (
   Stdlib::Absolutepath      $client_socket_path = '/var/run/.client',
   Stdlib::Absolutepath      $dpdk_socket_path   = '/var/run/dpdk/rte/telemetry',
 ) {
-
   include collectd
 
   collectd::plugin { 'dpdk_telemetry':

--- a/manifests/plugin/entropy.pp
+++ b/manifests/plugin/entropy.pp
@@ -3,7 +3,6 @@ class collectd::plugin::entropy (
   $ensure   = 'present',
   $interval = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'entropy':

--- a/manifests/plugin/ethstat.pp
+++ b/manifests/plugin/ethstat.pp
@@ -6,7 +6,6 @@ class collectd::plugin::ethstat (
   $mappedonly       = false,
   $interval         = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'ethstat':

--- a/manifests/plugin/exec.pp
+++ b/manifests/plugin/exec.pp
@@ -6,7 +6,6 @@ class collectd::plugin::exec (
   $ensure                 = 'present',
   Boolean $globals        = false,
 ) {
-
   include collectd
 
   collectd::plugin { 'exec':
@@ -18,7 +17,7 @@ class collectd::plugin::exec (
   # should be loaded after global plugin configuration
   $exec_conf = "${collectd::plugin_conf_dir}/exec-config.conf"
 
-  concat{ $exec_conf:
+  concat { $exec_conf:
     ensure         => $ensure,
     mode           => $collectd::config_mode,
     owner          => $collectd::config_owner,
@@ -27,13 +26,13 @@ class collectd::plugin::exec (
     ensure_newline => true,
   }
 
-  concat::fragment{ 'collectd_plugin_exec_conf_header':
+  concat::fragment { 'collectd_plugin_exec_conf_header':
     order   => '00',
     content => '<Plugin exec>',
     target  => $exec_conf,
   }
 
-  concat::fragment{ 'collectd_plugin_exec_conf_footer':
+  concat::fragment { 'collectd_plugin_exec_conf_footer':
     order   => '99',
     content => '</Plugin>',
     target  => $exec_conf,

--- a/manifests/plugin/exec/cmd.pp
+++ b/manifests/plugin/exec/cmd.pp
@@ -4,11 +4,10 @@ define collectd::plugin::exec::cmd (
   Array $exec              = [],
   Array $notification_exec = [],
 ) {
-
   include collectd
   include collectd::plugin::exec
 
-  concat::fragment{ "collectd_plugin_exec_conf_${title}":
+  concat::fragment { "collectd_plugin_exec_conf_${title}":
     order   => '50', # somewhere between header and footer
     target  => $collectd::plugin::exec::exec_conf,
     content => template('collectd/plugin/exec/cmd.conf.erb'),

--- a/manifests/plugin/fhcount.pp
+++ b/manifests/plugin/fhcount.pp
@@ -5,7 +5,6 @@ class collectd::plugin::fhcount (
   Boolean $valuespercentage = false,
   $interval                 = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'fhcount':

--- a/manifests/plugin/filecount.pp
+++ b/manifests/plugin/filecount.pp
@@ -4,7 +4,6 @@ class collectd::plugin::filecount (
   Hash $directories = {},
   $interval         = undef,
 ) {
-
   include collectd
 
   # We support two formats for directories:

--- a/manifests/plugin/filecount/directory.pp
+++ b/manifests/plugin/filecount/directory.pp
@@ -9,7 +9,6 @@ define collectd::plugin::filecount::directory (
   Optional[Boolean] $recursive      = undef,
   Optional[Boolean] $includehidden  = undef,
 ) {
-
   include collectd
   include collectd::plugin::filecount
 

--- a/manifests/plugin/filter.pp
+++ b/manifests/plugin/filter.pp
@@ -21,8 +21,7 @@ class collectd::plugin::filter (
 
   unless $ensure == 'present' {
     #kick all filter specifc plugins
-    ensure_resource('collectd::plugin', prefix($plugin_matches,'match_'), { 'ensure' => 'absent', 'order' => '02'} )
-    ensure_resource('collectd::plugin', prefix($plugin_targets,'target_'), { 'ensure' => 'absent', 'order' => '02'} )
+    ensure_resource('collectd::plugin', prefix($plugin_matches,'match_'), { 'ensure' => 'absent', 'order' => '02' })
+    ensure_resource('collectd::plugin', prefix($plugin_targets,'target_'), { 'ensure' => 'absent', 'order' => '02' })
   }
-
 }

--- a/manifests/plugin/filter/chain.pp
+++ b/manifests/plugin/filter/chain.pp
@@ -4,13 +4,12 @@ define collectd::plugin::filter::chain (
   Optional[Collectd::Filter::Target] $target = undef,
   Optional[Hash] $target_options             = undef,
 ) {
-
   include collectd
   include collectd::plugin::filter
 
   $conf_file = "${collectd::plugin_conf_dir}/filter-chain-${title}.conf"
 
-  concat{ $conf_file:
+  concat { $conf_file:
     ensure         => $ensure,
     mode           => $collectd::config_mode,
     owner          => $collectd::config_owner,
@@ -20,13 +19,13 @@ define collectd::plugin::filter::chain (
   }
 
   if $ensure == 'present' {
-    concat::fragment{ "${conf_file}_${title}_head":
+    concat::fragment { "${conf_file}_${title}_head":
       order   => '00',
       content => "<Chain \"${title}\">",
       target  => $conf_file,
     }
 
-    concat::fragment{ "${conf_file}_${title}_footer":
+    concat::fragment { "${conf_file}_${title}_footer":
       order   => '99',
       content => '</Chain>',
       target  => $conf_file,
@@ -34,7 +33,7 @@ define collectd::plugin::filter::chain (
 
     #add simple target if provided at the end
     if $target {
-      collectd::plugin::filter::target{ "z_chain-${title}-target":
+      collectd::plugin::filter::target { "z_chain-${title}-target":
         chain   => $title,
         plugin  => $target,
         rule    => undef,

--- a/manifests/plugin/filter/match.pp
+++ b/manifests/plugin/filter/match.pp
@@ -5,16 +5,15 @@ define collectd::plugin::filter::match (
   Collectd::Filter::Match $plugin,
   Optional[Hash] $options = undef,
 ) {
-
   include collectd
   include collectd::plugin::filter
 
-  ensure_resource('collectd::plugin', "match_${plugin}", { 'order' => '02'} )
+  ensure_resource('collectd::plugin', "match_${plugin}", { 'order' => '02' })
 
   $fragment_order = "10_${rule}_1_${title}"
   $conf_file = "${collectd::plugin_conf_dir}/filter-chain-${chain}.conf"
 
-  concat::fragment{ "${conf_file}_${fragment_order}":
+  concat::fragment { "${conf_file}_${fragment_order}":
     order   => $fragment_order,
     content => template('collectd/plugin/filter/match.erb'),
     target  => $conf_file,

--- a/manifests/plugin/filter/rule.pp
+++ b/manifests/plugin/filter/rule.pp
@@ -2,20 +2,19 @@
 define collectd::plugin::filter::rule (
   String $chain,
 ) {
-
   include collectd
   include collectd::plugin::filter
 
   $fragment_order = "10_${title}"
   $conf_file = "${collectd::plugin_conf_dir}/filter-chain-${chain}.conf"
 
-  concat::fragment{ "${conf_file}_${fragment_order}_0":
+  concat::fragment { "${conf_file}_${fragment_order}_0":
     order   => "${fragment_order}_0",
     content => "  <Rule \"${title}\">",
     target  => $conf_file,
   }
 
-  concat::fragment{ "${conf_file}_${fragment_order}_99":
+  concat::fragment { "${conf_file}_${fragment_order}_99":
     order   => "${fragment_order}_99",
     content => '  </Rule>',
     target  => $conf_file,

--- a/manifests/plugin/filter/target.pp
+++ b/manifests/plugin/filter/target.pp
@@ -5,14 +5,13 @@ define collectd::plugin::filter::target (
   Optional[Hash] $options = undef,
   Optional[String] $rule  = undef,
 ) {
-
   include collectd
   include collectd::plugin::filter
 
   # Load plugins
   if $plugin in $collectd::plugin::filter::plugin_targets {
     $order = 30
-    ensure_resource('collectd::plugin', "target_${plugin}", { 'order' => '02'} )
+    ensure_resource('collectd::plugin', "target_${plugin}", { 'order' => '02' })
   } else {
     # Built in plugins
     $order = 50
@@ -28,7 +27,7 @@ define collectd::plugin::filter::target (
 
   $conf_file = "${collectd::plugin_conf_dir}/filter-chain-${chain}.conf"
 
-  concat::fragment{ "${conf_file}_${fragment_order}":
+  concat::fragment { "${conf_file}_${fragment_order}":
     order   => $fragment_order,
     content => template('collectd/plugin/filter/target.erb'),
     target  => $conf_file,

--- a/manifests/plugin/fscache.pp
+++ b/manifests/plugin/fscache.pp
@@ -2,7 +2,6 @@
 class collectd::plugin::fscache (
   $ensure = 'present',
 ) {
-
   include collectd
 
   collectd::plugin { 'fscache':

--- a/manifests/plugin/genericjmx.pp
+++ b/manifests/plugin/genericjmx.pp
@@ -4,7 +4,6 @@ class collectd::plugin::genericjmx (
   $jvmarg         = [],
   $manage_package = undef,
 ) {
-
   include collectd
   include collectd::plugin::java
 

--- a/manifests/plugin/genericjmx/connection.pp
+++ b/manifests/plugin/genericjmx/connection.pp
@@ -7,7 +7,6 @@ define collectd::plugin::genericjmx::connection (
   Optional[String] $password        = undef,
   Optional[String] $instance_prefix = undef,
 ) {
-
   include collectd
   include collectd::plugin::genericjmx
 

--- a/manifests/plugin/genericjmx/mbean.pp
+++ b/manifests/plugin/genericjmx/mbean.pp
@@ -5,7 +5,6 @@ define collectd::plugin::genericjmx::mbean (
   Optional[String] $instance_prefix = undef,
   Array $instance_from              = [],
 ) {
-
   include collectd
   include collectd::plugin::genericjmx
 

--- a/manifests/plugin/hddtemp.pp
+++ b/manifests/plugin/hddtemp.pp
@@ -5,7 +5,6 @@ class collectd::plugin::hddtemp (
   $ensure       = 'present',
   $interval     = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'hddtemp':

--- a/manifests/plugin/hugepages.pp
+++ b/manifests/plugin/hugepages.pp
@@ -48,7 +48,6 @@ class collectd::plugin::hugepages (
   Boolean $values_bytes               = false,
   Boolean $values_percentage          = false,
 ) {
-
   include collectd
 
   collectd::plugin { 'hugepages':

--- a/manifests/plugin/intel_pmu.pp
+++ b/manifests/plugin/intel_pmu.pp
@@ -7,7 +7,6 @@ class collectd::plugin::intel_pmu (
   Optional[String]          $event_list                   = undef,
   Optional[Array[String]]   $hardware_events              = undef,
 ) {
-
   include collectd
 
   if $hardware_events and $event_list == undef {

--- a/manifests/plugin/intel_rdt.pp
+++ b/manifests/plugin/intel_rdt.pp
@@ -31,7 +31,6 @@ class collectd::plugin::intel_rdt (
   Optional[Integer] $interval         = undef,
   Array[String[1]] $cores             = [],
 ) {
-
   include collectd
 
   collectd::plugin { 'intel_rdt':

--- a/manifests/plugin/interface.pp
+++ b/manifests/plugin/interface.pp
@@ -6,7 +6,6 @@ class collectd::plugin::interface (
   Boolean $reportinactive = true,
   $interval               = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'interface':

--- a/manifests/plugin/ipc.pp
+++ b/manifests/plugin/ipc.pp
@@ -14,7 +14,6 @@
 class collectd::plugin::ipc (
   Enum['present', 'absent'] $ensure   = 'present',
 ) {
-
   include collectd
 
   collectd::plugin { 'ipc':

--- a/manifests/plugin/ipmi.pp
+++ b/manifests/plugin/ipmi.pp
@@ -10,7 +10,6 @@ class collectd::plugin::ipmi (
   Boolean $notify_sensor_not_present = false,
   Array $sensors                     = [],
 ) {
-
   include collectd
 
   $manage_package_real = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/iptables.pp
+++ b/manifests/plugin/iptables.pp
@@ -7,7 +7,6 @@ class collectd::plugin::iptables (
   Hash $chains6   = {},
   $interval       = undef,
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/irq.pp
+++ b/manifests/plugin/irq.pp
@@ -5,7 +5,6 @@ class collectd::plugin::irq (
   Boolean $ignoreselected = false,
   $interval               = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'irq':

--- a/manifests/plugin/iscdhcp.pp
+++ b/manifests/plugin/iscdhcp.pp
@@ -59,7 +59,7 @@ class collectd::plugin::iscdhcp (
   }
 
   if ($_manage_package) and ($provider_proxy) {
-    $install_options = [{'--proxy' => $provider_proxy}]
+    $install_options = [{ '--proxy' => $provider_proxy }]
   } else {
     $install_options = undef
   }

--- a/manifests/plugin/java.pp
+++ b/manifests/plugin/java.pp
@@ -7,7 +7,6 @@ class collectd::plugin::java (
   $manage_package                           = undef,
   Optional[Stdlib::Absolutepath] $java_home = undef,
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/load.pp
+++ b/manifests/plugin/load.pp
@@ -4,7 +4,6 @@ class collectd::plugin::load (
   $interval = undef,
   $report_relative = false,
 ) {
-
   include collectd
 
   collectd::plugin { 'load':

--- a/manifests/plugin/logfile.pp
+++ b/manifests/plugin/logfile.pp
@@ -7,7 +7,6 @@ class collectd::plugin::logfile (
   $log_timestamp  = true,
   $print_severity = false
 ) {
-
   include collectd
 
   collectd::plugin { 'logfile':

--- a/manifests/plugin/logparser.pp
+++ b/manifests/plugin/logparser.pp
@@ -19,7 +19,7 @@ class collectd::plugin::logparser (
                   'ismandatory' => false,
                 },
                 'root port' => {
-                  'regex' =>'pcieport (.*): AER:',
+                  'regex' => 'pcieport (.*): AER:',
                   'submatchidx' => 1,
                   'ismandatory' => true,
                 },
@@ -63,7 +63,7 @@ class collectd::plugin::logparser (
         ],
       }
   }]
-){
+) {
   include collectd
 
   collectd::plugin { 'logparser':

--- a/manifests/plugin/logparser.pp
+++ b/manifests/plugin/logparser.pp
@@ -2,74 +2,74 @@
 class collectd::plugin::logparser (
   $ensure         = 'present',
   Array[Hash[String[1],Collectd::LOGPARSER::Logfile]] $logfile = [{
-    '/var/log/syslog' => {
-      'firstfullread' => false,
-      'message' => [
-        'pcie_errors' => {
-          'defaulttype' => 'pcie_error',
-          'defaultseverity' => 'warning',
-          'match' => [{
-            'aer error' => {
-              'regex' => 'AER:.*error received',
-              'submatchidx' => -1,
-            },
-            'incident time' => {
-              'regex' => '(... .. ..:..:..) .* pcieport.*AER',
-              'submatchidx' => 1,
-              'ismandatory' => false,
-            },
-            'root port' => {
-              'regex' =>'pcieport (.*): AER:',
-              'submatchidx' => 1,
-              'ismandatory' => true,
-            },
-            'device' => {
-              'plugininstance' => true,
-              'regex' => ' ([0-9a-fA-F:\\.]*): PCIe Bus Error',
-              'submatchidx' => 1,
-              'ismandatory' => false,
-            },
-            'severity_mandatory' => {
-              'regex' => 'severity=',
-              'submatchidx' => -1,
-            },
-            'nonfatal' => {
-              'regex' => 'severity=.*\\([nN]on-[fF]atal',
-              'typeinstance' => 'non_fatal',
-              'ismandatory' => false,
-            },
-            'fatal' => {
-              'regex' => 'severity=.*\\([fF]atal',
-              'severity' => 'failure',
-              'typeinstance' => 'fatal',
-              'ismandatory' => false,
-            },
-            'corrected' => {
-              'regex' => 'severity=Corrected',
-              'typeinstance' => 'correctable',
-              'ismandatory' => false,
-            },
-            'error type' => {
-              'regex' => 'type=(.*),',
-              'submatchidx' => 1,
-              'ismandatory' => false,
-            },
-            'id' => {
-              'regex' => ', id=(.*)',
-              'submatchidx' => 1,
-            },
-          }],
-        },
-      ],
-    }
+      '/var/log/syslog' => {
+        'firstfullread' => false,
+        'message' => [
+          'pcie_errors' => {
+            'defaulttype' => 'pcie_error',
+            'defaultseverity' => 'warning',
+            'match' => [{
+                'aer error' => {
+                  'regex' => 'AER:.*error received',
+                  'submatchidx' => -1,
+                },
+                'incident time' => {
+                  'regex' => '(... .. ..:..:..) .* pcieport.*AER',
+                  'submatchidx' => 1,
+                  'ismandatory' => false,
+                },
+                'root port' => {
+                  'regex' =>'pcieport (.*): AER:',
+                  'submatchidx' => 1,
+                  'ismandatory' => true,
+                },
+                'device' => {
+                  'plugininstance' => true,
+                  'regex' => ' ([0-9a-fA-F:\\.]*): PCIe Bus Error',
+                  'submatchidx' => 1,
+                  'ismandatory' => false,
+                },
+                'severity_mandatory' => {
+                  'regex' => 'severity=',
+                  'submatchidx' => -1,
+                },
+                'nonfatal' => {
+                  'regex' => 'severity=.*\\([nN]on-[fF]atal',
+                  'typeinstance' => 'non_fatal',
+                  'ismandatory' => false,
+                },
+                'fatal' => {
+                  'regex' => 'severity=.*\\([fF]atal',
+                  'severity' => 'failure',
+                  'typeinstance' => 'fatal',
+                  'ismandatory' => false,
+                },
+                'corrected' => {
+                  'regex' => 'severity=Corrected',
+                  'typeinstance' => 'correctable',
+                  'ismandatory' => false,
+                },
+                'error type' => {
+                  'regex' => 'type=(.*),',
+                  'submatchidx' => 1,
+                  'ismandatory' => false,
+                },
+                'id' => {
+                  'regex' => ', id=(.*)',
+                  'submatchidx' => 1,
+                },
+            }],
+          },
+        ],
+      }
   }]
 ){
-include collectd
+  include collectd
 
   collectd::plugin { 'logparser':
     ensure  => $ensure,
     content => epp('collectd/plugin/logparser.conf.epp', {
-      'logfile' => $logfile,
+        'logfile' => $logfile,
     }),
     order   => '06',
   }

--- a/manifests/plugin/lvm.pp
+++ b/manifests/plugin/lvm.pp
@@ -4,7 +4,6 @@ class collectd::plugin::lvm (
   $manage_package   = undef,
   $interval         = undef,
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/mcelog.pp
+++ b/manifests/plugin/mcelog.pp
@@ -14,8 +14,8 @@ class collectd::plugin::mcelog (
   collectd::plugin { 'mcelog':
     ensure  => $ensure,
     content => epp('collectd/plugin/mcelog.conf.epp', {
-      'mceloglogfile' => $mceloglogfile,
-      'memory'        => $memory
+        'mceloglogfile' => $mceloglogfile,
+        'memory'        => $memory
     }),
   }
 }

--- a/manifests/plugin/mcelog.pp
+++ b/manifests/plugin/mcelog.pp
@@ -8,7 +8,6 @@ class collectd::plugin::mcelog (
     'persistentnotification' => false,
   }
 ) {
-
   include collectd
 
   collectd::plugin { 'mcelog':

--- a/manifests/plugin/memcached.pp
+++ b/manifests/plugin/memcached.pp
@@ -10,7 +10,6 @@ class collectd::plugin::memcached (
   },
   $interval       = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'memcached':

--- a/manifests/plugin/memcached.pp
+++ b/manifests/plugin/memcached.pp
@@ -3,9 +3,9 @@ class collectd::plugin::memcached (
   $ensure         = 'present',
   Hash $instances = {
     'default' => {
-        'host'    => 'localhost',
-        'address' => '127.0.0.1',
-        'port'    => 11211,
+      'host'    => 'localhost',
+      'address' => '127.0.0.1',
+      'port'    => 11211,
     },
   },
   $interval       = undef,

--- a/manifests/plugin/memory.pp
+++ b/manifests/plugin/memory.pp
@@ -5,7 +5,6 @@ class collectd::plugin::memory (
   Boolean $valuespercentage = false,
   $interval                 = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'memory':

--- a/manifests/plugin/mongodb.pp
+++ b/manifests/plugin/mongodb.pp
@@ -10,7 +10,6 @@ class collectd::plugin::mongodb (
   Optional[Array] $configured_dbs           = undef,
   $collectd_dir                             = '/usr/lib/collectd',
 ) {
-
   include collectd
 
   if $configured_dbs {

--- a/manifests/plugin/mysql.pp
+++ b/manifests/plugin/mysql.pp
@@ -5,7 +5,6 @@ class collectd::plugin::mysql (
   $manage_package   = undef,
   $interval         = undef,
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/mysql/database.pp
+++ b/manifests/plugin/mysql/database.pp
@@ -21,7 +21,6 @@ define collectd::plugin::mysql::database (
   Optional[String] $sslcapath          = undef,
   Optional[String] $sslcipher          = undef,
 ) {
-
   include collectd
   include collectd::plugin::mysql
 

--- a/manifests/plugin/netlink.pp
+++ b/manifests/plugin/netlink.pp
@@ -10,7 +10,6 @@ class collectd::plugin::netlink (
   Boolean $ignoreselected  = false,
   $interval                = undef,
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/network.pp
+++ b/manifests/plugin/network.pp
@@ -9,7 +9,6 @@ class collectd::plugin::network (
   Hash $listeners                            = {},
   Hash $servers                              = {},
 ) {
-
   include collectd
 
   $listeners_defaults = {

--- a/manifests/plugin/network/listener.pp
+++ b/manifests/plugin/network/listener.pp
@@ -6,7 +6,6 @@ define collectd::plugin::network::listener (
   Optional[Collectd::Network::SecurityLevel] $securitylevel = undef,
   Optional[String] $interface                               = undef,
 ) {
-
   include collectd
   include collectd::plugin::network
 

--- a/manifests/plugin/network/server.pp
+++ b/manifests/plugin/network/server.pp
@@ -9,7 +9,6 @@ define collectd::plugin::network::server (
   Optional[Boolean] $forward                                = undef,
   Optional[Integer[1]] $resolveinterval                     = undef,
 ) {
-
   include collectd
   include collectd::plugin::network
 

--- a/manifests/plugin/nfs.pp
+++ b/manifests/plugin/nfs.pp
@@ -3,7 +3,6 @@ class collectd::plugin::nfs (
   $ensure   = 'present',
   $interval = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'nfs':

--- a/manifests/plugin/nginx.pp
+++ b/manifests/plugin/nginx.pp
@@ -10,7 +10,6 @@ class collectd::plugin::nginx (
   $cacert           = undef,
   $interval         = undef,
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/ntpd.pp
+++ b/manifests/plugin/ntpd.pp
@@ -7,7 +7,6 @@ class collectd::plugin::ntpd (
   $includeunitid    = false,
   $interval         = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'ntpd':

--- a/manifests/plugin/numa.pp
+++ b/manifests/plugin/numa.pp
@@ -14,7 +14,6 @@
 class collectd::plugin::numa (
   Enum['present', 'absent'] $ensure   = 'present',
 ) {
-
   include collectd
 
   collectd::plugin { 'numa':

--- a/manifests/plugin/nut.pp
+++ b/manifests/plugin/nut.pp
@@ -1,11 +1,9 @@
 # https://collectd.org/wiki/index.php/Plugin:Nut
 class collectd::plugin::nut (
   $ensure        = 'present',
-  $upss       = { },
+  $upss       = {},
 ) {
-
   include collectd
-
 
   collectd::plugin { 'nut':
     ensure   => $ensure,

--- a/manifests/plugin/nut.pp
+++ b/manifests/plugin/nut.pp
@@ -11,8 +11,8 @@ class collectd::plugin::nut (
     ensure   => $ensure,
   }
   $upss.each |String $ups| {
-      collectd::plugin::nut::ups { $upss:
-        ensure => $ensure,
-      }
+    collectd::plugin::nut::ups { $upss:
+      ensure => $ensure,
+    }
   }
 }

--- a/manifests/plugin/nut/ups.pp
+++ b/manifests/plugin/nut/ups.pp
@@ -2,7 +2,6 @@
 define collectd::plugin::nut::ups (
   $ensure          = 'present',
 ) {
-
   include collectd
   include collectd::plugin::nut
 

--- a/manifests/plugin/openldap.pp
+++ b/manifests/plugin/openldap.pp
@@ -4,7 +4,6 @@ class collectd::plugin::openldap (
   Hash $instances = { 'localhost' => { 'url' => 'ldap://localhost/' } },
   $interval       = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'openldap':

--- a/manifests/plugin/openvpn.pp
+++ b/manifests/plugin/openvpn.pp
@@ -8,11 +8,10 @@ class collectd::plugin::openvpn (
   Boolean $collectusercount                                              = false,
   $interval                                                              = undef,
 ) {
-
   include collectd
 
   if $statusfile =~ String {
-    $statusfiles = [ $statusfile ]
+    $statusfiles = [$statusfile]
   } else {
     $statusfiles = $statusfile
   }

--- a/manifests/plugin/oracle.pp
+++ b/manifests/plugin/oracle.pp
@@ -5,7 +5,6 @@ class collectd::plugin::oracle (
   Boolean $manage_package           = false,
   Optional[Integer[1]] $interval    = undef,
 ) {
-
   include collectd
 
   $conf_dir = $collectd::plugin_conf_dir

--- a/manifests/plugin/oracle/database.pp
+++ b/manifests/plugin/oracle/database.pp
@@ -6,7 +6,6 @@ define collectd::plugin::oracle::database (
   String $connect_id = $name,
   String $database   = $name,
 ) {
-
   include collectd
   include collectd::plugin::oracle
 

--- a/manifests/plugin/oracle/query.pp
+++ b/manifests/plugin/oracle/query.pp
@@ -4,7 +4,6 @@ define collectd::plugin::oracle::query (
   Array $results,
   String $query = $name,
 ) {
-
   include collectd
   include collectd::plugin::oracle
 

--- a/manifests/plugin/ovs_events.pp
+++ b/manifests/plugin/ovs_events.pp
@@ -53,7 +53,6 @@ class collectd::plugin::ovs_events (
   Optional[Stdlib::Port] $port         = undef,
   Optional[String] $socket             = undef,
 ) {
-
   include collectd
 
   if $manage_package {

--- a/manifests/plugin/ovs_stats.pp
+++ b/manifests/plugin/ovs_stats.pp
@@ -42,7 +42,6 @@ class collectd::plugin::ovs_stats (
   Optional[Stdlib::Port] $port = undef,
   Optional[String] $socket  = undef,
 ) {
-
   include collectd
 
   if $manage_package {

--- a/manifests/plugin/pcie_errors.pp
+++ b/manifests/plugin/pcie_errors.pp
@@ -13,7 +13,6 @@ class collectd::plugin::pcie_errors (
   Boolean                   $report_masked            = false,
   Boolean                   $persistent_notifications = false,
 ) {
-
   include collectd
 
   collectd::plugin { 'pcie_errors':

--- a/manifests/plugin/perl.pp
+++ b/manifests/plugin/perl.pp
@@ -5,7 +5,6 @@ class collectd::plugin::perl (
   $interval         = undef,
   $order            = 20
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)
@@ -35,4 +34,3 @@ class collectd::plugin::perl (
     group  => $collectd::config_group,
   }
 }
-

--- a/manifests/plugin/perl/plugin.pp
+++ b/manifests/plugin/perl/plugin.pp
@@ -10,7 +10,6 @@ define collectd::plugin::perl::plugin (
   String $order                                = '01',
   Hash $config                                 = {},
 ) {
-
   include collectd
 
   if ! defined(Class['Collectd::Plugin::Perl']) {
@@ -19,7 +18,7 @@ define collectd::plugin::perl::plugin (
 
   if $include_dir {
     if $include_dir =~ String {
-      $include_dirs = [ $include_dir ]
+      $include_dirs = [$include_dir]
     } elsif $include_dir =~ Array {
       $include_dirs = $include_dir
     } else {

--- a/manifests/plugin/perl/plugin.pp
+++ b/manifests/plugin/perl/plugin.pp
@@ -71,8 +71,7 @@ define collectd::plugin::perl::plugin (
       }
     }
     default: {
-      fail("Unsupported provider: ${provider}. Use 'package', 'cpan',
-      'file' or false.")
+      fail("Unsupported provider: ${provider}. Use 'package', 'cpan', 'file' or false.")
     }
   }
 }

--- a/manifests/plugin/ping.pp
+++ b/manifests/plugin/ping.pp
@@ -11,7 +11,6 @@ class collectd::plugin::ping (
   Optional[Integer[-1]] $max_missed = undef,
   Optional[Integer[0]] $size        = undef,
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/postgresql.pp
+++ b/manifests/plugin/postgresql.pp
@@ -2,12 +2,11 @@
 class collectd::plugin::postgresql (
   $ensure         = 'present',
   $manage_package = undef,
-  $databases      = { },
+  $databases      = {},
   $interval       = undef,
-  $queries        = { },
-  $writers        = { },
+  $queries        = {},
+  $writers        = {},
 ) {
-
   include collectd
 
   $_manage_package    = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/postgresql/database.pp
+++ b/manifests/plugin/postgresql/database.pp
@@ -15,11 +15,10 @@ define collectd::plugin::postgresql::database (
   $writer       = undef,
   $service      = undef,
 ) {
-
   include collectd
   include collectd::plugin::postgresql
 
-  concat::fragment{ "collectd_plugin_postgresql_conf_db_${title}":
+  concat::fragment { "collectd_plugin_postgresql_conf_db_${title}":
     order   => '50',
     target  => "${collectd::plugin_conf_dir}/postgresql-config.conf",
     content => template('collectd/plugin/postgresql/database.conf.erb'),

--- a/manifests/plugin/postgresql/query.pp
+++ b/manifests/plugin/postgresql/query.pp
@@ -7,11 +7,10 @@ define collectd::plugin::postgresql::query (
   $minversion       = undef,
   $maxversion       = undef,
 ) {
-
   include collectd
   include collectd::plugin::postgresql
 
-  concat::fragment{ "collectd_plugin_postgresql_conf_query_${title}":
+  concat::fragment { "collectd_plugin_postgresql_conf_query_${title}":
     order   => '30',
     target  => "${collectd::plugin_conf_dir}/postgresql-config.conf",
     content => template('collectd/plugin/postgresql/query.conf.erb'),

--- a/manifests/plugin/postgresql/writer.pp
+++ b/manifests/plugin/postgresql/writer.pp
@@ -4,11 +4,10 @@ define collectd::plugin::postgresql::writer (
   String $statement = undef,
   $storerates       = undef,
 ) {
-
   include collectd
   include collectd::plugin::postgresql
 
-  concat::fragment{ "collectd_plugin_postgresql_conf_writer_${title}":
+  concat::fragment { "collectd_plugin_postgresql_conf_writer_${title}":
     order   => '40',
     target  => "${collectd::plugin_conf_dir}/postgresql-config.conf",
     content => template('collectd/plugin/postgresql/writer.conf.erb'),

--- a/manifests/plugin/powerdns.pp
+++ b/manifests/plugin/powerdns.pp
@@ -7,7 +7,6 @@ class collectd::plugin::powerdns (
   Optional[Hash[String, Hash]] $recursors = {},
   Optional[String] $local_socket          = undef,
 ) {
-
   include collectd
 
   $servers_defaults   = { 'ensure' => $ensure }

--- a/manifests/plugin/powerdns/recursor.pp
+++ b/manifests/plugin/powerdns/recursor.pp
@@ -3,11 +3,10 @@ define collectd::plugin::powerdns::recursor (
   Optional[String[1]] $socket       = undef,
   Array[String[1]] $collect         = [],
 ) {
-
   include collectd::plugin::powerdns
   include collectd
 
-  concat::fragment{ "collectd_plugin_powerdns_conf_recursor_${name}":
+  concat::fragment { "collectd_plugin_powerdns_conf_recursor_${name}":
     order   => '51',
     content => epp('collectd/plugin/powerdns/recursor.conf.epp', {
         'name'    => $name,

--- a/manifests/plugin/powerdns/recursor.pp
+++ b/manifests/plugin/powerdns/recursor.pp
@@ -10,9 +10,9 @@ define collectd::plugin::powerdns::recursor (
   concat::fragment{ "collectd_plugin_powerdns_conf_recursor_${name}":
     order   => '51',
     content => epp('collectd/plugin/powerdns/recursor.conf.epp', {
-      'name'    => $name,
-      'socket'  => $socket,
-      'collect' => $collect,
+        'name'    => $name,
+        'socket'  => $socket,
+        'collect' => $collect,
     }),
     target  => "${collectd::plugin_conf_dir}/powerdns-config.conf",
   }

--- a/manifests/plugin/powerdns/server.pp
+++ b/manifests/plugin/powerdns/server.pp
@@ -10,9 +10,9 @@ define collectd::plugin::powerdns::server (
   concat::fragment{ "collectd_plugin_powerdns_conf_server_${name}":
     order   => '50',
     content => epp('collectd/plugin/powerdns/server.conf.epp', {
-      'name'    => $name,
-      'socket'  => $socket,
-      'collect' => $collect,
+        'name'    => $name,
+        'socket'  => $socket,
+        'collect' => $collect,
     }),
     target  => "${collectd::plugin_conf_dir}/powerdns-config.conf",
   }

--- a/manifests/plugin/powerdns/server.pp
+++ b/manifests/plugin/powerdns/server.pp
@@ -3,11 +3,10 @@ define collectd::plugin::powerdns::server (
   Optional[String[1]] $socket       = undef,
   Array[String[1]] $collect         = [],
 ) {
-
   include collectd::plugin::powerdns
   include collectd
 
-  concat::fragment{ "collectd_plugin_powerdns_conf_server_${name}":
+  concat::fragment { "collectd_plugin_powerdns_conf_server_${name}":
     order   => '50',
     content => epp('collectd/plugin/powerdns/server.conf.epp', {
         'name'    => $name,

--- a/manifests/plugin/processes.pp
+++ b/manifests/plugin/processes.pp
@@ -9,7 +9,6 @@ class collectd::plugin::processes (
   Optional[Boolean] $collect_file_descriptor = undef,
   Optional[Boolean] $collect_memory_maps     = undef,
 ) {
-
   include collectd
 
   $processes_defaults       = { 'ensure' => $ensure }

--- a/manifests/plugin/processes/process.pp
+++ b/manifests/plugin/processes/process.pp
@@ -5,11 +5,10 @@ define collectd::plugin::processes::process (
   Optional[Boolean] $collect_file_descriptor = undef,
   Optional[Boolean] $collect_memory_maps     = undef,
 ) {
-
   include collectd::plugin::processes
   include collectd
 
-  concat::fragment{ "collectd_plugin_processes_conf_process_${process}":
+  concat::fragment { "collectd_plugin_processes_conf_process_${process}":
     order   => '50',
     content => epp('collectd/plugin/processes/process.conf.epp', {
         'process'                 => $process,
@@ -19,5 +18,4 @@ define collectd::plugin::processes::process (
     }),
     target  => "${collectd::plugin_conf_dir}/processes_config.conf",
   }
-
 }

--- a/manifests/plugin/processes/process.pp
+++ b/manifests/plugin/processes/process.pp
@@ -12,10 +12,10 @@ define collectd::plugin::processes::process (
   concat::fragment{ "collectd_plugin_processes_conf_process_${process}":
     order   => '50',
     content => epp('collectd/plugin/processes/process.conf.epp', {
-      'process'                 => $process,
-      'collect_context_switch'  => $collect_context_switch,
-      'collect_file_descriptor' => $collect_file_descriptor,
-      'collect_memory_maps'     => $collect_memory_maps,
+        'process'                 => $process,
+        'collect_context_switch'  => $collect_context_switch,
+        'collect_file_descriptor' => $collect_file_descriptor,
+        'collect_memory_maps'     => $collect_memory_maps,
     }),
     target  => "${collectd::plugin_conf_dir}/processes_config.conf",
   }

--- a/manifests/plugin/processes/processmatch.pp
+++ b/manifests/plugin/processes/processmatch.pp
@@ -13,11 +13,11 @@ define collectd::plugin::processes::processmatch (
   concat::fragment{ "collectd_plugin_processes_conf_processmatch_${matchname}":
     order   => '51',
     content => epp('collectd/plugin/processes/processmatch.conf.epp', {
-      'matchname'               => $matchname,
-      'regex'                   => $regex,
-      'collect_context_switch'  => $collect_context_switch,
-      'collect_file_descriptor' => $collect_file_descriptor,
-      'collect_memory_maps'     => $collect_memory_maps,
+        'matchname'               => $matchname,
+        'regex'                   => $regex,
+        'collect_context_switch'  => $collect_context_switch,
+        'collect_file_descriptor' => $collect_file_descriptor,
+        'collect_memory_maps'     => $collect_memory_maps,
     }),
     target  => "${collectd::plugin_conf_dir}/processes_config.conf",
   }

--- a/manifests/plugin/processes/processmatch.pp
+++ b/manifests/plugin/processes/processmatch.pp
@@ -6,11 +6,10 @@ define collectd::plugin::processes::processmatch (
   Optional[Boolean] $collect_file_descriptor = undef,
   Optional[Boolean] $collect_memory_maps     = undef,
 ) {
-
   include collectd::plugin::processes
   include collectd
 
-  concat::fragment{ "collectd_plugin_processes_conf_processmatch_${matchname}":
+  concat::fragment { "collectd_plugin_processes_conf_processmatch_${matchname}":
     order   => '51',
     content => epp('collectd/plugin/processes/processmatch.conf.epp', {
         'matchname'               => $matchname,

--- a/manifests/plugin/procevent.pp
+++ b/manifests/plugin/procevent.pp
@@ -38,7 +38,6 @@ class collectd::plugin::procevent (
   Optional[String[1]] $process_regex           = undef,
   Optional[Integer[1, default]] $buffer_length = undef,
 ) {
-
   include collectd
 
   if $manage_package and $facts['os']['family'] == 'RedHat' {

--- a/manifests/plugin/protocols.pp
+++ b/manifests/plugin/protocols.pp
@@ -4,7 +4,6 @@ class collectd::plugin::protocols (
   Boolean $ignoreselected = false,
   Array $values           = []
 ) {
-
   include collectd
 
   collectd::plugin { 'protocols':

--- a/manifests/plugin/python.pp
+++ b/manifests/plugin/python.pp
@@ -33,7 +33,7 @@ class collectd::plugin::python (
   }
 
   if $facts['os']['name'] == 'Amazon' or
-      ($facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'8') >= 0) {
+  ($facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'8') >= 0) {
     if $_manage_package {
       package { 'collectd-python':
         ensure => $ensure_real,

--- a/manifests/plugin/python.pp
+++ b/manifests/plugin/python.pp
@@ -15,7 +15,6 @@ class collectd::plugin::python (
   $order               = '10',
   $conf_name           = 'python-config.conf',
 ) {
-
   include collectd
 
   $module_dirs = empty($modulepaths) ? {

--- a/manifests/plugin/python/module.pp
+++ b/manifests/plugin/python/module.pp
@@ -7,7 +7,6 @@ define collectd::plugin::python::module (
   Optional[Stdlib::Absolutepath] $modulepath = undef,
   Optional[String] $script_source = undef,
 ) {
-
   include collectd
   include collectd::plugin::python
 
@@ -48,7 +47,7 @@ define collectd::plugin::python::module (
   )
 
   # Possibly many per instance of a module configuration.
-  concat::fragment{ "collectd_plugin_python_conf_${title}_config":
+  concat::fragment { "collectd_plugin_python_conf_${title}_config":
     order   => "50_${module}_50",
     target  => $collectd::plugin::python::python_conf,
     content => epp('collectd/plugin/python/module.conf_config.epp',

--- a/manifests/plugin/rabbitmq.pp
+++ b/manifests/plugin/rabbitmq.pp
@@ -98,7 +98,7 @@ class collectd::plugin::rabbitmq (
   }
 
   if ($_manage_package) and ($provider_proxy) {
-    $install_options = [{'--proxy' => $provider_proxy}]
+    $install_options = [{ '--proxy' => $provider_proxy }]
   } else {
     $install_options = undef
   }

--- a/manifests/plugin/redis.pp
+++ b/manifests/plugin/redis.pp
@@ -17,7 +17,6 @@ class collectd::plugin::redis (
     },
   },
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/rrdcached.pp
+++ b/manifests/plugin/rrdcached.pp
@@ -14,7 +14,6 @@ class collectd::plugin::rrdcached (
   $collectstatistics        = undef,
   $manage_package           = undef,
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/rrdtool.pp
+++ b/manifests/plugin/rrdtool.pp
@@ -12,7 +12,6 @@ class collectd::plugin::rrdtool (
   Optional[Integer] $cachetimeout    = 120,
   Optional[Integer] $writespersecond = 50
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/sensors.pp
+++ b/manifests/plugin/sensors.pp
@@ -8,7 +8,6 @@ class collectd::plugin::sensors (
   $interval         = undef,
   Optional[Array[String]] $package_install_options = undef
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/smart.pp
+++ b/manifests/plugin/smart.pp
@@ -16,7 +16,7 @@ class collectd::plugin::smart (
     } else {
       if versioncmp($collectd::collectd_version_real, '5.5') >= 0 {
         $_manage_package = true
-    } else {
+      } else {
         $_manage_package = false
       }
     }

--- a/manifests/plugin/smart.pp
+++ b/manifests/plugin/smart.pp
@@ -7,7 +7,6 @@ class collectd::plugin::smart (
   $manage_package         = undef,
   $package_name           = 'collectd-smart',
 ) {
-
   include collectd
 
   if $facts['os']['family'] == 'RedHat' {

--- a/manifests/plugin/snmp.pp
+++ b/manifests/plugin/snmp.pp
@@ -6,7 +6,6 @@ class collectd::plugin::snmp (
   Hash[String[1], Collectd::SNMP::Host] $hosts          = {},
   Optional[Integer[0]]                  $interval       = undef,
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/snmp/data.pp
+++ b/manifests/plugin/snmp/data.pp
@@ -11,7 +11,6 @@ define collectd::plugin::snmp::data (
   Optional[Variant[String[1], Array[String[1], 1]]] $ignore          = undef,
   Boolean                                           $invert_match    = false,
 ) {
-
   include collectd
   include collectd::plugin::snmp
 

--- a/manifests/plugin/snmp/host.pp
+++ b/manifests/plugin/snmp/host.pp
@@ -16,7 +16,6 @@ define collectd::plugin::snmp::host (
   Optional[Collectd::SNMP::PrivacyProtocol] $privacy_protocol   = undef,
   Optional[String[1]]                       $privacy_passphrase = undef,
 ) {
-
   include collectd
   include collectd::plugin::snmp
 

--- a/manifests/plugin/snmp_agent.pp
+++ b/manifests/plugin/snmp_agent.pp
@@ -45,8 +45,8 @@ class collectd::plugin::snmp_agent(
   collectd::plugin { 'snmp_agent':
     ensure  => $ensure,
     content => epp('collectd/plugin/snmp_agent.conf.epp', {
-      'data'  => $data,
-      'table' => $table
+        'data'  => $data,
+        'table' => $table
     }),
   }
 }

--- a/manifests/plugin/snmp_agent.pp
+++ b/manifests/plugin/snmp_agent.pp
@@ -7,7 +7,7 @@
 # @param ensure String Passed to package and collectd::plugin resources (both). Default: present
 # @param data Optional[Hash[String[1],Collectd::SNMP_AGENT::Data]] Defines scalar field, must be put outside Table block.
 # @param table Hash[String[1], Collectd::SNMP_AGENT::Table] Defines a table consisting of several Data blocks being its columns
-class collectd::plugin::snmp_agent(
+class collectd::plugin::snmp_agent (
   Enum['present', 'absent'] $ensure = 'present',
   Optional[Hash[String[1],Collectd::SNMP_AGENT::Data]] $data = {
     'memAvailReal' => {
@@ -39,7 +39,6 @@ class collectd::plugin::snmp_agent(
     },
   }
 ) {
-
   include collectd
 
   collectd::plugin { 'snmp_agent':
@@ -50,5 +49,3 @@ class collectd::plugin::snmp_agent(
     }),
   }
 }
-
-

--- a/manifests/plugin/statsd.pp
+++ b/manifests/plugin/statsd.pp
@@ -15,7 +15,6 @@ class collectd::plugin::statsd (
   $timersum              = undef,
   $timercount            = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'statsd':

--- a/manifests/plugin/swap.pp
+++ b/manifests/plugin/swap.pp
@@ -8,7 +8,6 @@ class collectd::plugin::swap (
   Boolean $valuespercentage = false,
   Boolean $reportio         = true,
 ) {
-
   include collectd
 
   collectd::plugin { 'swap':

--- a/manifests/plugin/sysevent.pp
+++ b/manifests/plugin/sysevent.pp
@@ -48,7 +48,6 @@ class collectd::plugin::sysevent (
   Optional[Integer[0]] $buffer_size            = undef,
   Optional[Integer[1, default]] $buffer_length = undef,
 ) {
-
   include collectd
 
   if $manage_package and $facts['os']['family'] == 'RedHat' {

--- a/manifests/plugin/syslog.pp
+++ b/manifests/plugin/syslog.pp
@@ -5,7 +5,6 @@ class collectd::plugin::syslog (
   Enum['debug', 'info', 'notice', 'warning', 'err'] $log_level = 'info',
   Optional[Enum['OKAY', 'WARNING', 'FAILURE']] $notify_level   = undef
 ) {
-
   include collectd
 
   collectd::plugin { 'syslog':

--- a/manifests/plugin/tail.pp
+++ b/manifests/plugin/tail.pp
@@ -4,7 +4,6 @@ class collectd::plugin::tail (
   $interval             = undef,
   Optional[Hash] $files = {},
 ) {
-
   collectd::plugin { 'tail':
     interval => $interval,
   }

--- a/manifests/plugin/tail/file.pp
+++ b/manifests/plugin/tail/file.pp
@@ -5,7 +5,6 @@ define collectd::plugin::tail::file (
   Array[Hash] $matches,
   $ensure = 'present',
 ) {
-
   include collectd
   include collectd::plugin::tail
 

--- a/manifests/plugin/target_v5upgrade.pp
+++ b/manifests/plugin/target_v5upgrade.pp
@@ -2,7 +2,6 @@
 class collectd::plugin::target_v5upgrade (
   $ensure = 'present',
 ) {
-
   include collectd
 
   collectd::plugin { 'target_v5upgrade':

--- a/manifests/plugin/tcpconns.pp
+++ b/manifests/plugin/tcpconns.pp
@@ -7,7 +7,6 @@ class collectd::plugin::tcpconns (
   Optional[Boolean] $allportssummary = undef,
   $ensure                            = 'present'
 ) {
-
   include collectd
 
   collectd::plugin { 'tcpconns':

--- a/manifests/plugin/thermal.pp
+++ b/manifests/plugin/thermal.pp
@@ -5,7 +5,6 @@ class collectd::plugin::thermal (
   Boolean $ignoreselected = false,
   $interval               = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'thermal':

--- a/manifests/plugin/threshold.pp
+++ b/manifests/plugin/threshold.pp
@@ -6,7 +6,6 @@ class collectd::plugin::threshold (
   Array[Collectd::Threshold::Plugin] $plugins  = [],
   Array[Collectd::Threshold::Host]   $hosts    = [],
 ) {
-
   include collectd
 
   collectd::plugin { 'threshold':

--- a/manifests/plugin/unixsock.pp
+++ b/manifests/plugin/unixsock.pp
@@ -7,7 +7,6 @@ class collectd::plugin::unixsock (
   $ensure                          = 'present',
   $interval                        = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'unixsock':

--- a/manifests/plugin/uptime.pp
+++ b/manifests/plugin/uptime.pp
@@ -3,7 +3,6 @@ class collectd::plugin::uptime (
   $ensure   = 'present',
   $interval = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'uptime':

--- a/manifests/plugin/users.pp
+++ b/manifests/plugin/users.pp
@@ -3,7 +3,6 @@ class collectd::plugin::users (
   $ensure   = 'present',
   $interval = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'users':

--- a/manifests/plugin/uuid.pp
+++ b/manifests/plugin/uuid.pp
@@ -4,7 +4,6 @@ class collectd::plugin::uuid (
   $ensure    = 'present',
   $interval  = undef,
 ) {
-
   include collectd
 
   collectd::plugin { 'uuid':

--- a/manifests/plugin/varnish.pp
+++ b/manifests/plugin/varnish.pp
@@ -8,7 +8,6 @@ class collectd::plugin::varnish (
   },
   $interval       = undef,
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/virt.pp
+++ b/manifests/plugin/virt.pp
@@ -6,14 +6,13 @@ class collectd::plugin::virt (
   Optional[Pattern[/^\d+$/]] $refresh_interval = undef,
   Optional[String] $domain                     = undef,
   Optional[String] $block_device               = undef,
-  Optional[String]$interface_device            = undef,
+  Optional[String] $interface_device           = undef,
   Optional[Boolean] $ignore_selected           = undef,
   Optional[String] $hostname_format            = undef,
   Optional[String] $interface_format           = undef,
   Optional[String] $extra_stats                = undef,
   $interval                                    = undef,
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/vmem.pp
+++ b/manifests/plugin/vmem.pp
@@ -4,7 +4,6 @@ class collectd::plugin::vmem (
   $interval = undef,
   $verbose  = false,
 ) {
-
   include collectd
 
   collectd::plugin { 'vmem':

--- a/manifests/plugin/write_graphite.pp
+++ b/manifests/plugin/write_graphite.pp
@@ -5,7 +5,6 @@ class collectd::plugin::write_graphite (
   $ensure            = 'present',
   $globals           = false,
 ) {
-
   include collectd
 
   collectd::plugin { 'write_graphite':

--- a/manifests/plugin/write_graphite/carbon.pp
+++ b/manifests/plugin/write_graphite/carbon.pp
@@ -14,7 +14,6 @@ define collectd::plugin::write_graphite::carbon (
   Boolean $logsenderrors     = true,
   Integer $reconnectinterval = 0,
 ) {
-
   include collectd
   include collectd::plugin::write_graphite
 

--- a/manifests/plugin/write_http.pp
+++ b/manifests/plugin/write_http.pp
@@ -10,7 +10,6 @@ class collectd::plugin::write_http (
   Hash[String, Hash[String, Scalar]] $urls  = {},
   Optional[Boolean]                  $manage_package = undef,
 ) {
-
   include collectd
 
   if !empty($nodes) and !empty($urls) {
@@ -27,7 +26,7 @@ class collectd::plugin::write_http (
     }
   }
   if $_manage_package {
-    package{'collectd-write_http':
+    package { 'collectd-write_http':
       ensure => $ensure,
     }
   }

--- a/manifests/plugin/write_kafka.pp
+++ b/manifests/plugin/write_kafka.pp
@@ -7,11 +7,10 @@ class collectd::plugin::write_kafka (
   Hash $properties           = {},
   Hash $meta                 = {},
 ) {
-
   include collectd
 
   if($kafka_host and $kafka_port) {
-    $real_kafka_hosts = [ "${kafka_host}:${kafka_port}" ]
+    $real_kafka_hosts = ["${kafka_host}:${kafka_port}"]
   } else {
     $real_kafka_hosts = $kafka_hosts
   }

--- a/manifests/plugin/write_log.pp
+++ b/manifests/plugin/write_log.pp
@@ -2,7 +2,6 @@ class collectd::plugin::write_log (
   String $format = 'JSON',
   $ensure        = 'present',
 ) {
-
   include collectd
 
   collectd::plugin { 'write_log':

--- a/manifests/plugin/write_network.pp
+++ b/manifests/plugin/write_network.pp
@@ -1,9 +1,8 @@
 # A define to make a generic network output for collectd
 class collectd::plugin::write_network (
   $ensure       = 'present',
-  Hash $servers = { 'localhost'  =>  { 'serverport' => '25826' } },
+  Hash $servers = { 'localhost'  => { 'serverport' => '25826' } },
 ) {
-
   include collectd
 
   $servernames = keys($servers)

--- a/manifests/plugin/write_prometheus.pp
+++ b/manifests/plugin/write_prometheus.pp
@@ -2,7 +2,6 @@ class collectd::plugin::write_prometheus (
   Stdlib::Port $port = 9103,
   $ensure = 'present',
 ) {
-
   include collectd
 
   collectd::plugin { 'write_prometheus':

--- a/manifests/plugin/write_riemann.pp
+++ b/manifests/plugin/write_riemann.pp
@@ -6,7 +6,6 @@ class collectd::plugin::write_riemann (
   Array[String[1]] $tags                = [],
   Hash[String[1],String[1]] $attributes = {},
 ) {
-
   include collectd
 
   if $facts['os']['family'] == 'RedHat' {

--- a/manifests/plugin/write_sensu.pp
+++ b/manifests/plugin/write_sensu.pp
@@ -11,7 +11,6 @@ class collectd::plugin::write_sensu (
   $notifications    = false,
   $notifs_handler   = 'example_notification_handler',
 ) {
-
   include collectd
 
   $_manage_package = pick($manage_package, $collectd::manage_package)

--- a/manifests/plugin/write_tsdb.pp
+++ b/manifests/plugin/write_tsdb.pp
@@ -8,10 +8,9 @@ class collectd::plugin::write_tsdb (
   Boolean $store_rates      = false,
   Boolean $always_append_ds = false,
 ) {
-
   include collectd
 
-  collectd::plugin {'write_tsdb':
+  collectd::plugin { 'write_tsdb':
     ensure  => $collectd::plugin::write_tsdb::ensure,
     content => template('collectd/plugin/write_tsdb.conf.erb'),
   }

--- a/manifests/plugin/zfs_arc.pp
+++ b/manifests/plugin/zfs_arc.pp
@@ -2,7 +2,6 @@
 class collectd::plugin::zfs_arc (
   $ensure = 'present',
 ) {
-
   include collectd
 
   collectd::plugin { 'zfs_arc':

--- a/manifests/plugin/zookeeper.pp
+++ b/manifests/plugin/zookeeper.pp
@@ -4,7 +4,6 @@ class collectd::plugin::zookeeper (
   Stdlib::Host              $zookeeper_host   = 'localhost',
   Stdlib::Port              $zookeeper_port   = 2181,
 ) {
-
   include collectd
 
   collectd::plugin { 'zookeeper':

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,16 +1,13 @@
 # collectd::repo
 # Handle package repo configuration
 class collectd::repo {
-
   if $collectd::manage_repo {
     $osfamily_downcase = downcase($facts['os']['family'])
 
     if defined("::collectd::repo::${osfamily_downcase}") {
       require "::collectd::repo::${osfamily_downcase}"
     } else {
-      notify{"You have asked to manage_repo on a system that doesn't have a repo class specified: ${facts['os']['family']}":}
+      notify { "You have asked to manage_repo on a system that doesn't have a repo class specified: ${facts['os']['family']}": }
     }
   }
-
 }
-

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,12 +1,10 @@
 class collectd::repo::debian {
-
   contain apt
   if $collectd::manage_package {
     Class['apt::update'] -> Package[$collectd::package_name]
   }
 
   if $collectd::ci_package_repo {
-
     apt::source { 'collectd-ci':
       location => 'https://pkg.ci.collectd.org/deb/',
       repos    => "collectd-${$collectd::ci_package_repo}",
@@ -30,5 +28,4 @@ class collectd::repo::debian {
       }
     }
   }
-
 }

--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -1,16 +1,12 @@
 class collectd::repo::redhat {
-
   if $collectd::ci_package_repo {
-
     yumrepo { 'collectd-ci':
       ensure  => present,
       enabled => '1',
       baseurl => "https://pkg.ci.collectd.org/rpm/collectd-${collectd::ci_package_repo}/epel-${facts['os']['release']['major']}-${facts['os']['architecture']}",
       gpgkey  => 'https://pkg.ci.collectd.org/pubkey.asc',
     }
-
   } else {
     require epel
   }
-
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,5 @@
 #
 class collectd::service {
-
   assert_private()
 
   if $collectd::manage_service {
@@ -10,5 +9,4 @@ class collectd::service {
       enable => $collectd::service_enable,
     }
   }
-
 }

--- a/manifests/type.pp
+++ b/manifests/type.pp
@@ -9,18 +9,18 @@ define collectd::type (
   # BC compatible .... ending
 
   Array[Struct[{
-    min     => Variant[Numeric, Enum['U']],
-    max     => Variant[Numeric, Enum['U']],
-    ds_type => Enum['ABSOLUTE', 'COUNTER', 'DERIVE', 'GAUGE'],
-    ds_name => String,
+        min     => Variant[Numeric, Enum['U']],
+        max     => Variant[Numeric, Enum['U']],
+        ds_type => Enum['ABSOLUTE', 'COUNTER', 'DERIVE', 'GAUGE'],
+        ds_name => String,
   }]]                                                         $types = [],
 ) {
   if empty($types) {
     $_types = [{
-      min     => $min,
-      max     => $max,
-      ds_type => $ds_type,
-      ds_name => $ds_name,
+        min     => $min,
+        max     => $max,
+        ds_type => $ds_type,
+        ds_name => $ds_name,
     }]
   } else {
     $_types = $types

--- a/manifests/typesdb.pp
+++ b/manifests/typesdb.pp
@@ -4,7 +4,6 @@ define collectd::typesdb (
   $mode  = $collectd::config_mode,
   $owner = $collectd::config_owner,
 ) {
-
   include collectd
 
   concat { $path:

--- a/spec/classes/collectd_plugin_tcpconns_spec.rb
+++ b/spec/classes/collectd_plugin_tcpconns_spec.rb
@@ -75,7 +75,7 @@ describe 'collectd::plugin::tcpconns', type: :class do
         end
 
         it 'Will raise an error about :allportssummary being a String' do
-          expect { is_expected.to.to raise_error(Puppet::Error, %r{String}) }
+          is_expected.to compile.and_raise_error(%r{String})
         end
       end
 


### PR DESCRIPTION
not labeling this one as `modulesync` because fix reformatted a bunch of code. This PR includes:
* https://github.com/voxpupuli/puppet-collectd/pull/947
https://github.com/voxpupuli/puppet-collectd/pull/948