### PR TITLE
Add PluginInstanceFormat parameter to virt plugin

### DIFF
--- a/manifests/plugin/virt.pp
+++ b/manifests/plugin/virt.pp
@@ -1,17 +1,18 @@
 # https://collectd.org/wiki/index.php/Plugin:virt
 class collectd::plugin::virt (
   String $connection,
-  $ensure                                      = 'present',
-  $manage_package                              = undef,
-  Optional[Pattern[/^\d+$/]] $refresh_interval = undef,
-  Optional[String] $domain                     = undef,
-  Optional[String] $block_device               = undef,
-  Optional[String] $interface_device           = undef,
-  Optional[Boolean] $ignore_selected           = undef,
-  Optional[String] $hostname_format            = undef,
-  Optional[String] $interface_format           = undef,
-  Optional[String] $extra_stats                = undef,
-  $interval                                    = undef,
+  $ensure                                                                    = 'present',
+  $manage_package                                                            = undef,
+  Optional[Pattern[/^\d+$/]] $refresh_interval                               = undef,
+  Optional[String] $domain                                                   = undef,
+  Optional[String] $block_device                                             = undef,
+  Optional[String] $interface_device                                         = undef,
+  Optional[Boolean] $ignore_selected                                         = undef,
+  Optional[Enum['none', 'name', 'uuid', 'metadata']] $plugin_instance_format = undef,
+  Optional[String] $hostname_format                                          = undef,
+  Optional[String] $interface_format                                         = undef,
+  Optional[String] $extra_stats                                              = undef,
+  $interval                                                                  = undef,
 ) {
   include collectd
 

--- a/spec/classes/collectd_plugin_virt_spec.rb
+++ b/spec/classes/collectd_plugin_virt_spec.rb
@@ -11,6 +11,57 @@ describe 'collectd::plugin::virt', type: :class do
         'include collectd'
       end
 
+      context 'plugin_instance_format in virt.conf' do
+        let :params do
+          {
+            connection: 'qemu:///system',
+            plugin_instance_format: 'name'
+          }
+        end
+
+        context 'with collectd_version < 5.0' do
+          let :facts do
+            facts.merge(collectd_version: '4.10.1')
+          end
+
+          it 'is ignored' do
+            is_expected.to contain_file('libvirt.load').
+              without_content(%r{.*PluginInstanceFormat name.*})
+          end
+        end
+
+        context 'with collectd_version >= 5.0' do
+          let :facts do
+            facts.merge(collectd_version: '5.0.0')
+          end
+
+          it 'is included' do
+            is_expected.to contain_file('libvirt.load').
+              without_content(%r{.*PluginInstanceFormat name.*})
+          end
+        end
+
+        context 'with collectd_version >= 5.5.0' do
+          let :facts do
+            facts.merge(collectd_version: '5.5.0')
+          end
+
+          it 'is included' do
+            is_expected.to contain_file('virt.load').
+              with_content(%r{.*PluginInstanceFormat name.*})
+          end
+        end
+
+        case facts[:os]['family']
+        when 'RedHat'
+          context 'on osfamily => RedHat' do
+            it 'Will delete packaging config file' do
+              is_expected.to contain_file('package_virt.load').with_ensure('absent')
+            end
+          end
+        end
+      end
+
       context 'interface_format in virt.conf' do
         let :params do
           {

--- a/templates/plugin/virt.conf.erb
+++ b/templates/plugin/virt.conf.erb
@@ -19,6 +19,11 @@
 <% if @ignore_selected != nil -%>
   IgnoreSelected <%= @ignore_selected %>
 <% end -%>
+<%- if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.5']) >= 0) -%>
+<% if @plugin_instance_format != nil -%>
+  PluginInstanceFormat <%= @plugin_instance_format %>
+<% end -%>
+<%- end -%>
 <% if @hostname_format != nil -%>
   HostnameFormat "<%= @hostname_format %>"
 <% end -%>


### PR DESCRIPTION
Add the PluginInstanceFormat parameter to the virt plugin to allow for specifying the
plugin instance format, resulting in a new label being available to the virt metrics. By
adding this you can provide the UUID of the virtual machine, along with HostnameFormat
to have information about VMs that exist per physical host.