### PR TITLE
Fix whitespace in .sync.yml

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,4 +2,4 @@
 .github/workflows/ci.yml:
   timeout_minutes: 75
 spec/spec_helper.rb:
-￼ spec_overrides: "require 'spec_helper_methods'"
+  spec_overrides: "require 'spec_helper_methods'"


### PR DESCRIPTION
ceacd462bb6150774b3acaf8df48a535a7fba0a8 attempted to fix this, but this is a change I needed to make. I'm not sure what the exact difference is, but it's clearly there.