### PR TITLE
Add support for the Host option for the write_prometheus plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2067,8 +2067,11 @@ class { 'collectd::plugin::write_log':
 
 #### Class: `collectd::plugin::write_prometheus`
 
+* The "host" option requires collectd 5.9 or later and will be ignored otherwise.
+
 ```puppet
 class { 'collectd::plugin::write_prometheus':
+  host => 'localhost',
   port => '9103',
 }
 ```

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7089,8 +7089,13 @@ The collectd::plugin::write_prometheus class.
 
 The following parameters are available in the `collectd::plugin::write_prometheus` class:
 
+* [`host`](#host)
 * [`port`](#port)
 * [`ensure`](#ensure)
+
+##### <a name="host"></a>`host`
+
+Data type: `Optional[Stdlib::Host]`
 
 ##### <a name="port"></a>`port`
 

--- a/examples/plugins/write_prometheus.pp
+++ b/examples/plugins/write_prometheus.pp
@@ -2,6 +2,6 @@ include collectd
 
 class { 'collectd::plugin::write_prometheus':
   port => '9103',
-  # Optionally, pass the host parameter to bind to a specific ip
-  host   => '127.0.0.1',
+  # Optionally, pass the ip parameter to bind to a specific ip
+  ip   => '127.0.0.1',
 }

--- a/examples/plugins/write_prometheus.pp
+++ b/examples/plugins/write_prometheus.pp
@@ -2,4 +2,6 @@ include collectd
 
 class { 'collectd::plugin::write_prometheus':
   port => '9103',
+  # Optionally, pass the host parameter to bind to a specific ip
+  host   => '127.0.0.1',
 }

--- a/manifests/plugin/write_prometheus.pp
+++ b/manifests/plugin/write_prometheus.pp
@@ -1,5 +1,6 @@
 class collectd::plugin::write_prometheus (
   Stdlib::Port $port = 9103,
+  Optional[Stdlib::Host] $host = undef,
   $ensure = 'present',
 ) {
   include collectd

--- a/manifests/plugin/write_prometheus.pp
+++ b/manifests/plugin/write_prometheus.pp
@@ -1,3 +1,11 @@
+# Class: collectd::plugin::write_prometheus
+#
+# @see https://collectd.org/wiki/index.php/Plugin:Write_Prometheus
+
+# Configures write_prometheus plugin.
+#
+# @param port Stdlib::Port Defines the port on which to accept scrape requests from Prometheus. Default: 9103
+# @param ip Optional[Stdlib::IP::Address] Defines the IP address to bind to. In not specified, the listener will bind to all IPs present.
 class collectd::plugin::write_prometheus (
   Stdlib::Port $port = 9103,
   Optional[Stdlib::IP::Address] $ip = undef,

--- a/manifests/plugin/write_prometheus.pp
+++ b/manifests/plugin/write_prometheus.pp
@@ -4,8 +4,8 @@
 
 # Configures write_prometheus plugin.
 #
-# @param port Stdlib::Port Defines the port on which to accept scrape requests from Prometheus. Default: 9103
-# @param ip Optional[Stdlib::IP::Address] Defines the IP address to bind to. In not specified, the listener will bind to all IPs present.
+# @param port Defines the port on which to accept scrape requests from Prometheus.
+# @param ip Defines the IP address to bind to. In not specified, the listener will bind to all IPs present.
 class collectd::plugin::write_prometheus (
   Stdlib::Port $port = 9103,
   Optional[Stdlib::IP::Address] $ip = undef,

--- a/manifests/plugin/write_prometheus.pp
+++ b/manifests/plugin/write_prometheus.pp
@@ -1,6 +1,6 @@
 class collectd::plugin::write_prometheus (
   Stdlib::Port $port = 9103,
-  Optional[Stdlib::Host] $host = undef,
+  Optional[Stdlib::IP::Address] $ip = undef,
   $ensure = 'present',
 ) {
   include collectd

--- a/spec/classes/collectd_plugin_write_prometheus_spec.rb
+++ b/spec/classes/collectd_plugin_write_prometheus_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::write_prometheus', type: :class do
-  host = '192.0.0.1'
+  ip = '192.0.0.1'
   port = 9103
   host_opt_min_collectd_ver = '5.9'
   on_supported_os(baseline_os_hash).each do |os, facts|
@@ -13,11 +13,11 @@ describe 'collectd::plugin::write_prometheus', type: :class do
       end
 
       options = os_specific_options(facts)
-      context ":ensure => present and :port => #{port} and host => #{host}" do
+      context ":ensure => present and :port => #{port} and ip => #{ip}" do
         let :params do
           {
             port: port,
-            host: host,
+            ip: ip,
           }
         end
 
@@ -27,7 +27,7 @@ describe 'collectd::plugin::write_prometheus', type: :class do
             path: "#{options[:plugin_conf_dir]}/10-write_prometheus.conf",
             content: %r{Port "#{port}"}
           ).without(
-            content: %r{Host "#{host}"}
+            content: %r{Host "#{ip}"}
           )
         end
 
@@ -42,7 +42,7 @@ describe 'collectd::plugin::write_prometheus', type: :class do
               path: "#{options[:plugin_conf_dir]}/10-write_prometheus.conf",
               content: %r{Port "#{port}"}
             ).with(
-              content: %r{Host "#{host}"}
+              content: %r{Host "#{ip}"}
             )
           end
         end
@@ -62,7 +62,7 @@ describe 'collectd::plugin::write_prometheus', type: :class do
               path: "#{options[:plugin_conf_dir]}/10-write_prometheus.conf",
               content: %r{Port "#{port}"}
             ).without(
-              content: %r{Host "#{host}"}
+              content: %r{Host "#{ip}"}
             )
           end
         end

--- a/spec/classes/collectd_plugin_write_prometheus_spec.rb
+++ b/spec/classes/collectd_plugin_write_prometheus_spec.rb
@@ -3,6 +3,9 @@
 require 'spec_helper'
 
 describe 'collectd::plugin::write_prometheus', type: :class do
+  host = '192.0.0.1'
+  port = 9103
+  host_opt_min_collectd_ver = '5.9'
   on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os}" do
       let :facts do
@@ -10,17 +13,58 @@ describe 'collectd::plugin::write_prometheus', type: :class do
       end
 
       options = os_specific_options(facts)
-      context ':ensure => present and :port => 9103' do
+      context ":ensure => present and :port => #{port} and host => #{host}" do
         let :params do
-          { port: 9103 }
+          {
+            port: port,
+            host: host,
+          }
         end
 
-        it "Will create #{options[:plugin_conf_dir]}/10-write_prometheus.conf" do
+        it "Will create #{options[:plugin_conf_dir]}/10-write_prometheus.conf without Host" do
           is_expected.to contain_file('write_prometheus.load').with(
             ensure: 'present',
             path: "#{options[:plugin_conf_dir]}/10-write_prometheus.conf",
-            content: %r{Port "9103"}
+            content: %r{Port "#{port}"}
+          ).without(
+            content: %r{Host "#{host}"}
           )
+        end
+
+        context "Will include hostname if version is >= #{host_opt_min_collectd_ver}" do
+          let :facts do
+            facts.merge(collectd_version: host_opt_min_collectd_ver)
+          end
+
+          it "Will create #{options[:plugin_conf_dir]}/10-write_prometheus.conf with Host" do
+            is_expected.to contain_file('write_prometheus.load').with(
+              ensure: 'present',
+              path: "#{options[:plugin_conf_dir]}/10-write_prometheus.conf",
+              content: %r{Port "#{port}"}
+            ).with(
+              content: %r{Host "#{host}"}
+            )
+          end
+        end
+
+        context "Will NOT include hostname if not specified even if version is >= #{host_opt_min_collectd_ver}" do
+          let :params do
+            { port: 9103 }
+          end
+
+          let :facts do
+            facts.merge(collectd_version: host_opt_min_collectd_ver)
+          end
+
+          it "Will create #{options[:plugin_conf_dir]}/10-write_prometheus.conf without Host" do
+            is_expected.to contain_file('write_prometheus.load').with(
+              ensure: 'present',
+              path: "#{options[:plugin_conf_dir]}/10-write_prometheus.conf",
+              content: %r{Port "#{port}"}
+            ).without(
+              content: %r{Host "#{host}"}
+            )
+          end
         end
       end
 

--- a/templates/plugin/write_prometheus.conf.erb
+++ b/templates/plugin/write_prometheus.conf.erb
@@ -1,5 +1,8 @@
 <% if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.7']) >= 0) -%>
 <Plugin "write_prometheus">
   Port "<%= @port %>"
+  <% if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.9']) >= 0) and @host -%>
+  Host "<%= @host %>"
+  <% end -%>
 </Plugin>
 <% end -%>

--- a/templates/plugin/write_prometheus.conf.erb
+++ b/templates/plugin/write_prometheus.conf.erb
@@ -1,8 +1,8 @@
 <% if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.7']) >= 0) -%>
 <Plugin "write_prometheus">
   Port "<%= @port %>"
-  <% if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.9']) >= 0) and @ip -%>
+<% if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.9']) >= 0) and @ip -%>
   Host "<%= @ip %>"
-  <% end -%>
+<% end -%>
 </Plugin>
 <% end -%>

--- a/templates/plugin/write_prometheus.conf.erb
+++ b/templates/plugin/write_prometheus.conf.erb
@@ -1,8 +1,8 @@
 <% if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.7']) >= 0) -%>
 <Plugin "write_prometheus">
   Port "<%= @port %>"
-  <% if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.9']) >= 0) and @host -%>
-  Host "<%= @host %>"
+  <% if scope.lookupvar('collectd::collectd_version_real') and (scope.function_versioncmp([scope.lookupvar('collectd::collectd_version_real'), '5.9']) >= 0) and @ip -%>
+  Host "<%= @ip %>"
   <% end -%>
 </Plugin>
 <% end -%>


### PR DESCRIPTION
The option was introduced in version 5.9 of collectd

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Add support for the Host option for the write_prometheus plugin. This allows narrowing down the IP to bind on.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
