### PR TITLE
Rely on autorequires of files when using concat

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -54,6 +54,4 @@ class collectd::config inherits collectd {
       target  => 'collectd_typesdb',
     }
   }
-
-  File['collectd.d'] -> Concat <| tag == 'collectd' |>
 }

--- a/spec/classes/collectd_plugin_dbi_spec.rb
+++ b/spec/classes/collectd_plugin_dbi_spec.rb
@@ -17,8 +17,7 @@ describe 'collectd::plugin::dbi', type: :class do
           )
         end
         it "Will create #{options[:plugin_conf_dir]}/dbi-config.conf" do
-          is_expected.to contain_concat("#{options[:plugin_conf_dir]}/dbi-config.conf").
-            that_requires('File[collectd.d]')
+          is_expected.to contain_concat("#{options[:plugin_conf_dir]}/dbi-config.conf")
           is_expected.to contain_concat__fragment('collectd_plugin_dbi_conf_header').with(content: %r{<Plugin dbi>})
         end
       end

--- a/spec/classes/collectd_plugin_exec_spec.rb
+++ b/spec/classes/collectd_plugin_exec_spec.rb
@@ -29,8 +29,7 @@ describe 'collectd::plugin::exec', type: :class do
         end
 
         it "Will create #{options[:plugin_conf_dir]}/exec-config" do
-          is_expected.to contain_concat("#{options[:plugin_conf_dir]}/exec-config.conf").
-            that_requires('File[collectd.d]')
+          is_expected.to contain_concat("#{options[:plugin_conf_dir]}/exec-config.conf")
           is_expected.to contain_concat__fragment('collectd_plugin_exec_conf_footer').with(
             content: %r{</Plugin>},
             target: "#{options[:plugin_conf_dir]}/exec-config.conf",

--- a/spec/classes/collectd_plugin_genericjmx_spec.rb
+++ b/spec/classes/collectd_plugin_genericjmx_spec.rb
@@ -23,7 +23,6 @@ describe 'collectd::plugin::genericjmx', type: :class do
         end
 
         it { is_expected.to contain_concat(config_filename).that_notifies('Service[collectd]') }
-        it { is_expected.to contain_concat(config_filename).that_requires('File[collectd.d]') }
 
         it do
           is_expected.to contain_concat__fragment('collectd_plugin_genericjmx_conf_header').

--- a/spec/classes/collectd_plugin_postgresql_spec.rb
+++ b/spec/classes/collectd_plugin_postgresql_spec.rb
@@ -21,7 +21,7 @@ describe 'collectd::plugin::postgresql', type: :class do
           )
         end
         it "Will create #{options[:plugin_conf_dir]}/postgresql-config.conf" do
-          is_expected.to contain_concat("#{options[:plugin_conf_dir]}/postgresql-config.conf").that_requires('File[collectd.d]')
+          is_expected.to contain_concat("#{options[:plugin_conf_dir]}/postgresql-config.conf")
           is_expected.to contain_concat__fragment('collectd_plugin_postgresql_conf_header').with(content: %r{<Plugin postgresql>})
         end
       end

--- a/spec/classes/collectd_plugin_powerdns_spec.rb
+++ b/spec/classes/collectd_plugin_powerdns_spec.rb
@@ -19,7 +19,7 @@ describe 'collectd::plugin::powerdns', type: :class do
           end
 
           it "Will create #{options[:plugin_conf_dir]}/powerdns-config.conf" do
-            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/powerdns-config.conf").that_requires('File[collectd.d]')
+            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/powerdns-config.conf")
             is_expected.to contain_concat__fragment('collectd_plugin_powerdns_conf_header').with(
               content: "<Plugin \"powerdns\">\n",
               target: "#{options[:plugin_conf_dir]}/powerdns-config.conf",
@@ -57,7 +57,7 @@ describe 'collectd::plugin::powerdns', type: :class do
           end
 
           it "Will create #{options[:plugin_conf_dir]}/powerdns-config.conf" do
-            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/powerdns-config.conf").that_requires('File[collectd.d]')
+            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/powerdns-config.conf")
             is_expected.to contain_concat__fragment('collectd_plugin_powerdns_conf_header').with(
               content: "<Plugin \"powerdns\">
   LocalSocket \"/var/run/whatever\"

--- a/spec/classes/collectd_plugin_processes_spec.rb
+++ b/spec/classes/collectd_plugin_processes_spec.rb
@@ -19,7 +19,7 @@ describe 'collectd::plugin::processes', type: :class do
           end
 
           it "Will create #{options[:plugin_conf_dir]}/processes_config.conf" do
-            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/processes_config.conf").that_requires('File[collectd.d]')
+            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/processes_config.conf")
             is_expected.to contain_concat__fragment('collectd_plugin_processes_conf_header').with(
               content: "<Plugin processes>\n",
               target: "#{options[:plugin_conf_dir]}/processes_config.conf",
@@ -67,7 +67,7 @@ describe 'collectd::plugin::processes', type: :class do
           end
 
           it "Will create #{options[:plugin_conf_dir]}/processes_config.conf" do
-            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/processes_config.conf").that_requires('File[collectd.d]')
+            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/processes_config.conf")
             is_expected.to contain_concat__fragment('collectd_plugin_processes_conf_header').with(
               content: "<Plugin processes>
   CollectContextSwitch true

--- a/spec/classes/collectd_plugin_python_spec.rb
+++ b/spec/classes/collectd_plugin_python_spec.rb
@@ -24,8 +24,7 @@ describe 'collectd::plugin::python', type: :class do
           end
 
           it "Will create #{options[:plugin_conf_dir]}/python-config.conf" do
-            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/python-config.conf").
-              that_requires('File[collectd.d]')
+            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/python-config.conf")
             is_expected.to contain_concat__fragment('collectd_plugin_python_conf_header').with(
               content: %r{<Plugin "python">},
               target: "#{options[:plugin_conf_dir]}/python-config.conf",
@@ -262,8 +261,7 @@ describe 'collectd::plugin::python', type: :class do
           end
 
           it "Will create #{options[:plugin_conf_dir]}/custom-location-config.conf" do
-            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/custom-location-config.conf").
-              that_requires('File[collectd.d]')
+            is_expected.to contain_concat("#{options[:plugin_conf_dir]}/custom-location-config.conf")
             is_expected.to contain_concat__fragment('collectd_plugin_python_conf_header').with(
               content: %r{<Plugin "python">},
               target: "#{options[:plugin_conf_dir]}/custom-location-config.conf",

--- a/spec/classes/collectd_plugin_write_graphite_spec.rb
+++ b/spec/classes/collectd_plugin_write_graphite_spec.rb
@@ -17,7 +17,7 @@ describe 'collectd::plugin::write_graphite', type: :class do
         end
 
         it "Will create #{options[:plugin_conf_dir]}/write_graphite-config.conf" do
-          is_expected.to contain_concat("#{options[:plugin_conf_dir]}/write_graphite-config.conf").that_requires('File[collectd.d]')
+          is_expected.to contain_concat("#{options[:plugin_conf_dir]}/write_graphite-config.conf")
           is_expected.to contain_concat__fragment('collectd_plugin_write_graphite_conf_header').with(
             content: %r{<Plugin write_graphite>},
             target: "#{options[:plugin_conf_dir]}/write_graphite-config.conf",

--- a/spec/defines/collectd_plugin_filter_chain_spec.rb
+++ b/spec/defines/collectd_plugin_filter_chain_spec.rb
@@ -12,8 +12,7 @@ describe 'collectd::plugin::filter::chain', type: :define do
         let(:title) { 'MyChain' }
 
         it "Will create #{options[:plugin_conf_dir]}/filter-chain-MyChain.conf" do
-          is_expected.to contain_concat("#{options[:plugin_conf_dir]}/filter-chain-MyChain.conf").with(ensure: 'present').
-            that_requires('File[collectd.d]')
+          is_expected.to contain_concat("#{options[:plugin_conf_dir]}/filter-chain-MyChain.conf").with(ensure: 'present')
           is_expected.to contain_concat__fragment("#{options[:plugin_conf_dir]}/filter-chain-MyChain.conf_MyChain_head").with(
             order: '00',
             content: '<Chain "MyChain">',


### PR DESCRIPTION
#### Pull Request (PR) description
Previously all the concat's created typically in /etc/collect.d were subject to

File['collectd.d'] -> Concat <| tag == 'collectd' |>
to ensure the directory was in place first.

This turns out to be too greedy and can cause problems as per #1000.

This declaration is unnecessary as concat creates a file type
and this auto-requires the directory one level above.

#### This Pull Request (PR) fixes the following issues
Fixes #1000 
