### PR TITLE
puppet/epel: Allow 4.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppet-epel",
-      "version_requirement": ">= 3.0.0 < 4.0.0"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     },
     {
       "name": "puppetlabs-python_task_helper",


### PR DESCRIPTION
This allows us to support EL9 systems in a later PR.

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>