### PR TITLE
Convert mocha tests to rspec

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -11,6 +11,5 @@
   secure: "FAK3Izs5bSZyblGvcFnGWm0exZV5+v9pbwfRDD2oihWxX3U3pArGW+3XcwcJfLQgrUYBsOTmHC8yPjlgTBYeIt/5pvg9X+3jwNgeto6kozpI/nvAq4NtcHhzxRejuPELhFYeXZ3hEw0w+v/ZRo2cNLwI0LLpiWEDvCMZN1CJ2RY="
 spec/spec_helper.rb:
   spec_overrides: "require 'spec_helper_methods'"
-  mock_with: ':mocha'
 spec/spec_helper_acceptance.rb:
   unmanaged: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def location_for(place, fake_version = nil)
 end
 
 group :test do
-  gem 'voxpupuli-test', '>= 1.0.0',  :require => false
+  gem 'voxpupuli-test', '~> 1.5',    :require => false
   gem 'coveralls',                   :require => false
   gem 'simplecov-console',           :require => false
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,6 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/voxpupuli/modulesync_config
 
-RSpec.configure do |c|
-  c.mock_with :mocha
-end
-
 # puppetlabs_spec_helper will set up coverage if the env variable is set.
 # We want to do this if lib exists and it hasn't been explicitly set.
 ENV['COVERAGE'] ||= 'yes' if Dir.exist?(File.expand_path('../../lib', __FILE__))

--- a/spec/unit/collectd_real_version_spec.rb
+++ b/spec/unit/collectd_real_version_spec.rb
@@ -5,21 +5,21 @@ describe 'collectd_version', type: :fact do
   after { Facter.clear }
 
   it 'is 5.1.0 according to output' do
-    Facter::Util::Resolution.stubs(:which).with('collectd').returns('/usr/sbin/collectd')
+    allow(Facter::Util::Resolution).to receive(:which).with('collectd').and_return('/usr/sbin/collectd')
     sample_collectd_help = File.read(fixtures('facts', 'collectd_help'))
-    Facter::Util::Resolution.stubs(:exec).with('collectd -h').returns(sample_collectd_help)
+    allow(Facter::Util::Resolution).to receive(:exec).with('collectd -h').and_return(sample_collectd_help)
     expect(Facter.fact(:collectd_version).value).to eq('5.1.0')
   end
 
   it 'is 5.1.0.git according to output' do
-    Facter::Util::Resolution.stubs(:which).with('collectd').returns('/usr/sbin/collectd')
+    allow(Facter::Util::Resolution).to receive(:which).with('collectd').and_return('/usr/sbin/collectd')
     sample_collectd_help_git = File.read(fixtures('facts', 'collectd_help_git'))
-    Facter::Util::Resolution.stubs(:exec).with('collectd -h').returns(sample_collectd_help_git)
+    allow(Facter::Util::Resolution).to receive(:exec).with('collectd -h').and_return(sample_collectd_help_git)
     expect(Facter.fact(:collectd_version).value).to eq('5.1.0.git')
   end
 
   it 'is not defined if collectd not installed' do
-    Facter::Util::Resolution.stubs(:which).with('collectd').returns(nil)
+    allow(Facter::Util::Resolution).to receive(:which).with('collectd').and_return(nil)
     expect(Facter.fact(:collectd_version).value).to be_nil
   end
 end

--- a/spec/unit/python_dir_spec.rb
+++ b/spec/unit/python_dir_spec.rb
@@ -7,44 +7,44 @@ describe 'python_dir', type: :fact do
     context 'default path' do
       before do
         # This is needed to make this spec work on Fedora, apparently
-        Facter.fact(:osfamily).stubs(:value).returns('AnythingNotRedHat')
-        Facter::Util::Resolution.stubs(:which).with('python').returns(true)
-        Facter::Util::Resolution.stubs(:exec).with('python -c "import site; print(site.getsitepackages()[0])"').returns('/usr/local/lib/python2.7/dist-packages')
+        allow(Facter).to receive(:value).with(:osfamily).and_return('AnythingNotRedHat')
+        allow(Facter::Util::Resolution).to receive(:which).with('python').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('python -c "import site; print(site.getsitepackages()[0])"').and_return('/usr/local/lib/python2.7/dist-packages')
       end
       it do
-        expect(Facter.value(:python_dir)).to eq('/usr/local/lib/python2.7/dist-packages')
+        expect(Facter.fact(:python_dir).value).to eq('/usr/local/lib/python2.7/dist-packages')
       end
     end
 
     context 'RedHat' do
       before do
-        Facter.fact(:osfamily).stubs(:value).returns('RedHat')
-        Facter::Util::Resolution.stubs(:which).with('python').returns(true)
-        Facter::Util::Resolution.stubs(:exec).with('python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"').returns('/usr/lib/python2.7/site-packages')
+        allow(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
+        allow(Facter::Util::Resolution).to receive(:which).with('python').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"').and_return('/usr/lib/python2.7/site-packages')
       end
       it do
-        expect(Facter.value(:python_dir)).to eq('/usr/lib/python2.7/site-packages')
+        expect(Facter.fact(:python_dir).value).to eq('/usr/lib/python2.7/site-packages')
       end
     end
 
     context 'RedHat versioned python' do
       before do
-        Facter.fact(:osfamily).stubs(:value).returns('RedHat')
-        Facter::Util::Resolution.stubs(:which).with('python').returns(false)
-        Facter::Util::Resolution.stubs(:which).with('python3').returns(true)
-        Facter::Util::Resolution.stubs(:exec).with('python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"').returns('/usr/lib/python3.6/site-packages')
+        allow(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
+        allow(Facter::Util::Resolution).to receive(:which).with('python').and_return(false)
+        allow(Facter::Util::Resolution).to receive(:which).with('python3').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec).with('python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"').and_return('/usr/lib/python3.6/site-packages')
       end
       it do
-        expect(Facter.value(:python_dir)).to eq('/usr/lib/python3.6/site-packages')
+        expect(Facter.fact(:python_dir).value).to eq('/usr/lib/python3.6/site-packages')
       end
     end
   end
 
   it 'is empty string if python not installed' do
-    Facter::Util::Resolution.stubs(:which).with('python').returns(nil)
-    Facter::Util::Resolution.stubs(:which).with('python2').returns(nil)
-    Facter::Util::Resolution.stubs(:which).with('python3').returns(nil)
-    File.stubs(:exist?).with('/usr/libexec/platform-python').returns(nil)
+    allow(Facter::Util::Resolution).to receive(:which).with('python').and_return(nil)
+    allow(Facter::Util::Resolution).to receive(:which).with('python2').and_return(nil)
+    allow(Facter::Util::Resolution).to receive(:which).with('python3').and_return(nil)
+    allow(File).to receive(:exist?).with('/usr/libexec/platform-python').and_return(nil)
     expect(Facter.fact(:python_dir).value).to eq('')
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
This PR converts the rspec tests used for testing the fact to rspec, rather than mocha, to match the other voxpupuli modules.
