### PR TITLE
Ensure plugin version is same version as main collectd package

### DIFF
--- a/manifests/plugin/curl.pp
+++ b/manifests/plugin/curl.pp
@@ -10,9 +10,15 @@ class collectd::plugin::curl (
   $_manage_package = pick($manage_package, $collectd::manage_package)
 
   if $facts['os']['family'] == 'RedHat' {
+    if $ensure == 'present' {
+      $ensure_real = $collectd::package_ensure
+    } elsif $ensure == 'absent' {
+      $ensure_real = 'absent'
+    }
+
     if $_manage_package {
       package { 'collectd-curl':
-        ensure => $ensure,
+        ensure => $ensure_real,
       }
     }
   }

--- a/manifests/plugin/mysql.pp
+++ b/manifests/plugin/mysql.pp
@@ -10,9 +10,15 @@ class collectd::plugin::mysql (
   $_manage_package = pick($manage_package, $collectd::manage_package)
 
   if $facts['os']['family'] == 'RedHat' {
+    if $ensure == 'present' {
+      $ensure_real = $collectd::package_ensure
+    } elsif $ensure == 'absent' {
+      $ensure_real = 'absent'
+    }
+
     if $_manage_package {
       package { 'collectd-mysql':
-        ensure => $ensure,
+        ensure => $ensure_real,
       }
     }
   }

--- a/manifests/plugin/postgresql.pp
+++ b/manifests/plugin/postgresql.pp
@@ -15,9 +15,15 @@ class collectd::plugin::postgresql (
   $writers_defaults   = { 'ensure' => $ensure }
 
   if $facts['os']['family'] == 'RedHat' {
+    if $ensure == 'present' {
+      $ensure_real = $collectd::package_ensure
+    } elsif $ensure == 'absent' {
+      $ensure_real = 'absent'
+    }
+
     if $_manage_package {
       package { 'collectd-postgresql':
-        ensure => $ensure,
+        ensure => $ensure_real,
       }
     }
   }

--- a/manifests/plugin/snmp.pp
+++ b/manifests/plugin/snmp.pp
@@ -11,9 +11,15 @@ class collectd::plugin::snmp (
   $_manage_package = pick($manage_package, $collectd::manage_package)
 
   if $facts['os']['family'] == 'RedHat' {
+    if $ensure == 'present' {
+      $ensure_real = $collectd::package_ensure
+    } elsif $ensure == 'absent' {
+      $ensure_real = 'absent'
+    }
+
     if $_manage_package {
       package { 'collectd-snmp':
-        ensure => $ensure,
+        ensure => $ensure_real,
       }
     }
   }


### PR DESCRIPTION
#### Pull Request (PR) description
If you attempt to specify the collectd version in Hiera, and a newer version is available, issue might be caused because the package install of the plugins on new hosts would install the latest version for both the plugin and the main package (as a dependency). Puppet then starts failing attempting to downgrade the main package to your specified version.

With this PR it is ensure that mysql, snmp, postgresql and curl, are installed with the same version as the core package. Same thing was done for the disk plugin some time ago: https://github.com/voxpupuli/puppet-collectd/blob/master/manifests/plugin/disk.pp#L26L37

#### This Pull Request (PR) fixes the following issues

Partially fixes #430 

