### PR TITLE
Fix dbi query.conf.erg template

### DIFF
--- a/templates/plugin/dbi/query.conf.erb
+++ b/templates/plugin/dbi/query.conf.erb
@@ -1,4 +1,4 @@
-  <Query <%= @name %>>
+  <Query "<%= @name %>">
     Statement "<%= @statement %>"
 <% if @minversion -%>
     MinVersion <%= @minversion %>


### PR DESCRIPTION
#### Pull Request (PR) description
Without this change collectd refuse to load configuration for dbi plugin with error (at least for me - collectd-5.8.1):
The Query block needs exactly one string argument.
dbi plugin: No <Query> blocks have been found. Without them, this plugin can't do anything useful, so we will return an error.

