### PR TITLE
Drop erroneous double quotes from virt plugin template

### DIFF
--- a/spec/classes/collectd_plugin_virt_spec.rb
+++ b/spec/classes/collectd_plugin_virt_spec.rb
@@ -11,6 +11,48 @@ describe 'collectd::plugin::virt', type: :class do
         'include collectd'
       end
 
+      context 'hostname_format in virt.conf' do
+        let :params do
+          {
+            connection: 'qemu:///system',
+            hostname_format: 'name metadata uuid'
+          }
+        end
+
+        context 'with collectd_version < 5.0' do
+          let :facts do
+            facts.merge(collectd_version: '4.10.1')
+          end
+
+          it 'contains appropriate configuration' do
+            is_expected.to contain_file('libvirt.load').
+              with_content(%r{.*HostnameFormat name metadata uuid.*})
+          end
+        end
+
+        context 'with collectd_version >= 5.0' do
+          let :facts do
+            facts.merge(collectd_version: '5.0.0')
+          end
+
+          it 'contains appropriate configuration' do
+            is_expected.to contain_file('libvirt.load').
+              with_content(%r{.*HostnameFormat name metadata uuid.*})
+          end
+        end
+
+        context 'with collectd_version >= 5.5.0' do
+          let :facts do
+            facts.merge(collectd_version: '5.5.0')
+          end
+
+          it 'contains appropriate configuration' do
+            is_expected.to contain_file('virt.load').
+              with_content(%r{.*HostnameFormat name metadata uuid.*})
+          end
+        end
+      end
+
       context 'plugin_instance_format in virt.conf' do
         let :params do
           {

--- a/templates/plugin/virt.conf.erb
+++ b/templates/plugin/virt.conf.erb
@@ -25,7 +25,7 @@
 <% end -%>
 <%- end -%>
 <% if @hostname_format != nil -%>
-  HostnameFormat "<%= @hostname_format %>"
+  HostnameFormat <%= @hostname_format %>
 <% end -%>
 <% if @extra_stats != nil -%>
   ExtraStats "<%= @extra_stats %>"


### PR DESCRIPTION
Use of double-quotes around the HostnameFormat field in the virt plugin erb
template is wrong when using multiple names. Error generated will be
[2020-09-04 03:17:04] virt plugin: unknown HostnameFormat field: name metadata uuid
when setting the configuration to

HostnameFormat "name metadata uuid"

Simply removing the double quotes allows for a successful virt plugin load. Source
in collectd justifying this change is at: https://github.com/collectd/collectd/blob/main/src/virt.c#L834

Fixes #953