### PR TITLE
Update socket path of ceph services in ceph plugin

### DIFF
--- a/manifests/plugin/ceph.pp
+++ b/manifests/plugin/ceph.pp
@@ -33,13 +33,17 @@
 #   to be used with manage_package; if manage_package is true, this gives the name
 #   of the package to manage. Defaults to 'collectd-ceph'
 #
+# [*ceph_fsid*]
+#   The Ceph cluster FSID. Must be a UUID.
+#
 class collectd::plugin::ceph (
   Array $daemons,
   Enum['present', 'absent'] $ensure  = 'present',
   Boolean $longrunavglatency         = false,
   Boolean $convertspecialmetrictypes = true,
   Boolean $manage_package            = $collectd::manage_package,
-  String $package_name               = 'collectd-ceph'
+  String $package_name               = 'collectd-ceph',
+  Optional[String] $ceph_fsid        = undef,
 ) {
   include collectd
 

--- a/spec/classes/collectd_plugin_ceph_spec.rb
+++ b/spec/classes/collectd_plugin_ceph_spec.rb
@@ -48,6 +48,36 @@ describe 'collectd::plugin::ceph', type: :class do
         end
       end
 
+      context ':ensure => present and :daemons => [ \'ceph-osd.0\, \ceph-osd.1\, \ceph-mon.mon01\ ] and ceph_fsid => acd038fe-ce5c-5350-bfd2-0a2c17ad2c59' do
+        let :params do
+          {
+            daemons: ['ceph-osd.0', 'ceph-osd.1', 'ceph-mon.mon01'],
+            ceph_fsid: 'acd038fe-ce5c-5350-bfd2-0a2c17ad2c59'
+          }
+        end
+
+        content = <<~EOS
+          <Plugin ceph>
+            LongRunAvgLatency false
+            ConvertSpecialMetricTypes true
+
+            <Daemon "ceph-osd.0">
+              SocketPath "/var/run/ceph/acd038fe-ce5c-5350-bfd2-0a2c17ad2c59/ceph-osd.0.asok"
+            </Daemon>
+            <Daemon "ceph-osd.1">
+              SocketPath "/var/run/ceph/acd038fe-ce5c-5350-bfd2-0a2c17ad2c59/ceph-osd.1.asok"
+            </Daemon>
+            <Daemon "ceph-mon.mon01">
+              SocketPath "/var/run/ceph/acd038fe-ce5c-5350-bfd2-0a2c17ad2c59/ceph-mon.mon01.asok"
+            </Daemon>
+
+          </Plugin>
+        EOS
+        it "Will create #{options[:plugin_conf_dir]}/10-ceph.conf" do
+          is_expected.to contain_collectd__plugin('ceph').with_content(content)
+        end
+      end
+
       context ':ensure => absent' do
         let :params do
           { daemons: ['ceph-osd.0', 'ceph-osd.1', 'ceph-osd.2'], ensure: 'absent' }

--- a/templates/plugin/ceph.conf.erb
+++ b/templates/plugin/ceph.conf.erb
@@ -4,7 +4,11 @@
 
 <% @daemons.each do |daemon| -%>
   <Daemon "<%= daemon %>">
+    <%- if defined? @ceph_fsid -%>
+    SocketPath "/var/run/ceph/<%= @ceph_fsid %>/<%= daemon %>.asok"
+    <%- else -%>
     SocketPath "/var/run/ceph/<%= daemon %>.asok"
+    <%- end -%>
   </Daemon>
 <% end -%>
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Ceph 16 onwards sockets for Ceph services are placed under '/var/run/ceph/\<fsid\>/'

This change introduces a new variable `ceph_fsid` to hold Ceph cluster's fsid which must be of type string.

Configuration file for ceph plugin will be generated with new path only if `ceph_fsid` is set.

#### This Pull Request (PR) fixes the following issues
n/a


Signed-off-by: Yadnesh Kulkarni <ykulkarn@redhat.com>

