### PR TITLE
Be explicit for requires of collectd.d

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -42,10 +42,11 @@ class collectd::config inherits collectd {
 
   if $_conf_content {
     concat { 'collectd_typesdb':
-      ensure => present,
-      mode   => $collectd::config_mode,
-      owner  => $collectd::config_group,
-      path   => "${collectd::collectd_dir}/typesdb.conf",
+      ensure  => present,
+      mode    => $collectd::config_mode,
+      owner   => $collectd::config_group,
+      path    => "${collectd::collectd_dir}/typesdb.conf",
+      require => File['collectd.d'],
     }
 
     concat::fragment { 'collectd_typesdb_header':
@@ -54,6 +55,4 @@ class collectd::config inherits collectd {
       target  => 'collectd_typesdb',
     }
   }
-
-  File['collectd.d'] -> Concat <| tag == 'collectd' |>
 }

--- a/manifests/plugin/dbi.pp
+++ b/manifests/plugin/dbi.pp
@@ -46,6 +46,7 @@ class collectd::plugin::dbi (
     group          => $collectd::config_group,
     notify         => Service[$collectd::service_name],
     ensure_newline => true,
+    require        => File['collectd.d'],
   }
 
   concat::fragment { 'collectd_plugin_dbi_conf_header':

--- a/manifests/plugin/exec.pp
+++ b/manifests/plugin/exec.pp
@@ -24,6 +24,7 @@ class collectd::plugin::exec (
     group          => $collectd::config_group,
     notify         => Service[$collectd::service_name],
     ensure_newline => true,
+    require        => File['collectd.d'],
   }
 
   concat::fragment { 'collectd_plugin_exec_conf_header':

--- a/manifests/plugin/filter/chain.pp
+++ b/manifests/plugin/filter/chain.pp
@@ -16,6 +16,7 @@ define collectd::plugin::filter::chain (
     group          => $collectd::config_group,
     notify         => Service[$collectd::service_name],
     ensure_newline => true,
+    require        => File['collectd.d'],
   }
 
   if $ensure == 'present' {

--- a/manifests/plugin/genericjmx.pp
+++ b/manifests/plugin/genericjmx.pp
@@ -26,6 +26,7 @@ class collectd::plugin::genericjmx (
     group          => $collectd::config_group,
     notify         => Service[$collectd::service_name],
     ensure_newline => true,
+    require        => File['collectd.d'],
   }
 
   concat::fragment {

--- a/manifests/plugin/oracle.pp
+++ b/manifests/plugin/oracle.pp
@@ -27,6 +27,7 @@ class collectd::plugin::oracle (
     group          => $collectd::config_group,
     notify         => Service[$collectd::service_name],
     ensure_newline => true,
+    require        => File['collectd.d'],
   }
 
   concat::fragment {

--- a/manifests/plugin/postgresql.pp
+++ b/manifests/plugin/postgresql.pp
@@ -34,6 +34,7 @@ class collectd::plugin::postgresql (
     group          => $collectd::config_group,
     notify         => Service[$collectd::service_name],
     ensure_newline => true,
+    require        => File['collectd.d'],
   }
 
   concat::fragment { 'collectd_plugin_postgresql_conf_header':

--- a/manifests/plugin/powerdns.pp
+++ b/manifests/plugin/powerdns.pp
@@ -25,6 +25,7 @@ class collectd::plugin::powerdns (
     group          => $collectd::config_group,
     notify         => Service[$collectd::service_name],
     ensure_newline => true,
+    require        => File['collectd.d'],
   }
   concat::fragment { 'collectd_plugin_powerdns_conf_header':
     order   => '00',

--- a/manifests/plugin/processes.pp
+++ b/manifests/plugin/processes.pp
@@ -27,6 +27,7 @@ class collectd::plugin::processes (
     group          => $collectd::config_group,
     notify         => Service[$collectd::service_name],
     ensure_newline => true,
+    require        => File['collectd.d'],
   }
   concat::fragment { 'collectd_plugin_processes_conf_header':
     order   => '00',

--- a/manifests/plugin/write_graphite.pp
+++ b/manifests/plugin/write_graphite.pp
@@ -23,6 +23,7 @@ class collectd::plugin::write_graphite (
         group          => $collectd::config_group,
         notify         => Service[$collectd::service_name],
         ensure_newline => true,
+        require        => File['collectd.d'],
       }
 
       concat::fragment { 'collectd_plugin_write_graphite_conf_header':

--- a/manifests/typesdb.pp
+++ b/manifests/typesdb.pp
@@ -23,6 +23,7 @@ define collectd::typesdb (
     mode           => $mode,
     ensure_newline => true,
     notify         => Service[$collectd::service_name],
+    require        => File['collectd.d'],
   }
 
   if $include and $collectd::purge_config {


### PR DESCRIPTION
#### Pull Request (PR) description

Previously all the concat's created typically in `/etc/collect.d` were subject to

```
File['collectd.d'] -> Concat <| tag == 'collectd' |>
```
to ensure the directory was in place first.

This turns out to be too greedy and can cause problems as per #1000.

Instead be explicit about requiring the directory on the concat files that are being created.

Consequence of this if concat files are being created in `/etc/collect.d` outside this module they will now
have to require this directory. At worst such configuration would require a second puppet run.

#### This Pull Request (PR) fixes the following issues
Fixes #1000
