### PR TITLE
New collectd::plugin::table::table type

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -95,7 +95,7 @@
 * [`collectd::plugin::swap`](#collectd--plugin--swap): https://collectd.org/wiki/index.php/Plugin:Swap
 * [`collectd::plugin::sysevent`](#collectd--plugin--sysevent): == Class: collectd::plugin::sysevent  Class to manage sysevent plugin for collectd  Documentation:   https://collectd.org/documentation/manpa
 * [`collectd::plugin::syslog`](#collectd--plugin--syslog): https://collectd.org/wiki/index.php/Plugin:SysLog
-* [`collectd::plugin::table`](#collectd--plugin--table): https://collectd.org/wiki/index.php/Chains
+* [`collectd::plugin::table`](#collectd--plugin--table): Load and configure the table plugin
 * [`collectd::plugin::tail`](#collectd--plugin--tail): Tail plugin https://collectd.org/wiki/index.php/Plugin:Tail
 * [`collectd::plugin::tail_csv`](#collectd--plugin--tail_csv): https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_tail_csv
 * [`collectd::plugin::target_v5upgrade`](#collectd--plugin--target_v5upgrade): https://collectd.org/wiki/index.php/Target:v5_upgrade
@@ -164,6 +164,7 @@
 * [`collectd::plugin::python::module`](#collectd--plugin--python--module): Single module definition
 * [`collectd::plugin::snmp::data`](#collectd--plugin--snmp--data): https://collectd.org/wiki/index.php/Plugin:SNMP
 * [`collectd::plugin::snmp::host`](#collectd--plugin--snmp--host): https://collectd.org/wiki/index.php/Plugin:SNMP
+* [`collectd::plugin::table::table`](#collectd--plugin--table--table): table definition for table plugin
 * [`collectd::plugin::tail::file`](#collectd--plugin--tail--file)
 * [`collectd::plugin::write_graphite::carbon`](#collectd--plugin--write_graphite--carbon): a single graphite backend
 * [`collectd::type`](#collectd--type)
@@ -6179,7 +6180,32 @@ Default value: `undef`
 
 ### <a name="collectd--plugin--table"></a>`collectd::plugin::table`
 
-https://collectd.org/wiki/index.php/Chains
+Load and configure the table plugin
+
+* **See also**
+  * https://collectd.org/wiki/index.php/Plugin:Table
+
+#### Examples
+
+##### Parse `/proc/pressure/cpu`
+
+```puppet
+class {'collectd::plugin::table':
+  tables => {
+    '/proc/pressure/cpu' => {
+      'plugin'    => 'psi',
+      'instance   => 'cpu',
+      'seperator' => ' =',
+      'results'   => [{
+        'type'            => 'gauge',
+        'instance_from'   => [0],
+        'instance_prefix' => 'arg10',
+        'values_from'     => [2],
+      }],
+    }
+  }
+}
+```
 
 #### Parameters
 
@@ -6191,15 +6217,17 @@ The following parameters are available in the `collectd::plugin::table` class:
 
 ##### <a name="-collectd--plugin--table--tables"></a>`tables`
 
-Data type: `Hash[String, Collectd::Table::Table, 1]`
+Data type: `Optional[Hash[String, Collectd::Table::Table, 1]]`
 
+`<Table>` blocks for table plugin
 
+Default value: `undef`
 
 ##### <a name="-collectd--plugin--table--ensure"></a>`ensure`
 
 Data type: `Enum['present', 'absent']`
 
-
+Should the plugin be configured
 
 Default value: `'present'`
 
@@ -6207,7 +6235,7 @@ Default value: `'present'`
 
 Data type: `Integer`
 
-
+Prefix of file in collectd config directory
 
 Default value: `10`
 
@@ -9735,6 +9763,68 @@ Data type: `Optional[String[1]]`
 
 
 Default value: `undef`
+
+### <a name="collectd--plugin--table--table"></a>`collectd::plugin::table::table`
+
+table definition for table plugin
+
+#### Examples
+
+##### Parse the /proc/uptime file
+
+```puppet
+collectd::plugin::table::table{'/proc/uptime':
+  table => {
+    'plugin'    => 'uptime',
+    'instance'  => 'first',
+    'separator' => ' ',
+    'results' => [{
+      'type'        => 'gauge',
+      'values_from' => [0],
+    }],
+  }
+}
+```
+
+#### Parameters
+
+The following parameters are available in the `collectd::plugin::table::table` defined type:
+
+* [`$tablename`](#-collectd--plugin--table--table---tablename)
+* [`$table`](#-collectd--plugin--table--table---table)
+* [`ensure`](#-collectd--plugin--table--table--ensure)
+* [`tablename`](#-collectd--plugin--table--table--tablename)
+* [`table`](#-collectd--plugin--table--table--table)
+
+##### <a name="-collectd--plugin--table--table---tablename"></a>`$tablename`
+
+Name of table typically a filename
+
+##### <a name="-collectd--plugin--table--table---table"></a>`$table`
+
+Table definition
+
+##### <a name="-collectd--plugin--table--table--ensure"></a>`ensure`
+
+Data type: `Enum['present', 'absent']`
+
+
+
+Default value: `'present'`
+
+##### <a name="-collectd--plugin--table--table--tablename"></a>`tablename`
+
+Data type: `Stdlib::Unixpath`
+
+
+
+Default value: `$name`
+
+##### <a name="-collectd--plugin--table--table--table"></a>`table`
+
+Data type: `Collectd::Table::Table`
+
+
 
 ### <a name="collectd--plugin--tail--file"></a>`collectd::plugin::tail::file`
 

--- a/manifests/plugin/table.pp
+++ b/manifests/plugin/table.pp
@@ -1,14 +1,42 @@
-# https://collectd.org/wiki/index.php/Chains
+# @summary Load and configure the table plugin
+# @see https://collectd.org/wiki/index.php/Plugin:Table
+#
+# @param tables `<Table>` blocks for table plugin
+# @param ensure Should the plugin be configured
+# @param order Prefix of file in collectd config directory
+#
+# @example Parse `/proc/pressure/cpu`
+#   class {'collectd::plugin::table':
+#     tables => {
+#       '/proc/pressure/cpu' => {
+#         'plugin'    => 'psi',
+#         'instance   => 'cpu',
+#         'seperator' => ' =',
+#         'results'   => [{
+#           'type'            => 'gauge',
+#           'instance_from'   => [0],
+#           'instance_prefix' => 'arg10',
+#           'values_from'     => [2],
+#         }],
+#       }
+#     }
+#   }
+#
 class collectd::plugin::table (
-  Hash[String, Collectd::Table::Table, 1] $tables,
-  Enum['present', 'absent'] $ensure    = 'present',
-  Integer $order                       = 10,
+  Optional[Hash[String, Collectd::Table::Table, 1]] $tables = undef,
+  Enum['present', 'absent'] $ensure                         = 'present',
+  Integer $order                                            = 10,
 ) {
   include collectd
 
+  $_content = $tables ? {
+    Undef   => undef,
+    default => epp('collectd/plugin/table.conf.epp', { 'tables' => $tables }),
+  }
+
   collectd::plugin { 'table':
     ensure  => $ensure,
-    content => epp('collectd/plugin/table.conf.epp'),
+    content => $_content,
     order   => $order,
   }
 }

--- a/manifests/plugin/table/table.pp
+++ b/manifests/plugin/table/table.pp
@@ -1,0 +1,37 @@
+# @summary table definition for table plugin
+# @param $tablename Name of table typically a filename
+# @param $table Table definition
+#
+# @example Parse the /proc/uptime file
+#   collectd::plugin::table::table{'/proc/uptime':
+#     table => {
+#       'plugin'    => 'uptime',
+#       'instance'  => 'first',
+#       'separator' => ' ',
+#       'results' => [{
+#         'type'        => 'gauge',
+#         'values_from' => [0],
+#       }],
+#     }
+#   }
+#
+define collectd::plugin::table::table (
+  Enum['present', 'absent'] $ensure    = 'present',
+  Stdlib::Unixpath          $tablename = $name,
+  Collectd::Table::Table    $table,
+) {
+  include collectd::plugin::table
+
+  $_safer_file_name = regsubst($name,'/','_','G')
+
+  # Must come lexically after 10-table.conf
+  file { "table-${tablename}.conf":
+    ensure  => file,
+    owner   => $collectd::config_owner,
+    path    => "${collectd::plugin_conf_dir}/${collectd::plugin::table::order}-tabletable-${_safer_file_name}.conf",
+    group   => $collectd::config_group,
+    mode    => $collectd::config_mode,
+    content => epp('collectd/plugin/table.conf.epp', { 'tables' => { $tablename => $table } }),
+    notify  => Service[$collectd::service_name],
+  }
+}

--- a/spec/acceptance/define_plugin_table_table_spec.rb
+++ b/spec/acceptance/define_plugin_table_table_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'collectd::plugin::table::table' do
+  context 'basic parameters' do
+    # Using puppet_apply as a helper
+    it 'works idempotently with no errors' do
+      pp = <<-EOS
+      class{'collectd':
+        utils        => true,
+        purge        => true,
+        recurse      => true,
+        purge_config => true,
+      }
+
+      # ubuntu 18.04 has old collectd version.
+      $_plugin = $facts['os']['release']['major'] ? {
+        '18.04' => undef,
+        default => 'uptime',
+      }
+      collectd::plugin::table::table{'/proc/uptime':
+        table =>  {
+          'plugin'    => $_plugin,
+          'instance'  => 'first',
+          'separator' => ' ',
+          'results' => [{
+             'type'        => 'gauge',
+             'values_from' => [0],
+          }],
+        },
+      }
+
+      # Configure one write plugin to keep logs quiet
+      class{'collectd::plugin::csv':}
+      # Create a socket to query
+      class{'collectd::plugin::unixsock':
+        socketfile  => '/var/run/collectd-sock',
+        socketgroup => 'root',
+        deletesocket => true,
+      }
+
+      EOS
+      # Run 3 times since the collectd_version
+      # fact is impossible until collectd is
+      # installed.
+      apply_manifest(pp, catch_failures: false)
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+      # Wait to get some data
+      shell('sleep 10')
+    end
+
+    describe service('collectd') do
+      it { is_expected.to be_running }
+    end
+
+    describe command('collectdctl -s /var/run/collectd-sock listval') do
+      its(:exit_status) { is_expected.to eq 0 }
+
+      case fact('os.release.major')
+      when '18.04'
+        its(:stdout) { is_expected.to match %r{table-first/gauge} }
+      else
+        its(:stdout) { is_expected.to match %r{uptime-first/gauge} }
+      end
+    end
+  end
+end

--- a/spec/defines/collectd_plugin_table_table_spec.rb
+++ b/spec/defines/collectd_plugin_table_table_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'collectd::plugin::table::table' do
+  let :title do
+    '/proc/bar'
+  end
+
+  on_supported_os(baseline_os_hash).each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      options = os_specific_options(facts)
+      context 'Minimal attributes' do
+        let :params do
+          {
+            'table' => {
+              'results' => [{
+                'type' => 'gauge',
+                'values_from' => [0, 1]
+              }, {
+                'type' => 'counter',
+                'values_from' => [2, 3]
+              }]
+            }
+          }
+        end
+
+        it 'overrides defaults' do
+          content = <<~EOS
+            <Plugin "table">
+              <Table "/proc/bar">
+                <Result>
+                  Type gauge
+                  ValuesFrom 0 1
+                </Result>
+                <Result>
+                  Type counter
+                  ValuesFrom 2 3
+                </Result>
+              </Table>
+            </Plugin>
+          EOS
+
+          is_expected.to compile.with_all_deps
+          is_expected.to contain_class('collectd')
+          is_expected.to contain_class('collectd::plugin::table')
+          is_expected.to contain_file('table-/proc/bar.conf').with(
+            content: content,
+            path: "#{options[:plugin_conf_dir]}/10-tabletable-_proc_bar.conf"
+          )
+        end
+      end
+
+      context 'All attributes' do
+        let :params do
+          {
+            'table' => {
+              'plugin' => 'foo',
+              'separator' => '_',
+              'instance' => 'foo-metric',
+              'results' => [{
+                'type' => 'gauge',
+                'values_from' => [0, 1],
+                'instances_from' => [3, 4],
+                'instance_prefix' => 'foo-'
+              }]
+            }
+          }
+        end
+
+        it 'overrides defaults' do
+          content = <<~EOS
+            <Plugin "table">
+              <Table "/proc/bar">
+                Plugin "foo"
+                Separator "_"
+                Instance "foo-metric"
+                <Result>
+                  Type gauge
+                  InstancePrefix "foo-"
+                  InstancesFrom 3 4
+                  ValuesFrom 0 1
+                </Result>
+              </Table>
+            </Plugin>
+          EOS
+
+          is_expected.to compile.with_all_deps
+          is_expected.to contain_class('collectd')
+          is_expected.to contain_file('table-/proc/bar.conf').with(
+            content: content,
+            path: "#{options[:plugin_conf_dir]}/10-tabletable-_proc_bar.conf"
+          )
+        end
+      end
+    end
+  end
+end

--- a/templates/plugin/table.conf.epp
+++ b/templates/plugin/table.conf.epp
@@ -1,5 +1,8 @@
+<%-|
+  Hash[String, Collectd::Table::Table, 1] $tables,
+|-%>
 <Plugin "table">
-<% $collectd::plugin::table::tables.each |$path, $table| { -%>
+<% $tables.each |$path, $table| { -%>
   <Table "<%= $path %>">
 <% unless $table['plugin'] =~ Undef { -%>
     Plugin "<%= $table['plugin'] %>"


### PR DESCRIPTION
#### Pull Request (PR) description

For example to parse `/proc/uptime` with the collectd table plugin can now be defined with:

```
collectd::plugin::table::table{'/proc/uptime':
  table =>  {
    'plugin'    => 'uptime',
    'instance'  => 'first',
    'separator' => ' ',
    'results' => [{
      'type'        => 'gauge',
      'values_from' => [0],
    }],
  }
}
```

Previously it was only possible to specify tables at one location with the class `collectd::plugin::table`. The class `collectd::plugin::table` remains unchanged.

