### PR TITLE
Separation of values for a python plugin array module key

### DIFF
--- a/spec/classes/collectd_plugin_python_spec.rb
+++ b/spec/classes/collectd_plugin_python_spec.rb
@@ -150,7 +150,9 @@ describe 'collectd::plugin::python', type: :class do
               target: "#{options[:plugin_conf_dir]}/python-config.conf"
             )
             is_expected.to contain_concat__fragment('collectd_plugin_python_conf_alpha_config').with(content: %r{Beta 4.2})
-            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_alpha_config').with(content: %r{Delta "a" 4 5})
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_alpha_config').with(content: %r{Delta "a"})
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_alpha_config').with(content: %r{Delta 4})
+            is_expected.to contain_concat__fragment('collectd_plugin_python_conf_alpha_config').with(content: %r{Delta 5})
             is_expected.to contain_concat__fragment('collectd_plugin_python_conf_alpha_config').with(content: %r{Gamma "b"})
           end
         end

--- a/spec/defines/collectd_plugin_python_module_spec.rb
+++ b/spec/defines/collectd_plugin_python_module_spec.rb
@@ -31,7 +31,10 @@ describe 'collectd::plugin::python::module', type: :define do
           )
 
           is_expected.to contain_concat__fragment('collectd_plugin_python_conf_spam_config').with(
-            content: %r{spam "wonderful" "lovely"}
+            content: %r{spam "wonderful"}
+          )
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_spam_config').with(
+            content: %r{spam "lovely"}
           )
         end
 
@@ -108,7 +111,8 @@ describe 'collectd::plugin::python::module', type: :define do
 
         it 'includes foo module configuration' do
           is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo_config').with(content: %r{k1 "v1"})
-          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo_config').with(content: %r{k2 "v21" "v22"})
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo_config').with(content: %r{k2 "v21"})
+          is_expected.to contain_concat__fragment('collectd_plugin_python_conf_foo_config').with(content: %r{k2 "v22"})
         end
       end
     end

--- a/templates/plugin/python/module.conf_config.epp
+++ b/templates/plugin/python/module.conf_config.epp
@@ -9,16 +9,14 @@
     <%- if ($value =~ Numeric or $value =~ Boolean) { -%>
     <%= $key %> <%= $value %>
     <%- } elsif $value =~ Array { -%>
-      <%#- Render arrays as key "Value 1" "Value2" 22 false -%>
-    <%= $key -%> 
+      <%#- Render arrays as key "Value 1" \n key "Value 2" \n key 22 \n key false -%>
       <%- $value.each |$v| { -%>
         <%- if ($v =~ Boolean or $v =~ Numeric) { -%>
- <%= $v -%>
+    <%= $key %> <%= $v %>
         <%- } else { -%>
- "<%= $v -%><%= '"' -%>
+    <%= $key %> "<%= $v %>"
         <%- } -%>
       <%- } -%>
-<%= "\n" -%>
     <%- } else { -%>
     <%= $key %> "<%= $value %>"
     <%- } -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Collectd expects to have a single value per each key when it is not another Config object instance included within the module configuration. So the result from an array of params is supposed to be like.

Key "Value1"
Key "Value 2"
Key 22
Key false

Change of module configuration parsing array values to per single value fixes the issue.


#### This Pull Request (PR) fixes the following issues
Fixes #964 