### PR TITLE
Convert plugin_instance_format from Enum to String

### DIFF
--- a/manifests/plugin/virt.pp
+++ b/manifests/plugin/virt.pp
@@ -8,7 +8,7 @@ class collectd::plugin::virt (
   Optional[String] $block_device                                             = undef,
   Optional[String] $interface_device                                         = undef,
   Optional[Boolean] $ignore_selected                                         = undef,
-  Optional[Enum['none', 'name', 'uuid', 'metadata']] $plugin_instance_format = undef,
+  Optional[String] $plugin_instance_format                                   = undef,
   Optional[String] $hostname_format                                          = undef,
   Optional[String] $interface_format                                         = undef,
   Optional[String] $extra_stats                                              = undef,

--- a/manifests/plugin/virt.pp
+++ b/manifests/plugin/virt.pp
@@ -8,7 +8,7 @@ class collectd::plugin::virt (
   Optional[String] $block_device                                             = undef,
   Optional[String] $interface_device                                         = undef,
   Optional[Boolean] $ignore_selected                                         = undef,
-  Optional[String[1]] $plugin_instance_format                                   = undef,
+  Optional[String[1]] $plugin_instance_format                                = undef,
   Optional[String] $hostname_format                                          = undef,
   Optional[String] $interface_format                                         = undef,
   Optional[String] $extra_stats                                              = undef,

--- a/manifests/plugin/virt.pp
+++ b/manifests/plugin/virt.pp
@@ -8,7 +8,7 @@ class collectd::plugin::virt (
   Optional[String] $block_device                                             = undef,
   Optional[String] $interface_device                                         = undef,
   Optional[Boolean] $ignore_selected                                         = undef,
-  Optional[String] $plugin_instance_format                                   = undef,
+  Optional[String[1]] $plugin_instance_format                                   = undef,
   Optional[String] $hostname_format                                          = undef,
   Optional[String] $interface_format                                         = undef,
   Optional[String] $extra_stats                                              = undef,

--- a/spec/classes/collectd_plugin_virt_spec.rb
+++ b/spec/classes/collectd_plugin_virt_spec.rb
@@ -57,7 +57,7 @@ describe 'collectd::plugin::virt', type: :class do
         let :params do
           {
             connection: 'qemu:///system',
-            plugin_instance_format: 'name'
+            plugin_instance_format: 'name metadata uuid'
           }
         end
 
@@ -68,7 +68,7 @@ describe 'collectd::plugin::virt', type: :class do
 
           it 'is ignored' do
             is_expected.to contain_file('libvirt.load').
-              without_content(%r{.*PluginInstanceFormat name.*})
+              without_content(%r{.*PluginInstanceFormat name metadata uuid.*})
           end
         end
 
@@ -79,7 +79,7 @@ describe 'collectd::plugin::virt', type: :class do
 
           it 'is included' do
             is_expected.to contain_file('libvirt.load').
-              without_content(%r{.*PluginInstanceFormat name.*})
+              without_content(%r{.*PluginInstanceFormat name metadata uuid.*})
           end
         end
 
@@ -90,7 +90,7 @@ describe 'collectd::plugin::virt', type: :class do
 
           it 'is included' do
             is_expected.to contain_file('virt.load').
-              with_content(%r{.*PluginInstanceFormat name.*})
+              with_content(%r{.*PluginInstanceFormat name metadata uuid.*})
           end
         end
 


### PR DESCRIPTION
The plugin_instance_format (PluginInstanceFormat) parameter in the
collectd virt plugin is capable of taking multiple values, not a single
value from an Enum list.

Fixes #968