### PR TITLE
add server parameter on collectd::plugin::network::server

### DIFF
--- a/manifests/plugin/network/server.pp
+++ b/manifests/plugin/network/server.pp
@@ -8,6 +8,7 @@ define collectd::plugin::network::server (
   Optional[String] $interface                               = undef,
   Optional[Boolean] $forward                                = undef,
   Optional[Integer[1]] $resolveinterval                     = undef,
+  String[1] $server                                         = $name,
 ) {
   include collectd
   include collectd::plugin::network

--- a/spec/defines/collectd_plugin_network_server_spec.rb
+++ b/spec/defines/collectd_plugin_network_server_spec.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'collectd::plugin::network::server', type: :define do
   on_supported_os(baseline_os_hash).each do |os, facts|
-    context "on #{os} " do
+    context "on #{os}" do
       let :facts do
         facts
       end
@@ -39,6 +41,19 @@ describe 'collectd::plugin::network::server', type: :define do
 
         it "Will not create #{options[:plugin_conf_dir]}/network-server-node1.conf" do
           is_expected.to contain_file("#{options[:plugin_conf_dir]}/network-server-node1.conf").with(ensure: 'absent')
+        end
+      end
+
+      context 'with specifique title' do
+        let(:title) { 'eatapples' }
+        let :params do
+          { server: '10.0.0.1', port: 1234 }
+        end
+
+        it do
+          is_expected.to contain_file(
+            "#{options[:plugin_conf_dir]}/network-server-eatapples.conf"
+          ).with_content(%r{<Server "10\.0\.0\.1" "1234">\n})
         end
       end
     end

--- a/templates/plugin/network/server.conf.erb
+++ b/templates/plugin/network/server.conf.erb
@@ -1,6 +1,6 @@
 <Plugin network>
 <% if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '4.7']) >= 0) -%>
-  <Server "<%= @name %>" "<%= @port %>">
+  <Server "<%= @server %>" "<%= @port %>">
 <% if @securitylevel -%>
     SecurityLevel "<%= @securitylevel %>"
 <% end -%>
@@ -18,7 +18,7 @@
 <% end %>
   </Server>
 <% else -%>
-  Server "<%= @name %>" "<%= @port %>"
+  Server "<%= @server %>" "<%= @port %>"
 <% end -%>
 <% if ! @forward.nil? -%>
   Forward <%= @forward %>


### PR DESCRIPTION
Hello,

I've actually a profile class with a Collectd::Plugin::Network::Server. My collectd can be overwrite by anybody, and my profil class can't be detect which old network file it's require to clean if I not create a new resource with absent statement.

I would like to manage this plugin with a fixed file name and define the server with a separated parameter.

#### Pull Request (PR) description
[](https://github.com/voxpupuli/puppet-collectd/commits?author=fe80)This feature include the possibility to add a specific title on `collectd::plugin::network::server` for the configuration file name. The server should be define with the `server` option.

#### This Pull Request (PR) fixes the following issues
