### PR TITLE
Set python module name from module variable

### DIFF
--- a/manifests/plugin/python/module.pp
+++ b/manifests/plugin/python/module.pp
@@ -55,7 +55,7 @@ define collectd::plugin::python::module (
         {
           'title'  => $title,
           'config' => $config,
-          'module' => $_module_import,
+          'module' => $module,
         },
       ),
     }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Module name can be different than name of imported module. These might be rare cases, but one example for those is collectd-haproxy.
#### This Pull Request (PR) fixes the following issues
n/a
