### PR TITLE
Install collectd-mcelog package on RedHat

### DIFF
--- a/manifests/plugin/mcelog.pp
+++ b/manifests/plugin/mcelog.pp
@@ -1,6 +1,8 @@
 # https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_mcelog
 class collectd::plugin::mcelog (
   Enum['present', 'absent'] $ensure = 'present',
+  Optional[Boolean] $manage_package = undef,
+  Optional[Array] $package_install_options = $collectd::package_install_options,
   # Log file option and memory option are mutualy exclusive.
   Optional[String] $mceloglogfile = undef,
   Optional[Collectd::MCELOG::Memory] $memory = {
@@ -9,6 +11,23 @@ class collectd::plugin::mcelog (
   }
 ) {
   include collectd
+
+  $_manage_package = pick($manage_package, $collectd::manage_package)
+
+  if $ensure == 'present' {
+    $package_ensure = $collectd::package_ensure
+  } elsif $ensure == 'absent' {
+    $package_ensure = 'absent'
+  }
+
+  if $facts['os']['family'] == 'RedHat' {
+    if $_manage_package {
+      package { 'collectd-mcelog':
+        ensure          => $package_ensure,
+        install_options => $package_install_options,
+      }
+    }
+  }
 
   collectd::plugin { 'mcelog':
     ensure  => $ensure,

--- a/spec/classes/collectd_plugin_mcelog_spec.rb
+++ b/spec/classes/collectd_plugin_mcelog_spec.rb
@@ -7,6 +7,10 @@ describe 'collectd::plugin::mcelog', type: :class do
         facts
       end
 
+      let :pre_condition do
+        'include collectd'
+      end
+
       it { is_expected.to compile.with_all_deps }
 
       options = os_specific_options(facts)
@@ -20,6 +24,13 @@ describe 'collectd::plugin::mcelog', type: :class do
         it { is_expected.to contain_file('mcelog.load').with(content: %r{<Memory>}) }
         it { is_expected.to contain_file('mcelog.load').with(content: %r{McelogClientSocket "/var/run/mcelog-client"}) }
         it { is_expected.to contain_file('mcelog.load').with(content: %r{PersistentNotification false}) }
+      end
+
+      case facts[:os]['family']
+      when 'RedHat'
+        context 'on osfamily => RedHat' do
+          it { is_expected.to contain_package('collectd-mcelog').with(ensure: 'present') }
+        end
       end
 
       context ':ensure => :mceloglogfile => true' do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Similar to `collectd-sensors`, redhat systems need `collectd-mcelog` package to be installed.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
Fixes issue when collectd fails with `plugin_load: Could not find plugin "mcelog" in /usr/lib64/collectd`