### PR TITLE
Remove legacy syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the default `collectd.conf` file shipped with collectd. This can
 be done by simply including the class:
 
 ```puppet
-include ::collectd
+include collectd
 ```
 
 Collectd is most useful when configured with customized plugins.
@@ -30,7 +30,7 @@ configurations. Configure a node with the following class
 declaration:
 
 ```puppet
-class { '::collectd':
+class { 'collectd':
   purge           => true,
   recurse         => true,
   purge_config    => true,
@@ -1635,7 +1635,7 @@ collectd::config::typesdb:
 ```
 
 ```puppet
-class { '::collectd::plugin::rabbitmq':
+class { 'collectd::plugin::rabbitmq':
   config           => {
     'Username' => 'admin',
     'Password' => $admin_pass,
@@ -1683,7 +1683,7 @@ class {'collectd::plugin::sensors':
 #### Class: `collectd::plugin::smart`
 
 ```puppet
-class { '::collectd::plugin::smart':
+class { 'collectd::plugin::smart':
   disks          => ['/^dm/'],
   ignoreselected => true,
 }
@@ -1848,7 +1848,7 @@ collectd::plugin::tail::file { 'exim-log':
 #### Class: `collectd::plugin::tail_csv`
 
 ```puppet
-class { '::collectd::plugin::tail_csv':
+class { 'collectd::plugin::tail_csv':
   metrics => {
     'snort-dropped' => {
       'type'        => 'gauge',
@@ -1871,7 +1871,7 @@ class { '::collectd::plugin::tail_csv':
 #### Class: `collectd::plugin::thermal`
 
 ```puppet
-class { '::collectd::plugin::thermal':
+class { 'collectd::plugin::thermal':
   devices        => ['foo0'],
   ignoreselected => false,
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -4,8 +4,8 @@ class collectd::repo {
   if $collectd::manage_repo {
     $osfamily_downcase = downcase($facts['os']['family'])
 
-    if defined("::collectd::repo::${osfamily_downcase}") {
-      require "::collectd::repo::${osfamily_downcase}"
+    if defined("collectd::repo::${osfamily_downcase}") {
+      require "collectd::repo::${osfamily_downcase}"
     } else {
       notify { "You have asked to manage_repo on a system that doesn't have a repo class specified: ${facts['os']['family']}": }
     }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -29,9 +29,9 @@ describe 'collectd class' do
   context 'install plugins' do
     it 'works idemptontently' do
       pp = <<-EOS
-      class { '::collectd': }
+      class { 'collectd': }
 
-      class { '::collectd::plugin::memory': }
+      class { 'collectd::plugin::memory': }
 
       class { 'collectd::plugin::csv':}
       EOS

--- a/templates/plugin/amqp1.conf.epp
+++ b/templates/plugin/amqp1.conf.epp
@@ -1,48 +1,48 @@
 <Plugin amqp1>
-  <Transport "<%= $::collectd::plugin::amqp1::transport %>">
-    Host "<%= $::collectd::plugin::amqp1::host %>"
-    Port "<%= $::collectd::plugin::amqp1::port %>"
-    User "<%= $::collectd::plugin::amqp1::user %>"
-    Password "<%= $::collectd::plugin::amqp1::password %>"
-    Address "<%= $::collectd::plugin::amqp1::address %>"
-<% unless $::collectd::plugin::amqp1::retry_delay =~ Undef { -%>
-    RetryDelay <%= $::collectd::plugin::amqp1::retry_delay %>
+  <Transport "<%= $collectd::plugin::amqp1::transport %>">
+    Host "<%= $collectd::plugin::amqp1::host %>"
+    Port "<%= $collectd::plugin::amqp1::port %>"
+    User "<%= $collectd::plugin::amqp1::user %>"
+    Password "<%= $collectd::plugin::amqp1::password %>"
+    Address "<%= $collectd::plugin::amqp1::address %>"
+<% unless $collectd::plugin::amqp1::retry_delay =~ Undef { -%>
+    RetryDelay <%= $collectd::plugin::amqp1::retry_delay %>
 <% } -%>
-<% unless $::collectd::plugin::amqp1::send_queue_limit =~ Undef { -%>
-    SendQueueLimit <%= $::collectd::plugin::amqp1::send_queue_limit %>
+<% unless $collectd::plugin::amqp1::send_queue_limit =~ Undef { -%>
+    SendQueueLimit <%= $collectd::plugin::amqp1::send_queue_limit %>
 <% } -%>
-<% $::collectd::plugin::amqp1::instances.keys.sort.each |$name| { -%>
+<% $collectd::plugin::amqp1::instances.keys.sort.each |$name| { -%>
     <Instance "<%= $name %>">
-<% $::collectd::plugin::amqp1::instances[$name].keys.sort.each |$key| { -%>
+<% $collectd::plugin::amqp1::instances[$name].keys.sort.each |$key| { -%>
 <% if $key == 'format' { -%>
-      Format "<%= $::collectd::plugin::amqp1::instances[$name][$key] %>"
+      Format "<%= $collectd::plugin::amqp1::instances[$name][$key] %>"
 <% } -%>
 <% if $key == 'presettle' { -%>
-      PreSettle <%= $::collectd::plugin::amqp1::instances[$name][$key] %>
+      PreSettle <%= $collectd::plugin::amqp1::instances[$name][$key] %>
 <% } -%>
 <% if $key == 'notify' { -%>
-      Notify <%= $::collectd::plugin::amqp1::instances[$name][$key] %>
+      Notify <%= $collectd::plugin::amqp1::instances[$name][$key] %>
 <% } -%>
 <% if $key == 'store_rates' { -%>
-      StoreRates <%= $::collectd::plugin::amqp1::instances[$name][$key] %>
+      StoreRates <%= $collectd::plugin::amqp1::instances[$name][$key] %>
 <% } -%>
 <% if $key == 'graphite_prefix' { -%>
-      GraphitePrefix "<%= $::collectd::plugin::amqp1::instances[$name][$key] %>"
+      GraphitePrefix "<%= $collectd::plugin::amqp1::instances[$name][$key] %>"
 <% } -%>
 <% if $key == 'graphite_postfix' { -%>
-      GraphitePostfix "<%= $::collectd::plugin::amqp1::instances[$name][$key] %>"
+      GraphitePostfix "<%= $collectd::plugin::amqp1::instances[$name][$key] %>"
 <% } -%>
 <% if $key == 'graphite_escape_char' { -%>
-      GraphiteEscapeChar "<%= $::collectd::plugin::amqp1::instances[$name][$key] %>"
+      GraphiteEscapeChar "<%= $collectd::plugin::amqp1::instances[$name][$key] %>"
 <% } -%>
 <% if $key == 'graphite_separate_instances' { -%>
-      GraphiteSeparateInstances <%= $::collectd::plugin::amqp1::instances[$name][$key] %>
+      GraphiteSeparateInstances <%= $collectd::plugin::amqp1::instances[$name][$key] %>
 <% } -%>
 <% if $key == 'graphite_always_append_ds' { -%>
-      GraphiteAlwaysAppendDS <%= $::collectd::plugin::amqp1::instances[$name][$key] %>
+      GraphiteAlwaysAppendDS <%= $collectd::plugin::amqp1::instances[$name][$key] %>
 <% } -%>
 <% if $key == 'graphite_preserve_separator' { -%>
-      GraphitePreserveSeparator <%= $::collectd::plugin::amqp1::instances[$name][$key] %>
+      GraphitePreserveSeparator <%= $collectd::plugin::amqp1::instances[$name][$key] %>
 <% } -%>
 <% } -%>
     </Instance>

--- a/templates/plugin/cpu.conf.epp
+++ b/templates/plugin/cpu.conf.epp
@@ -1,14 +1,14 @@
-<% if versioncmp($::collectd::collectd_version_real, '5.5') >= 0 { -%>
+<% if versioncmp($collectd::collectd_version_real, '5.5') >= 0 { -%>
 <Plugin cpu>
-  ReportByState <%= $::collectd::plugin::cpu::reportbystate %>
-  ReportByCpu <%= $::collectd::plugin::cpu::reportbycpu %>
-  ValuesPercentage <%= $::collectd::plugin::cpu::valuespercentage %>
-<% if versioncmp($::collectd::collectd_version_real, '5.6') >= 0 { -%>
-  ReportNumCpu <%= $::collectd::plugin::cpu::reportnumcpu %>
+  ReportByState <%= $collectd::plugin::cpu::reportbystate %>
+  ReportByCpu <%= $collectd::plugin::cpu::reportbycpu %>
+  ValuesPercentage <%= $collectd::plugin::cpu::valuespercentage %>
+<% if versioncmp($collectd::collectd_version_real, '5.6') >= 0 { -%>
+  ReportNumCpu <%= $collectd::plugin::cpu::reportnumcpu %>
 <% } -%>
-<% if versioncmp($::collectd::collectd_version_real, '5.8') >= 0 { -%>
-  ReportGuestState <%= $::collectd::plugin::cpu::reportgueststate %>
-  SubtractGuestState <%= $::collectd::plugin::cpu::subtractgueststate %>
+<% if versioncmp($collectd::collectd_version_real, '5.8') >= 0 { -%>
+  ReportGuestState <%= $collectd::plugin::cpu::reportgueststate %>
+  SubtractGuestState <%= $collectd::plugin::cpu::subtractgueststate %>
 <% } -%>
 </Plugin>
 <% } -%>

--- a/templates/plugin/procevent.conf.epp
+++ b/templates/plugin/procevent.conf.epp
@@ -1,11 +1,11 @@
 <Plugin procevent>
-<% unless $::collectd::plugin::procevent::process  =~ Undef { -%>
-    Process "<%= $::collectd::plugin::procevent::process %>"
+<% unless $collectd::plugin::procevent::process  =~ Undef { -%>
+    Process "<%= $collectd::plugin::procevent::process %>"
 <% } -%>
-<% unless $::collectd::plugin::procevent::process_regex  =~ Undef { -%>
-    ProcessRegex "<%= $::collectd::plugin::procevent::process_regex %>"
+<% unless $collectd::plugin::procevent::process_regex  =~ Undef { -%>
+    ProcessRegex "<%= $collectd::plugin::procevent::process_regex %>"
 <% } -%>
-<% unless $::collectd::plugin::procevent::buffer_length =~ Undef { -%>
-    BufferLength <%= $::collectd::plugin::procevent::buffer_length %>
+<% unless $collectd::plugin::procevent::buffer_length =~ Undef { -%>
+    BufferLength <%= $collectd::plugin::procevent::buffer_length %>
 <% } -%>
 </Plugin>

--- a/templates/plugin/swap.conf.epp
+++ b/templates/plugin/swap.conf.epp
@@ -1,13 +1,13 @@
 <Plugin swap>
-  ReportByDevice <%= $::collectd::plugin::swap::reportbydevice %>
-<% if versioncmp($::collectd::collectd_version_real, '5.2') > 0 { -%>
-  ReportBytes <%= $::collectd::plugin::swap::reportbytes %>
+  ReportByDevice <%= $collectd::plugin::swap::reportbydevice %>
+<% if versioncmp($collectd::collectd_version_real, '5.2') > 0 { -%>
+  ReportBytes <%= $collectd::plugin::swap::reportbytes %>
 <% } -%>
-<% if versioncmp($::collectd::collectd_version_real, '5.5') > 0 { -%>
-  ValuesAbsolute <%= $::collectd::plugin::swap::valuesabsolute %>
-  ValuesPercentage <%= $::collectd::plugin::swap::valuespercentage %>
+<% if versioncmp($collectd::collectd_version_real, '5.5') > 0 { -%>
+  ValuesAbsolute <%= $collectd::plugin::swap::valuesabsolute %>
+  ValuesPercentage <%= $collectd::plugin::swap::valuespercentage %>
 <% } -%>
-<% if versioncmp($::collectd::collectd_version_real, '5.8') > 0 { -%>
-  ReportIO <%= $::collectd::plugin::swap::reportio %>
+<% if versioncmp($collectd::collectd_version_real, '5.8') > 0 { -%>
+  ReportIO <%= $collectd::plugin::swap::reportio %>
 <% } -%>
 </Plugin>

--- a/templates/plugin/sysevent.conf.epp
+++ b/templates/plugin/sysevent.conf.epp
@@ -1,10 +1,10 @@
 <Plugin sysevent>
-    Listen "<%= $::collectd::plugin::sysevent::listen_host %>" "<%= $::collectd::plugin::sysevent::listen_port %>"
-    RegexFilter "<%= $::collectd::plugin::sysevent::regex_filter %>"
-<% unless $::collectd::plugin::sysevent::buffer_size =~ Undef { -%>
-    BufferSize <%= $::collectd::plugin::sysevent::buffer_size %>
+    Listen "<%= $collectd::plugin::sysevent::listen_host %>" "<%= $collectd::plugin::sysevent::listen_port %>"
+    RegexFilter "<%= $collectd::plugin::sysevent::regex_filter %>"
+<% unless $collectd::plugin::sysevent::buffer_size =~ Undef { -%>
+    BufferSize <%= $collectd::plugin::sysevent::buffer_size %>
 <% } -%>
-<% unless $::collectd::plugin::sysevent::buffer_length =~ Undef { -%>
-    BufferLength <%= $::collectd::plugin::sysevent::buffer_length %>
+<% unless $collectd::plugin::sysevent::buffer_length =~ Undef { -%>
+    BufferLength <%= $collectd::plugin::sysevent::buffer_length %>
 <% } -%>
 </Plugin>


### PR DESCRIPTION
Prepending `::` to classes is unneeded since Puppet 3-ish… Time to get
rid of this.
