### PR TITLE
Adding Reverse Host parameter

### DIFF
--- a/manifests/plugin/write_graphite/carbon.pp
+++ b/manifests/plugin/write_graphite/carbon.pp
@@ -13,6 +13,7 @@ define collectd::plugin::write_graphite::carbon (
   Boolean $separateinstances = false,
   Boolean $logsenderrors     = true,
   Integer $reconnectinterval = 0,
+  Boolean $reversehost       = false,
 ) {
   include collectd
   include collectd::plugin::write_graphite

--- a/templates/plugin/write_graphite/carbon.conf.erb
+++ b/templates/plugin/write_graphite/carbon.conf.erb
@@ -20,6 +20,9 @@
 <%- if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.6']) >= 0) -%>
   ReconnectInterval <%= @reconnectinterval %>
 <%- end -%>
+<%- if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.9']) >= 0) -%>
+  ReverseHost <%= @reversehost %>
+<%- end -%>  
 <%- if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.3']) >= 0) -%>
 </Node>
 <%- else -%>


### PR DESCRIPTION
#### Pull Request (PR) description
In version 5.9.0 of collectd, a ReverseHost parameters was added to the write_graphite plugin.  If set to **true**, the (dot separated) parts of the host field of the value list will be rewritten in reverse order. The rewrite happens before special characters are replaced with the EscapeCharacter.


#### This Pull Request (PR) fixes the following issues
Feature is currently unavailable when using the module
