### PR TITLE
Drop Arch Linux support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -80,9 +80,6 @@
     },
     {
       "operatingsystem": "Gentoo"
-    },
-    {
-      "operatingsystem": "Archlinux"
     }
   ],
   "requirements": [


### PR DESCRIPTION
Arch doesn't have the collectd package in the official repos anymore.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
