### PR TITLE
ValuesFrom in postgresql query.conf should allow multiple values

### DIFF
--- a/templates/plugin/postgresql/query.conf.erb
+++ b/templates/plugin/postgresql/query.conf.erb
@@ -20,7 +20,13 @@
 <% if result['instancesfrom'] -%>
         InstancesFrom "<%= result['instancesfrom'] %>"
 <% end -%>
+<%- if result['valuesfrom'].is_a?(Array) -%>
+<%- result['valuesfrom'].each do |v| -%>
+        ValuesFrom "<%= v %>"
+<%- end -%>
+<%- else -%>
         ValuesFrom "<%= result['valuesfrom'] %>"
-      </Result>
+<%- end -%>
+    </Result>
 <% end -%>
   </Query>


### PR DESCRIPTION
#### Pull Request (PR) description
ValuesFrom in postgresql query.conf should allow an array of multiple values, not just a single value, as per documentation:
https://collectd.org/documentation/manpages/collectd.conf.5.shtml#query_blocks

#### This Pull Request (PR) fixes the following issues
Issue is not documented yet
