### PR TITLE
.sync.yml: load spec_helper_methods in spec_helper.rb

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,3 +1,5 @@
 ---
 .github/workflows/ci.yml:
   timeout_minutes: 75
+spec/spec_helper.rb:
+￼  spec_overrides: "require 'spec_helper_methods'"


### PR DESCRIPTION
We had this in the past, but it was purged by accident in a previous
msync run:
https://github.com/voxpupuli/puppet-collectd/commit/c5e7f6d1d00c7bce637b31118873773a4a9aa9ff#diff-b1bbc4d50c1c098ca18224cbc9519ad646dcc5e3dd912edf55610ab5bba3566eL12-L13

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
