### PR TITLE
Fix spacing in YAML file

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,4 +2,4 @@
 .github/workflows/ci.yml:
   timeout_minutes: 75
 spec/spec_helper.rb:
-￼  spec_overrides: "require 'spec_helper_methods'"
+￼ spec_overrides: "require 'spec_helper_methods'"


### PR DESCRIPTION
#### Pull Request (PR) description

#979 introduced a line with 3 spaces instead of 2.  It is the root cause of this error:
https://github.com/voxpupuli/modulesync_config/pull/732/checks?check_run_id=3247404546

Running `msync update` with the `--offline` flag after fixing this space problem does not fail.

#### This Pull Request (PR) fixes the following issues
n/a
