### PR TITLE
Accept + in collectd_version Fact

### DIFF
--- a/lib/facter/collectd_version.rb
+++ b/lib/facter/collectd_version.rb
@@ -12,7 +12,7 @@ Facter.add(:collectd_version) do
   setcode do
     if Facter::Util::Resolution.which('collectd')
       collectd_help = Facter::Util::Resolution.exec('collectd -h')
-      %r{^collectd ([\w.]+), http://collectd\.org/}.match(collectd_help)[1]
+      %r{^collectd ([+\w.]+), http://collectd\.org/}.match(collectd_help)[1]
     end
   end
 end

--- a/spec/fixtures/facts/collectd_help_git_plus
+++ b/spec/fixtures/facts/collectd_help_git_plus
@@ -1,0 +1,23 @@
+Usage: collectd [OPTIONS]
+
+Available options:
+  General:
+    -C <file>       Configuration file.
+                    Default: /etc/collectd.conf
+    -t              Test config and exit.
+    -T              Test plugin read and exit.
+    -P <file>       PID-file.
+                    Default: /var/run/collectd.pid
+    -f              Don't fork to the background.
+    -B              Don't create the BaseDir
+    -h              Display help (this message)
+
+Builtin defaults:
+  Config file       /etc/collectd.conf
+  PID file          /var/run/collectd.pid
+  Plugin directory  /usr/lib64/collectd
+  Data directory    /var/lib/collectd
+
+collectd 5.12.0.167.g7c5ce9f+, http://collectd.org/
+by Florian octo Forster <octo@collectd.org>
+for contributions see `AUTHORS'

--- a/spec/unit/collectd_real_version_spec.rb
+++ b/spec/unit/collectd_real_version_spec.rb
@@ -21,6 +21,13 @@ describe 'collectd_version', type: :fact do
     expect(Facter.fact(:collectd_version).value).to eq('5.1.0.git')
   end
 
+  it 'is 5.12.0.167.g7c5ce9f+ according to output' do
+    allow(Facter::Util::Resolution).to receive(:which).with('collectd').and_return('/usr/sbin/collectd')
+    sample_collectd_help_git_plus = File.read(fixtures('facts', 'collectd_help_git_plus'))
+    allow(Facter::Util::Resolution).to receive(:exec).with('collectd -h').and_return(sample_collectd_help_git_plus)
+    expect(Facter.fact(:collectd_version).value).to eq('5.12.0.167.g7c5ce9f+')
+  end
+
   it 'is not defined if collectd not installed' do
     allow(Facter::Util::Resolution).to receive(:which).with('collectd').and_return(nil)
     expect(Facter.fact(:collectd_version).value).to be_nil


### PR DESCRIPTION


<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The version string resulting from a `make dist` of collectd may contain a +, e.g. 5.12.0.167.g7c5ce9f+, from being run on a dirty working tree.
